### PR TITLE
feat(webapi): Add version route

### DIFF
--- a/KnoraBuild.sbt
+++ b/KnoraBuild.sbt
@@ -701,7 +701,10 @@ lazy val webapi = knoraModule("webapi")
             buildInfoKeys ++= Seq[BuildInfoKey](
                 name,
                 version,
-                "akkaHttp" -> Dependencies.akkaHttpVersion.value
+                "akkaHttp" -> Dependencies.akkaHttpVersion.value,
+                "sipi" -> Dependencies.sipiImage.value,
+                "gdbSE" -> Dependencies.gdbSEImage.value,
+                "gdbFree" -> Dependencies.gdbFreeImage.value
             ),
             buildInfoPackage := "org.knora.webapi"
         )

--- a/docs/src/paradox/03-apis/api-util/health.md
+++ b/docs/src/paradox/03-apis/api-util/health.md
@@ -17,26 +17,6 @@ You should have received a copy of the GNU Affero General Public
 License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-# The Knora APIs
+# Health
 
-The Knora APIs include:
-
-* The Knora API versions 1 and 2, which is intended to be used by
-  virtual research environments and other clients for querying and updating
-  data.
-* The Knora Admin API, which is intended to be used only by the
-  [SALSAH](https://github.com/dhlab-basel/Salsah) user interface, for
-  administering projects that use Knora as well as Knora itself.
-* The Knora Util API, which is intended to be used for information retrieval
-  about the Knora-stack itself.
-
-@@toc { depth=2 }
-
-@@@ index
-
-* [API v1](api-v1/index.md)
-* [API v2](api-v2/index.md)
-* [Admin API](api-admin/index.md)
-* [Util API](api-util/index.md)
-
-@@@
+@@toc

--- a/docs/src/paradox/03-apis/api-util/index.md
+++ b/docs/src/paradox/03-apis/api-util/index.md
@@ -17,26 +17,19 @@ You should have received a copy of the GNU Affero General Public
 License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-# The Knora APIs
+# Knora Util API
 
-The Knora APIs include:
+The Knora Util API allows retrieving information about the Knora-stack itself.
+It consists of the following elements:
+* Health: Knora health state
+* Version: Versions of used stack components
 
-* The Knora API versions 1 and 2, which is intended to be used by
-  virtual research environments and other clients for querying and updating
-  data.
-* The Knora Admin API, which is intended to be used only by the
-  [SALSAH](https://github.com/dhlab-basel/Salsah) user interface, for
-  administering projects that use Knora as well as Knora itself.
-* The Knora Util API, which is intended to be used for information retrieval
-  about the Knora-stack itself.
-
-@@toc { depth=2 }
+@@toc { depth=1 }
 
 @@@ index
 
-* [API v1](api-v1/index.md)
-* [API v2](api-v2/index.md)
-* [Admin API](api-admin/index.md)
-* [Util API](api-util/index.md)
+- [Health](health.md)
+- [Version](version.md)
+
 
 @@@

--- a/docs/src/paradox/03-apis/api-util/version.md
+++ b/docs/src/paradox/03-apis/api-util/version.md
@@ -17,26 +17,39 @@ You should have received a copy of the GNU Affero General Public
 License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 -->
 
-# The Knora APIs
+# Version
 
-The Knora APIs include:
+@@toc
 
-* The Knora API versions 1 and 2, which is intended to be used by
-  virtual research environments and other clients for querying and updating
-  data.
-* The Knora Admin API, which is intended to be used only by the
-  [SALSAH](https://github.com/dhlab-basel/Salsah) user interface, for
-  administering projects that use Knora as well as Knora itself.
-* The Knora Util API, which is intended to be used for information retrieval
-  about the Knora-stack itself.
+The version endpoint provides the versions of the used components in the Knora-stack.
+The response has the type `application/json` and contains the following information:
 
-@@toc { depth=2 }
+1. name: has the value "version"
 
-@@@ index
+2. version numbers for the following components:
+    - akkaHttp
+    - gdbFree
+    - gdbSE
+    - sbt
+    - scala
+    - sipi
+    - webapi
 
-* [API v1](api-v1/index.md)
-* [API v2](api-v2/index.md)
-* [Admin API](api-admin/index.md)
-* [Util API](api-util/index.md)
 
-@@@
+## Example request
+`GET /version`
+
+
+## Example response
+```
+{
+    "akkaHttp": "10.1.7",
+    "gdbFree": "8.10.0-free",
+    "gdbSE": "8.5.0-se",
+    "name": "version",
+    "sbt": "1.2.8",
+    "scala": "2.12.8",
+    "sipi": "v2.0.1",
+    "webapi": "10.0.0-7-gc5a72b3-SNAPSHOT"
+}
+```

--- a/webapi/src/it/scala/org/knora/webapi/e2e/VersionRouteITSpec.scala
+++ b/webapi/src/it/scala/org/knora/webapi/e2e/VersionRouteITSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ * This file is part of Knora.
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.e2e
+
+import java.util.NoSuchElementException
+
+import akka.http.scaladsl.model._
+import com.typesafe.config.{Config, ConfigFactory}
+import org.knora.webapi.ITKnoraLiveSpec
+import spray.json._
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.languageFeature.postfixOps
+
+
+object VersionRouteITSpec {
+    val config: Config = ConfigFactory.parseString(
+        """
+          |akka.loglevel = "DEBUG"
+          |akka.stdout-loglevel = "DEBUG"
+        """.stripMargin)
+}
+
+/**
+  * End-to-End (E2E) test specification for testing route rejections.
+  */
+class VersionRouteITSpec extends ITKnoraLiveSpec(VersionRouteITSpec.config) {
+
+    private def getJsonResponse: JsObject = {
+        val request = Get(baseApiUrl + s"/version")
+        val response: HttpResponse = singleAwaitingRequest(request)
+        val responseBody: String = Await.result(response.entity.toStrict(10.seconds).map(_.data.decodeString("UTF-8")), 10.seconds)
+        val responseBodyJson = responseBody.parseJson.asJsObject
+        responseBodyJson
+    }
+
+    private def checkNonEmpty(field: String): Boolean = {
+        val responseBodyJson = getJsonResponse
+        var result = false
+        try {
+            val value = responseBodyJson.fields(field).toString().replaceAll("\"","")
+            result = !value.equals("")
+        } catch {
+            case nse: NoSuchElementException => result = false
+        }
+        result
+    }
+
+    "The Version Route" should {
+
+        "return 'OK'" in {
+            val request = Get(baseApiUrl + s"/version")
+            val response: HttpResponse = singleAwaitingRequest(request)
+            response.status should be(StatusCodes.OK)
+        }
+
+        "return 'version' as name" in {
+            val responseBodyJson = getJsonResponse
+            val value = responseBodyJson.fields("name").toString().replaceAll("\"","")
+            assert(value.equals("version"))
+        }
+
+        "contain nonempty value for key 'akkaHttp'" in {
+            assert(checkNonEmpty("akkaHttp"))
+        }
+
+        "contain nonempty value for key 'gdbSE'" in {
+            assert(checkNonEmpty("gdbSE"))
+        }
+
+        "contain nonempty value for key 'gdbFree'" in {
+            assert(checkNonEmpty("gdbFree"))
+        }
+
+        "contain nonempty value for key 'sbt'" in {
+            assert(checkNonEmpty("sbt"))
+        }
+
+        "contain nonempty value for key 'scala'" in {
+            assert(checkNonEmpty("scala"))
+        }
+
+        "contain nonempty value for key 'webapi'" in {
+            assert(checkNonEmpty("webapi"))
+        }
+
+        "fail for nonexisting key 'fail'" in {
+            assert(!checkNonEmpty("fail"))
+        }
+    }
+}

--- a/webapi/src/main/scala/org/knora/webapi/app/ApplicationActor.scala
+++ b/webapi/src/main/scala/org/knora/webapi/app/ApplicationActor.scala
@@ -335,6 +335,7 @@ class ApplicationActor extends Actor with LazyLogging with AroundDirectives with
         addServerHeader {
             CORS(
                 new HealthRoute(routeData).knoraApiPath ~
+                  new VersionRoute(routeData).knoraApiPath ~
                   new RejectingRoute(routeData).knoraApiPath ~
                   new ClientApiRoute(routeData).knoraApiPath ~
                   new ResourcesRouteV1(routeData).knoraApiPath ~

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -34,7 +34,10 @@ case class VersionCheckResult(name: String,
                               webapi: String,
                               scala: String,
                               sbt: String,
-                              akkaHttp: String)
+                              akkaHttp: String,
+                              sipi: String,
+                              gdbSE: String,
+                              gdbFree: String)
 
 /**
   * Provides version check logic
@@ -61,19 +64,29 @@ trait VersionCheck {
                     "webapi" -> JsString(result.webapi),
                     "scala" -> JsString(result.scala),
                     "sbt" -> JsString(result.sbt),
-                    "akkaHttp" -> JsString(result.akkaHttp)
+                    "akkaHttp" -> JsString(result.akkaHttp),
+                    "sipi" -> JsString(result.sipi),
+                    "gdbSE" -> JsString(result.gdbSE),
+                    "gdbFree" -> JsString(result.gdbFree)
                 ).compactPrint
             )
         )
     }
 
     private def getVersion() = {
+        val sipiVersion = BuildInfo.sipi
+        val gdbSEVersion = BuildInfo.gdbSE
+        val gdbFreeVersion = BuildInfo.gdbFree
+
         VersionCheckResult(
             name = "version",
             webapi = BuildInfo.version,
             scala = BuildInfo.scalaVersion,
             sbt = BuildInfo.sbtVersion,
-            akkaHttp = BuildInfo.akkaHttp
+            akkaHttp = BuildInfo.akkaHttp,
+            sipi = sipiVersion.substring(sipiVersion.indexOf(':')+1),
+            gdbSE = gdbSEVersion.substring(gdbSEVersion.indexOf(':')+1),
+            gdbFree = gdbFreeVersion.substring(gdbFreeVersion.indexOf(':')+1)
         )
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -49,13 +49,10 @@ trait VersionCheck {
 
     override implicit val timeout: Timeout = 1.second
 
-    protected def versionCheck(): Future[HttpResponse] = for {
-
-        state <- (applicationStateActor ? GetAppState()).mapTo[AppState]
-
-        result = getVersion()
-        response = createResponse(result)
-    } yield response
+    protected def versionCheck() = {
+        val result = getVersion()
+        createResponse(result)
+    }
 
 
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.routing
+
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives.{get, path}
+import akka.http.scaladsl.server.Route
+import akka.pattern.ask
+import akka.util.Timeout
+import org.knora.webapi.messages.app.appmessages.AppState.AppState
+import org.knora.webapi.messages.app.appmessages.{AppState, GetAppState}
+import spray.json.{JsObject, JsString}
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+
+import org.knora.webapi.BuildInfo
+
+
+case class VersionCheckResult(name: String,
+                              webapi: String,
+                              scala: String,
+                              sbt: String,
+                              akkaHttp: String)
+
+/**
+  * Provides version check logic
+  */
+trait VersionCheck {
+    this: VersionRoute =>
+
+    override implicit val timeout: Timeout = 1.second
+
+    protected def versionCheck(): Future[HttpResponse] = for {
+
+        state <- (applicationStateActor ? GetAppState()).mapTo[AppState]
+
+        result = getVersion()
+        response = createResponse(result)
+    } yield response
+
+
+
+    protected def createResponse(result: VersionCheckResult): HttpResponse = {
+        HttpResponse(
+            status = StatusCodes.OK,
+            entity = HttpEntity(
+                ContentTypes.`application/json`,
+                JsObject(
+                    "name" -> JsString(result.name),
+                    "webapi" -> JsString(result.webapi),
+                    "scala" -> JsString(result.scala),
+                    "sbt" -> JsString(result.sbt),
+                    "akkaHttp" -> JsString(result.akkaHttp)
+                ).compactPrint
+            )
+        )
+    }
+
+    private def getVersion() = {
+        VersionCheckResult(
+            name = "version",
+            webapi = BuildInfo.version,
+            scala = BuildInfo.scalaVersion,
+            sbt = BuildInfo.sbtVersion,
+            akkaHttp = BuildInfo.akkaHttp
+        )
+    }
+}
+
+/**
+  * Provides the '/version' endpoint serving the components versions.
+  */
+class VersionRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) with VersionCheck {
+
+    override def knoraApiPath: Route = {
+        path("version") {
+            get {
+                requestContext =>
+                    requestContext.complete(versionCheck())
+            }
+        }
+    }
+}

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -22,15 +22,10 @@ package org.knora.webapi.routing
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives.{get, path}
 import akka.http.scaladsl.server.Route
-import akka.pattern.ask
 import akka.util.Timeout
-import org.knora.webapi.messages.app.appmessages.AppState.AppState
-import org.knora.webapi.messages.app.appmessages.{AppState, GetAppState}
 import spray.json.{JsObject, JsString}
 
-import scala.concurrent.Future
 import scala.concurrent.duration._
-
 
 import org.knora.webapi.BuildInfo
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -74,9 +74,17 @@ trait VersionCheck {
     }
 
     private def getVersion() = {
-        val sipiVersion = BuildInfo.sipi
-        val gdbSEVersion = BuildInfo.gdbSE
-        val gdbFreeVersion = BuildInfo.gdbFree
+        var sipiVersion = BuildInfo.sipi
+        val sipiIndex = sipiVersion.indexOf(':')
+        sipiVersion = if (sipiIndex > 0) sipiVersion.substring(sipiIndex+1) else sipiVersion
+
+        var gdbSEVersion = BuildInfo.gdbSE
+        val gdbSEIndex = gdbSEVersion.indexOf(':')
+        gdbSEVersion = if (gdbSEIndex > 0) gdbSEVersion.substring(gdbSEIndex+1) else gdbSEVersion
+
+        var gdbFreeVersion = BuildInfo.gdbFree
+        val gdbFreeIndex = gdbFreeVersion.indexOf(':')
+        gdbFreeVersion = if (gdbFreeIndex > 0) gdbFreeVersion.substring(gdbFreeIndex+1) else gdbFreeVersion
 
         VersionCheckResult(
             name = "version",
@@ -84,9 +92,9 @@ trait VersionCheck {
             scala = BuildInfo.scalaVersion,
             sbt = BuildInfo.sbtVersion,
             akkaHttp = BuildInfo.akkaHttp,
-            sipi = sipiVersion.substring(sipiVersion.indexOf(':')+1),
-            gdbSE = gdbSEVersion.substring(gdbSEVersion.indexOf(':')+1),
-            gdbFree = gdbFreeVersion.substring(gdbFreeVersion.indexOf(':')+1)
+            sipi = sipiVersion,
+            gdbSE = gdbSEVersion,
+            gdbFree = gdbFreeVersion
         )
     }
 }


### PR DESCRIPTION
Add version endpoint at `GET /version` to retrieve the deployed versions of the Knora-stack components.

resolves #1444