### PR TITLE
feat(clientapi): Support collection classes

### DIFF
--- a/docs/src/paradox/05-internals/design/client-api/index.md
+++ b/docs/src/paradox/05-internals/design/client-api/index.md
@@ -57,7 +57,7 @@ generates each file using a Twirl template, and arranges the files in the
 correct directory structure.
 
 Currently one back end, `TypeScriptBackEnd`, is implemented; it generates code
-for use with [knora-api-js-lib](https://github.com/dhlab-basel/knora-api-js-lib).
+for use with [knora-api-js-lib](https://github.com/dasch-swiss/knora-api-js-lib).
 
 ## Client Function DSL
 
@@ -148,6 +148,34 @@ submit a resource with an embedded link value), but the property pointing from a
 link value to an embedded resource is read-only.
 
 The read-only properties and ID properties are specified in each `ClientApi`.
+
+## Collection Types
+
+`Array[T]` and `Map[K, V]` collection types can be generated and used as the object types
+of properties in ordinary classes. The collection type is specified in the IRI of the
+property object type, using a Scala-like type annotation syntax, like this:
+
+```
+http://api.knora.org/ontology/knora-admin/v2#collection: Map[URI, Array[Permission]]
+```
+
+(The local part of the IRI can also be URL-encoded.) The keyword `collection:` indicates
+that the rest of the IRI specifies a collection type, which must be an `Array` or `Map` type.
+The following literal types can be used:
+
+- `String`
+- `Boolean`
+- `Integer`
+- `Decimal`
+- `URI`
+- `DateTimeStamp`
+
+Class names (like `Permission`) in the example above refer to classes in the same IRI
+namespace as the collection type. The keys of a `Map` must be `String` or `URI`.
+
+`ClientCollectionTypeParser` parses these definitions into `MapType` and `ArrayType`
+objects, which can then be used by a language-specific back end to generate type signatures
+in the target language.
 
 ## Testing
 

--- a/webapi/_test_data/typescript-client-mock-src/json2typescript.ts
+++ b/webapi/_test_data/typescript-client-mock-src/json2typescript.ts
@@ -1,0 +1,11 @@
+export class JsonConvert {
+
+}
+
+export class JsonConverter {
+
+}
+
+export interface JsonCustomConvert<T> {
+
+}

--- a/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/administrative-permissions-per-project-converter.ts
+++ b/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/administrative-permissions-per-project-converter.ts
@@ -1,0 +1,15 @@
+import {JsonConverter, JsonCustomConvert} from "json2typescript";
+
+import {Permission} from "../permission";
+
+@JsonConverter
+export class AdministrativePermissionsPerProjectConverter implements JsonCustomConvert<{ [key: string]: Permission[] }> {
+
+    serialize(permissions: { [key: string]: Permission[] }): any {
+        return {};
+    }
+
+    deserialize(item: any): { [key: string]: Permission[] } {
+        return {};
+    }
+}

--- a/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/administrative-permissions-per-project-converter.ts
+++ b/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/administrative-permissions-per-project-converter.ts
@@ -1,8 +1,7 @@
-import {JsonConverter, JsonCustomConvert} from "json2typescript";
+import {JsonCustomConvert} from "../../../json2typescript";
 
 import {Permission} from "../permission";
 
-@JsonConverter
 export class AdministrativePermissionsPerProjectConverter implements JsonCustomConvert<{ [key: string]: Permission[] }> {
 
     serialize(permissions: { [key: string]: Permission[] }): any {

--- a/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/groups-per-project-converter.ts
+++ b/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/groups-per-project-converter.ts
@@ -1,6 +1,5 @@
-import { JsonConverter, JsonCustomConvert } from "json2typescript";
+import { JsonCustomConvert } from "../../../json2typescript";
 
-@JsonConverter
 export class GroupsPerProjectConverter implements JsonCustomConvert<{ [key: string]: string[] }> {
     serialize(groups: { [key: string]: string[] }): any {
         return {};

--- a/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/groups-per-project-converter.ts
+++ b/webapi/_test_data/typescript-client-mock-src/models/admin/custom-converters/groups-per-project-converter.ts
@@ -1,0 +1,12 @@
+import { JsonConverter, JsonCustomConvert } from "json2typescript";
+
+@JsonConverter
+export class GroupsPerProjectConverter implements JsonCustomConvert<{ [key: string]: string[] }> {
+    serialize(groups: { [key: string]: string[] }): any {
+        return {};
+    }
+
+    deserialize(item: any): { [key: string]: string[] } {
+        return {};
+    }
+}

--- a/webapi/_test_data/typescript-client-mock-src/models/admin/permission.ts
+++ b/webapi/_test_data/typescript-client-mock-src/models/admin/permission.ts
@@ -1,0 +1,3 @@
+export class Permission {
+
+}

--- a/webapi/_test_data/typescript-client-mock-src/models/api-response-data.ts
+++ b/webapi/_test_data/typescript-client-mock-src/models/api-response-data.ts
@@ -1,5 +1,5 @@
-import {AjaxResponse} from "rxjs/ajax";
-import {JsonConvert} from "json2typescript";
+import {AjaxResponse} from "../rxjs/ajax";
+import {JsonConvert} from "../json2typescript";
 
 export class ApiResponseData<T> {
 

--- a/webapi/_test_data/typescript-client-mock-src/rxjs/ajax.ts
+++ b/webapi/_test_data/typescript-client-mock-src/rxjs/ajax.ts
@@ -1,0 +1,3 @@
+export class AjaxResponse {
+
+}

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -611,6 +611,11 @@ object OntologyConstants {
         val StringLiteral: IRI = KnoraAdminPrefixExpansion + "StringLiteral"
         val Value: IRI = KnoraAdminPrefixExpansion + "value"
         val Language: IRI = KnoraAdminPrefixExpansion + "language"
+        val Permissions: IRI = KnoraAdminPrefixExpansion + "permissions"
+        val PermissionData: IRI = KnoraAdminPrefixExpansion + "PermissionsData"
+        val GroupsPerProject: IRI = KnoraAdminPrefixExpansion + "groupsPerProject"
+        val AdministrativePermissionsPerProject: IRI = KnoraAdminPrefixExpansion + "administrativePermissionsPerProject"
+        val AdministrativePermissionsPerProjectType: IRI = KnoraAdminPrefixExpansion + "collection: Map[URI, Array[Permission]]"
     }
 
     object Standoff {

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -612,10 +612,11 @@ object OntologyConstants {
         val Value: IRI = KnoraAdminPrefixExpansion + "value"
         val Language: IRI = KnoraAdminPrefixExpansion + "language"
         val Permissions: IRI = KnoraAdminPrefixExpansion + "permissions"
-        val PermissionData: IRI = KnoraAdminPrefixExpansion + "PermissionsData"
+        val PermissionsData: IRI = KnoraAdminPrefixExpansion + "PermissionsData"
         val GroupsPerProject: IRI = KnoraAdminPrefixExpansion + "groupsPerProject"
         val AdministrativePermissionsPerProject: IRI = KnoraAdminPrefixExpansion + "administrativePermissionsPerProject"
-        val AdministrativePermissionsPerProjectType: IRI = KnoraAdminPrefixExpansion + "collection: Map[URI, Array[Permission]]"
+        val AdministrativePermissionsPerProjectCollectionType: IRI = KnoraAdminPrefixExpansion + "collection: Map[URI, Array[Permission]]"
+        val GroupsPerProjectCollectionType: IRI = KnoraAdminPrefixExpansion + "collection: Map[URI, Array[URI]]"
     }
 
     object Standoff {

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraAdminToApiV2ComplexTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraAdminToApiV2ComplexTransformationRules.scala
@@ -650,6 +650,69 @@ object KnoraAdminToApiV2ComplexTransformationRules extends OntologyTransformatio
         )
     )
 
+    private val Permissions: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraAdminV2.Permissions,
+        propertyType = OntologyConstants.Owl.ObjectProperty,
+        subjectType = Some(OntologyConstants.KnoraAdminV2.UserClass),
+        objectType = Some(OntologyConstants.KnoraAdminV2.PermissionsData),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "permissions data"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "A user's permissions data."
+                )
+            )
+        )
+    )
+
+    private val AdministrativePermissionsPerProject: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraAdminV2.AdministrativePermissionsPerProject,
+        propertyType = OntologyConstants.Owl.ObjectProperty,
+        subjectType = Some(OntologyConstants.KnoraAdminV2.PermissionsData),
+        objectType = Some(OntologyConstants.KnoraAdminV2.AdministrativePermissionsPerProjectCollectionType),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "administrative permissions per project"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "A user's administrative permissions per project."
+                )
+            )
+        )
+    )
+
+    private val GroupsPerProject: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.KnoraAdminV2.GroupsPerProject,
+        propertyType = OntologyConstants.Owl.ObjectProperty,
+        subjectType = Some(OntologyConstants.KnoraAdminV2.PermissionsData),
+        objectType = Some(OntologyConstants.KnoraAdminV2.GroupsPerProjectCollectionType),
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "groups per project"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "A user's groups per project."
+                )
+            )
+        )
+    )
+
     private val Name: ReadPropertyInfoV2 = makeProperty(
         propertyIri = OntologyConstants.KnoraAdminV2.Name,
         propertyType = OntologyConstants.Owl.DatatypeProperty,
@@ -908,6 +971,28 @@ object KnoraAdminToApiV2ComplexTransformationRules extends OntologyTransformatio
         )
     )
 
+    private val PermissionsData = makeClass(
+        classIri = OntologyConstants.KnoraAdminV2.PermissionsData,
+        predicates = Seq(
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Label,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "permissions data"
+                )
+            ),
+            makePredicate(
+                predicateIri = OntologyConstants.Rdfs.Comment,
+                objectsWithLang = Map(
+                    LanguageCodes.EN -> "A user's permissions data."
+                )
+            )
+        ),
+        directCardinalities = Map(
+            OntologyConstants.KnoraAdminV2.AdministrativePermissionsPerProject -> Cardinality.MayHaveOne,
+            OntologyConstants.KnoraAdminV2.GroupsPerProject -> Cardinality.MayHaveOne
+        )
+    )
+
     private val CreateGroupRequest = makeClass(
         classIri = OntologyConstants.KnoraAdminV2.CreateGroupRequest,
         predicates = Seq(
@@ -1139,6 +1224,7 @@ object KnoraAdminToApiV2ComplexTransformationRules extends OntologyTransformatio
         AdministrativePermissionResponse,
         AdministrativePermissionClass,
         Permission,
+        PermissionsData,
         MembersResponse,
         KeywordsResponse,
         ProjectRestrictedViewSettings,
@@ -1162,6 +1248,9 @@ object KnoraAdminToApiV2ComplexTransformationRules extends OntologyTransformatio
         ProjectDescription,
         AdministrativePermissionProperty,
         AdministrativePermissions,
+        Permissions,
+        AdministrativePermissionsPerProject,
+        GroupsPerProject,
         ForGroup,
         ForProject,
         ForResourceClass,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraAdminToApiV2ComplexTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraAdminToApiV2ComplexTransformationRules.scala
@@ -1083,7 +1083,8 @@ object KnoraAdminToApiV2ComplexTransformationRules extends OntologyTransformatio
         OntologyConstants.KnoraAdminV2.Token -> Cardinality.MayHaveOne,
         OntologyConstants.KnoraAdminV2.SessionID -> Cardinality.MayHaveOne,
         OntologyConstants.KnoraAdminV2.SystemAdmin -> Cardinality.MayHaveOne,
-        OntologyConstants.KnoraAdminV2.Groups -> Cardinality.MayHaveMany
+        OntologyConstants.KnoraAdminV2.Groups -> Cardinality.MayHaveMany,
+        OntologyConstants.KnoraAdminV2.Permissions -> Cardinality.MustHaveOne
     )
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/AdminClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/AdminClientApi.scala
@@ -125,10 +125,4 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
         case (propertyIri, propertyName) =>
             propertyIri.toSmartIri -> propertyName
     }
-
-    /**
-      * A set of IRIs of classes that are inherently read only and therefore do not need
-      * `Stored*` or `Read*` subclasses generated for them.
-      */
-    override val inherentlyReadOnlyClasses: Set[SmartIri] = Set(OntologyConstants.KnoraAdminV2.PermissionsData.toSmartIri)
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/AdminClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/AdminClientApi.scala
@@ -75,7 +75,8 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
             OntologyConstants.KnoraAdminV2.Token,
             OntologyConstants.KnoraAdminV2.SessionID,
             OntologyConstants.KnoraAdminV2.Groups,
-            OntologyConstants.KnoraAdminV2.Projects
+            OntologyConstants.KnoraAdminV2.Projects,
+            OntologyConstants.KnoraAdminV2.Permissions
         ),
         OntologyConstants.KnoraAdminV2.GroupClass ->  Set(
             OntologyConstants.KnoraAdminV2.ProjectProperty
@@ -124,4 +125,10 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
         case (propertyIri, propertyName) =>
             propertyIri.toSmartIri -> propertyName
     }
+
+    /**
+      * A set of IRIs of classes that are inherently read only and therefore do not need
+      * `Stored*` or `Read*` subclasses generated for them.
+      */
+    override val inherentlyReadOnlyClasses: Set[SmartIri] = Set(OntologyConstants.KnoraAdminV2.PermissionsData.toSmartIri)
 }

--- a/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
@@ -19,6 +19,7 @@
 
 package org.knora.webapi.util
 
+import java.net.URLDecoder
 import java.nio.ByteBuffer
 import java.text.ParseException
 import java.time._
@@ -45,6 +46,7 @@ import org.knora.webapi.messages.v2.responder.KnoraContentV2
 import org.knora.webapi.messages.v2.responder.standoffmessages._
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.JavaUtil.Optional
+import org.knora.webapi.util.clientapi.{ClientCollectionTypeParser, CollectionType}
 import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -163,6 +165,16 @@ object StringFormatter {
       * The domain name used to construct Knora IRIs.
       */
     val IriDomain: String = "rdfh.ch"
+
+    /**
+      * A keyword used in IRI entity names to introduce a collection type annotation for client code generation.
+      */
+    val ClientCollectionTypeKeyword: String = "collection:"
+
+    /**
+      * A string found in IRIs representing collection type annotations for client code generation.
+      */
+    val ClientCollectionEntityNameStart: String = "#" + ClientCollectionTypeKeyword
 
     /**
       * A container for an XML import namespace and its prefix label.
@@ -349,20 +361,22 @@ object StringFormatter {
     /**
       * Holds information extracted from the IRI.
       *
-      * @param iriType            the type of the IRI.
-      * @param projectCode        the IRI's project code, if any.
-      * @param ontologyName       the IRI's ontology name, if any.
-      * @param entityName         the IRI's entity name, if any.
-      * @param resourceID         if this is a resource IRI or value IRI, its resource ID.
-      * @param valueID            if this is a value IRI, its value ID.
-      * @param standoffStartIndex if this is a standoff IRI, its start index.
-      * @param ontologySchema     the IRI's ontology schema, or `None` if it is not a Knora definition IRI.
-      * @param isBuiltInDef       `true` if the IRI refers to a built-in Knora ontology or ontology entity.
+      * @param iriType              the type of the IRI.
+      * @param projectCode          the IRI's project code, if any.
+      * @param ontologyName         the IRI's ontology name, if any.
+      * @param entityName           the IRI's entity name, if any.
+      * @param clientCollectionType the [[CollectionType]] represented by this IRI, if any.
+      * @param resourceID           if this is a resource IRI or value IRI, its resource ID.
+      * @param valueID              if this is a value IRI, its value ID.
+      * @param standoffStartIndex   if this is a standoff IRI, its start index.
+      * @param ontologySchema       the IRI's ontology schema, or `None` if it is not a Knora definition IRI.
+      * @param isBuiltInDef         `true` if the IRI refers to a built-in Knora ontology or ontology entity.
       */
     private case class SmartIriInfo(iriType: IriType,
                                     projectCode: Option[String] = None,
                                     ontologyName: Option[String] = None,
                                     entityName: Option[String] = None,
+                                    clientCollectionType: Option[CollectionType] = None,
                                     resourceID: Option[String] = None,
                                     valueID: Option[String] = None,
                                     standoffStartIndex: Option[Int] = None,
@@ -498,6 +512,11 @@ sealed trait SmartIri extends Ordered[SmartIri] with KnoraContentV2[SmartIri] {
     def isKnoraApiV2EntityIri: Boolean
 
     /**
+      * Returns `true` if this IRI represents a collection type for use in client code generation.
+      */
+    def isClientCollectionTypeIri: Boolean
+
+    /**
       * Returns the IRI's project code, if any.
       */
     def getProjectCode: Option[String]
@@ -531,6 +550,11 @@ sealed trait SmartIri extends Ordered[SmartIri] with KnoraContentV2[SmartIri] {
       * If this is a Knora entity IRI, returns the name of the entity. Otherwise, throws [[DataConversionException]].
       */
     def getEntityName: String
+
+    /**
+      * If this IRI represents a collection type for use in client code generation, returns the collection type.
+      */
+    def getClientCollectionType: CollectionType
 
     /**
       * If this is a Knora ontology IRI, constructs a Knora entity IRI based on it. Otherwise, throws [[DataConversionException]].
@@ -984,10 +1008,22 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl] = None, ma
 
                     val hashPos = iri.lastIndexOf('#')
 
-                    val (namespace: String, entityName: Option[String]) = if (hashPos >= 0 && hashPos < iri.length) {
-                        (iri.substring(0, hashPos), Some(validateNCName(iri.substring(hashPos + 1), errorFun)))
+                    val (namespace: String, entityName: Option[String], maybeClientCollectionType: Option[CollectionType]) = if (hashPos >= 0 && hashPos < iri.length) {
+                        val namespace = iri.substring(0, hashPos)
+                        val entityName = iri.substring(hashPos + 1)
+
+                        // Is the entity a type annotation representing a collection type for client code generation?
+                        if (entityName.startsWith(ClientCollectionTypeKeyword)) {
+                            // Yes. Parse it.
+                            val typeStr = URLDecoder.decode(entityName, "UTF-8").substring(ClientCollectionTypeKeyword.length)
+                            val clientCollectionType = ClientCollectionTypeParser.parse(typeStr = typeStr, ontologyIri = toSmartIri(namespace))
+                            (namespace, Some(entityName), Some(clientCollectionType))
+                        } else {
+                            // No. Validate the entity name as an NCName.
+                            (namespace, Some(validateNCName(entityName, errorFun)), None)
+                        }
                     } else {
-                        (iri, None)
+                        (iri, None, None)
                     }
 
                     // Remove the URL scheme (http://), and split the remainder of the namespace into slash-delimited segments.
@@ -1096,6 +1132,7 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl] = None, ma
                             projectCode = projectCode,
                             ontologyName = Some(ontologyName),
                             entityName = entityName,
+                            clientCollectionType = maybeClientCollectionType,
                             ontologySchema = ontologySchema,
                             isBuiltInDef = hasBuiltInOntologyName,
                             sharedOntology = sharedOntology
@@ -1135,6 +1172,8 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl] = None, ma
 
         override def isKnoraEntityIri: Boolean = iriInfo.iriType == KnoraDefinitionIri && iriInfo.entityName.nonEmpty
 
+        override def isClientCollectionTypeIri: Boolean = iriInfo.clientCollectionType.nonEmpty
+
         override def getProjectCode: Option[String] = iriInfo.projectCode
 
         override def getResourceID: Option[String] = iriInfo.resourceID
@@ -1169,7 +1208,7 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl] = None, ma
 
         override def makeEntityIri(entityName: String): SmartIri = {
             if (isKnoraOntologyIri) {
-                val entityIriStr = iri + "#" + validateNCName(entityName, throw DataConversionException(s"Invalid entity name: $entityName"))
+                val entityIriStr = iri + "#" + entityName
                 getOrCacheSmartIri(entityIriStr, () => new SmartIriImpl(entityIriStr))
             } else {
                 throw DataConversionException(s"$iri is not a Knora ontology IRI")
@@ -1187,6 +1226,13 @@ class StringFormatter private(val maybeSettings: Option[SettingsImpl] = None, ma
             iriInfo.entityName match {
                 case Some(name) => name
                 case None => throw DataConversionException(s"Expected a Knora entity IRI: $iri")
+            }
+        }
+
+        override def getClientCollectionType: CollectionType = {
+            iriInfo.clientCollectionType match {
+                case Some(collectionType) => collectionType
+                case None => throw DataConversionException(s"Expected a client collection type IRI: $iri")
             }
         }
 

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
@@ -103,12 +103,6 @@ trait ClientApi {
     val propertyNames: Map[SmartIri, String]
 
     /**
-      * A set of IRIs of classes that are inherently read only and therefore do not need
-      * `Stored*` or `Read*` subclasses generated for them.
-      */
-    val inherentlyReadOnlyClasses: Set[SmartIri]
-
-    /**
       * The IRIs of the classes used by this API.
       */
     lazy val classIrisUsed: Set[SmartIri] = endpoints.flatMap(_.classIrisUsed).toSet

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
@@ -103,6 +103,12 @@ trait ClientApi {
     val propertyNames: Map[SmartIri, String]
 
     /**
+      * A set of IRIs of classes that are inherently read only and therefore do not need
+      * `Stored*` or `Read*` subclasses generated for them.
+      */
+    val inherentlyReadOnlyClasses: Set[SmartIri]
+
+    /**
       * The IRIs of the classes used by this API.
       */
     lazy val classIrisUsed: Set[SmartIri] = endpoints.flatMap(_.classIrisUsed).toSet

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
@@ -625,7 +625,7 @@ case class ClientClassDefinition(className: String,
     lazy val classObjectTypesUsed: Set[ClassRef] = properties.foldLeft(Set.empty[ClassRef]) {
         (acc, property) =>
             property.objectType match {
-                case classRef: ClassRef => acc + classRef
+                case typeWithClassIri: TypeWithClassIri => acc ++ typeWithClassIri.getClassRef
                 case _ => acc
             }
     }
@@ -697,22 +697,31 @@ sealed trait TypeWithClassIri {
       * Returns the class IRI, if any, that the type refers to.
       */
     def getClassIri: Option[SmartIri]
+
+    /**
+      * Returns a [[ClassRef]] representing the class IRI, if any, that the type refers to.
+      */
+    def getClassRef: Option[ClassRef] = {
+        getClassIri.map {
+            classIri => ClassRef(className = classIri.getEntityName.capitalize, classIri = classIri)
+        }
+    }
 }
 
 /**
   * A trait for types representing collections in the target language.
   */
-sealed trait CollectionType extends TypeWithClassIri
+sealed trait CollectionType extends ClientObjectType with TypeWithClassIri
 
 /**
   * A trait for types that can be keys in [[MapType]] data structures.
   */
-sealed trait MapKeyDatatype
+sealed trait MapKeyDatatype extends ClientObjectType
 
 /**
   * A trait for types that can be values in [[MapType]] data structures.
   */
-sealed trait MapValueType
+sealed trait MapValueType extends ClientObjectType
 
 /**
   * Represents a map-like data structure in the target language.

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientApi.scala
@@ -30,89 +30,89 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
- * A trait for enumerated values representing API serialisation formats.
- */
+  * A trait for enumerated values representing API serialisation formats.
+  */
 trait ApiSerialisationFormat
 
 /**
- * Indicates that an API uses plain JSON as its serialisation format.
- */
+  * Indicates that an API uses plain JSON as its serialisation format.
+  */
 case object Json extends ApiSerialisationFormat
 
 /**
- * Indicates that an API uses JSON-LD as its serialisation format.
- */
+  * Indicates that an API uses JSON-LD as its serialisation format.
+  */
 case object JsonLD extends ApiSerialisationFormat
 
 /**
- * Represents a client API.
- */
+  * Represents a client API.
+  */
 trait ClientApi {
     /**
-     * The serialisation format used by the API.
-     */
+      * The serialisation format used by the API.
+      */
     val serialisationFormat: ApiSerialisationFormat
 
     /**
-     * The machine-readable name of the API.
-     */
+      * The machine-readable name of the API.
+      */
     val name: String
 
     /**
-     * The name of a directory in which the API code can be generated.
-     */
+      * The name of a directory in which the API code can be generated.
+      */
     val directoryName: String
 
     /**
-     * The URL path of the API.
-     */
+      * The URL path of the API.
+      */
     val urlPath: String
 
     /**
-     * A human-readable description of the API.
-     */
+      * A human-readable description of the API.
+      */
     val description: String
 
     /**
-     * The endpoints available in the API.
-     */
+      * The endpoints available in the API.
+      */
     val endpoints: Seq[ClientEndpoint]
 
     /**
-     * A map of class IRIs to their read-only properties. Each class in this collection will
-     * be separated into a base class without the read-only properties, and a subclass with the
-     * read-only properties.
-     */
+      * A map of class IRIs to their read-only properties. Each class in this collection will
+      * be separated into a base class without the read-only properties, and a subclass with the
+      * read-only properties.
+      */
     val classesWithReadOnlyProperties: Map[SmartIri, Set[SmartIri]]
 
     /**
-     * A set of IRIs of classes that represent API responses and whose contents are therefore
-     * always read-only.
-     */
+      * A set of IRIs of classes that represent API responses and whose contents are therefore
+      * always read-only.
+      */
     val responseClasses: Set[SmartIri]
 
     /**
-     * A set of property IRIs that are used for the unique IDs of objects.
-     */
+      * A set of property IRIs that are used for the unique IDs of objects.
+      */
     val idProperties: Set[SmartIri]
 
     /**
-     * A map of property IRIs to non-standard names that those properties must have.
-     * Needed only if two different properties should have the same name in different classes.
-     */
+      * A map of property IRIs to non-standard names that those properties must have.
+      * Needed only if two different properties should have the same name in different classes.
+      */
     val propertyNames: Map[SmartIri, String]
 
     /**
-     * The IRIs of the classes used by this API.
-     */
+      * The IRIs of the classes used by this API.
+      */
     lazy val classIrisUsed: Set[SmartIri] = endpoints.flatMap(_.classIrisUsed).toSet
 
     /**
-     * Returns test data for this API.
-     *
-     * @param testDataDirectoryPath the path of the top-level test data directory.
-     * @return a set of test data files to be used for testing this API.
-     */
+      * Returns test data for this API.
+      *
+      * @param testDataDirectoryPath the path of the top-level test data directory.
+      * @return a set of test data files to be used for testing this API.
+      */
     def getTestData(testDataDirectoryPath: Seq[String])(implicit executionContext: ExecutionContext,
                                                         actorSystem: ActorSystem,
                                                         materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]] = {
@@ -137,37 +137,37 @@ trait ClientApi {
 }
 
 /**
- * Represents a client endpoint.
- */
+  * Represents a client endpoint.
+  */
 trait ClientEndpoint {
     /**
-     * The machine-readable name of the endpoint.
-     */
+      * The machine-readable name of the endpoint.
+      */
     val name: String
 
     /**
-     * The name of a directory in which the endpoint code can be generated.
-     */
+      * The name of a directory in which the endpoint code can be generated.
+      */
     val directoryName: String
 
     /**
-     * The URL path of the endpoint, relative to its API path.
-     */
+      * The URL path of the endpoint, relative to its API path.
+      */
     val urlPath: String
 
     /**
-     * A human-readable description of the endpoint.
-     */
+      * A human-readable description of the endpoint.
+      */
     val description: String
 
     /**
-     * The functions provided by the endpoint.
-     */
+      * The functions provided by the endpoint.
+      */
     val functions: Seq[ClientFunction]
 
     /**
-     * The IRIs of the classes used by this endpoint.
-     */
+      * The IRIs of the classes used by this endpoint.
+      */
     lazy val classIrisUsed: Set[SmartIri] = functions.flatMap {
         function =>
             val maybeReturnedClass: Option[SmartIri] = function.returnType match {
@@ -185,11 +185,11 @@ trait ClientEndpoint {
     }.toSet
 
     /**
-     * Makes a request to Knora to get test data.
-     *
-     * @param request the request to send.
-     * @return the string value of the response.
-     */
+      * Makes a request to Knora to get test data.
+      *
+      * @param request the request to send.
+      * @return the string value of the response.
+      */
     protected def doTestDataRequest(request: HttpRequest)(implicit executionContext: ExecutionContext,
                                                           actorSystem: ActorSystem,
                                                           materializer: ActorMaterializer): Future[String] = {
@@ -200,126 +200,126 @@ trait ClientEndpoint {
     }
 
     /**
-     * Returns test data for this endpoint.
-     *
-     * @return a set of test data files to be used for testing this endpoint. The directory paths should be empty.
-     */
+      * Returns test data for this endpoint.
+      *
+      * @return a set of test data files to be used for testing this endpoint. The directory paths should be empty.
+      */
     def getTestData(implicit executionContext: ExecutionContext,
                     actorSystem: ActorSystem,
                     materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]]
 }
 
 /**
- * A DSL for defining functions in client endpoints.
- */
+  * A DSL for defining functions in client endpoints.
+  */
 object EndpointFunctionDSL {
 
     import scala.language.implicitConversions
 
     /**
-     * Constructs a [[ClientHttpRequest]] for a `GET` request.
-     *
-     * @param path   the URL path to be used in the request.
-     * @param params the query parameters to be used in the request.
-     * @return a [[ClientHttpRequest]].
-     */
+      * Constructs a [[ClientHttpRequest]] for a `GET` request.
+      *
+      * @param path   the URL path to be used in the request.
+      * @param params the query parameters to be used in the request.
+      * @return a [[ClientHttpRequest]].
+      */
     def httpGet(path: Seq[UrlComponent], params: Seq[(String, Value)] = Seq.empty): ClientHttpRequest =
         http(httpMethod = GET, path = path, params = params, body = None)
 
     /**
-     * Constructs a [[ClientHttpRequest]] for a `POST` request.
-     *
-     * @param path   the URL path to be used in the request.
-     * @param params the query parameters to be used in the request.
-     * @param body   the body of the request.
-     * @return a [[ClientHttpRequest]].
-     */
+      * Constructs a [[ClientHttpRequest]] for a `POST` request.
+      *
+      * @param path   the URL path to be used in the request.
+      * @param params the query parameters to be used in the request.
+      * @param body   the body of the request.
+      * @return a [[ClientHttpRequest]].
+      */
     def httpPost(path: Seq[UrlComponent], params: Seq[(String, Value)] = Seq.empty, body: Option[HttpRequestBody] = None): ClientHttpRequest =
         http(httpMethod = POST, path = path, params = params, body = body)
 
     /**
-     * Constructs a [[ClientHttpRequest]] for a `PUT` request.
-     *
-     * @param path   the URL path to be used in the request.
-     * @param params the query parameters to be used in the request.
-     * @param body   the body of the request.
-     * @return a [[ClientHttpRequest]].
-     */
+      * Constructs a [[ClientHttpRequest]] for a `PUT` request.
+      *
+      * @param path   the URL path to be used in the request.
+      * @param params the query parameters to be used in the request.
+      * @param body   the body of the request.
+      * @return a [[ClientHttpRequest]].
+      */
     def httpPut(path: Seq[UrlComponent], params: Seq[(String, Value)] = Seq.empty, body: Option[HttpRequestBody] = None): ClientHttpRequest =
         http(httpMethod = PUT, path = path, params = params, body = body)
 
     /**
-     * Constructs a [[ClientHttpRequest]] for a `DELETE` request.
-     *
-     * @param path   the URL path to be used in the request.
-     * @param params the query parameters to be used in the request.
-     * @return a [[ClientHttpRequest]].
-     */
+      * Constructs a [[ClientHttpRequest]] for a `DELETE` request.
+      *
+      * @param path   the URL path to be used in the request.
+      * @param params the query parameters to be used in the request.
+      * @return a [[ClientHttpRequest]].
+      */
     def httpDelete(path: Seq[UrlComponent], params: Seq[(String, Value)] = Seq.empty): ClientHttpRequest =
         http(httpMethod = DELETE, path = path, params = params, body = None)
 
     /**
-     * Constructs a [[ClassRef]] for referring to a class in a function definition.
-     *
-     * @param classIri the IRI of the class.
-     * @return a [[ClassRef]] that can be used for referring to the class.
-     */
+      * Constructs a [[ClassRef]] for referring to a class in a function definition.
+      *
+      * @param classIri the IRI of the class.
+      * @return a [[ClassRef]] that can be used for referring to the class.
+      */
     def classRef(classIri: SmartIri): ClassRef = ClassRef(className = classIri.getEntityName.capitalize, classIri = classIri)
 
     /**
-     * Constructs a [[StringLiteralValue]].
-     *
-     * @param value the value of the string literal.
-     * @return a [[StringLiteralValue]].
-     */
+      * Constructs a [[StringLiteralValue]].
+      *
+      * @param value the value of the string literal.
+      * @return a [[StringLiteralValue]].
+      */
     def str(value: String): StringLiteralValue = StringLiteralValue(value)
 
     /**
-     * A [[BooleanLiteralValue]] with the value `true`.
-     */
+      * A [[BooleanLiteralValue]] with the value `true`.
+      */
     val True: BooleanLiteralValue = BooleanLiteralValue(true)
 
     /**
-     * A [[BooleanLiteralValue]] with the value `false`.
-     */
+      * A [[BooleanLiteralValue]] with the value `false`.
+      */
     val False: BooleanLiteralValue = BooleanLiteralValue(false)
 
     /**
-     * Constructs an [[EnumDatatype]].
-     *
-     * @param values the values of the enumeration.
-     * @return an [[EnumDatatype]].
-     */
+      * Constructs an [[EnumDatatype]].
+      *
+      * @param values the values of the enumeration.
+      * @return an [[EnumDatatype]].
+      */
     def enum(values: String*): EnumDatatype = EnumDatatype(values.toSet)
 
     /**
-     * Constructs an [[ArgValue]] referring to a function argument.
-     *
-     * @param name the name of the argument.
-     * @return an [[ArgValue]].
-     */
+      * Constructs an [[ArgValue]] referring to a function argument.
+      *
+      * @param name the name of the argument.
+      * @return an [[ArgValue]].
+      */
     def arg(name: String) = ArgValue(name)
 
     /**
-     * Constructs an [[ArgValue]] referring to a member of a function argument.
-     *
-     * @param name   the name of the argument.
-     * @param member the name of the member of the argument.
-     * @return an [[ArgValue]].
-     */
+      * Constructs an [[ArgValue]] referring to a member of a function argument.
+      *
+      * @param name   the name of the argument.
+      * @param member the name of the member of the argument.
+      * @return an [[ArgValue]].
+      */
     def argMember(name: String, member: String) = ArgValue(name = name, memberVariableName = Some(member))
 
     /**
-     * A URL path representing the base path of an endpoint.
-     */
+      * A URL path representing the base path of an endpoint.
+      */
     val BasePath: Seq[UrlComponent] = Seq.empty[UrlComponent]
 
     /**
-     * Constructs a [[JsonRequestBody]].
-     *
-     * @param pairs the key-value pairs to be included in the JSON.
-     * @return a [[JsonRequestBody]].
-     */
+      * Constructs a [[JsonRequestBody]].
+      *
+      * @param pairs the key-value pairs to be included in the JSON.
+      * @return a [[JsonRequestBody]].
+      */
     def json(pairs: (String, Value)*): JsonRequestBody = JsonRequestBody(pairs)
 
     private def http(httpMethod: ClientHttpMethod, path: Seq[UrlComponent], params: Seq[(String, Value)], body: Option[HttpRequestBody] = None): ClientHttpRequest = {
@@ -410,14 +410,14 @@ object EndpointFunctionDSL {
 }
 
 /**
- * Represents a client endpoint function.
- *
- * @param name           the name of the function.
- * @param params         the parameters of the function.
- * @param returnType     the function's return type.
- * @param implementation the implementation of the function.
- * @param description    a human-readable description of the function.
- */
+  * Represents a client endpoint function.
+  *
+  * @param name           the name of the function.
+  * @param params         the parameters of the function.
+  * @param returnType     the function's return type.
+  * @param implementation the implementation of the function.
+  * @param description    a human-readable description of the function.
+  */
 case class ClientFunction(name: String,
                           params: Seq[FunctionParam],
                           returnType: ClientObjectType,
@@ -427,47 +427,47 @@ case class ClientFunction(name: String,
 }
 
 /**
- * Represents a function parameter.
- *
- * @param name        the name of the parameter.
- * @param objectType  the type of the parameter.
- * @param isOptional  `true` if the parameter is optional.
- * @param description a human-readable description of the parameter.
- */
+  * Represents a function parameter.
+  *
+  * @param name        the name of the parameter.
+  * @param objectType  the type of the parameter.
+  * @param isOptional  `true` if the parameter is optional.
+  * @param description a human-readable description of the parameter.
+  */
 case class FunctionParam(name: String,
                          objectType: ClientObjectType,
                          isOptional: Boolean,
                          description: String)
 
 /**
- * Represents the implementation of a client endpoint function.
- */
+  * Represents the implementation of a client endpoint function.
+  */
 trait FunctionImplementation
 
 /**
- * Represents an HTTP request to be used as the implementation of a client function.
- *
- * @param httpMethod  the HTTP method to be used.
- * @param urlPath     the URL path to be used.
- * @param params      the URL parameters to be included.
- * @param requestBody if provided, the body of the HTTP request.
- */
+  * Represents an HTTP request to be used as the implementation of a client function.
+  *
+  * @param httpMethod  the HTTP method to be used.
+  * @param urlPath     the URL path to be used.
+  * @param params      the URL parameters to be included.
+  * @param requestBody if provided, the body of the HTTP request.
+  */
 case class ClientHttpRequest(httpMethod: ClientHttpMethod,
                              urlPath: Seq[UrlComponent],
                              params: Seq[(String, Value)],
                              requestBody: Option[HttpRequestBody] = None) extends FunctionImplementation {
     /**
-     * Represents all URL elements, including query parameters, as a sequence of [[Value]] objects
-     * for concatenation.
-     */
+      * Represents all URL elements, including query parameters, as a sequence of [[Value]] objects
+      * for concatenation.
+      */
     lazy val urlElementsAsValues: Seq[Value] = urlPath.map {
         case SlashUrlComponent => StringLiteralValue("/")
         case value: Value => value
     } ++ paramsAsValues
 
     /**
-     * Represents the URL query parameters as a sequence of [[Value]] objects for concatenation.
-     */
+      * Represents the URL query parameters as a sequence of [[Value]] objects for concatenation.
+      */
     lazy val paramsAsValues: Seq[Value] = {
         if (params.isEmpty) {
             Seq.empty
@@ -502,126 +502,126 @@ case class ClientHttpRequest(httpMethod: ClientHttpMethod,
 }
 
 /**
- * Represents a function call to be used as the implementation of a client endpoint function.
- *
- * @param name the name of the function to be called.
- * @param args the arguments to be passed to the function call.
- */
+  * Represents a function call to be used as the implementation of a client endpoint function.
+  *
+  * @param name the name of the function to be called.
+  * @param args the arguments to be passed to the function call.
+  */
 case class FunctionCall(name: String, args: Seq[Value]) extends FunctionImplementation
 
 /**
- * Indicates the HTTP method used in a client endpoint function.
- */
+  * Indicates the HTTP method used in a client endpoint function.
+  */
 trait ClientHttpMethod
 
 /**
- * Represents HTTP GET.
- */
+  * Represents HTTP GET.
+  */
 case object GET extends ClientHttpMethod
 
 /**
- * Represents HTTP POST.
- */
+  * Represents HTTP POST.
+  */
 case object POST extends ClientHttpMethod
 
 /**
- * Represents HTTP PUT.
- */
+  * Represents HTTP PUT.
+  */
 case object PUT extends ClientHttpMethod
 
 /**
- * Represents HTTP DELETE.
- */
+  * Represents HTTP DELETE.
+  */
 case object DELETE extends ClientHttpMethod
 
 /**
- * Represents part of a URL path to be constructed for a client endpoint function.
- */
+  * Represents part of a URL path to be constructed for a client endpoint function.
+  */
 trait UrlComponent
 
 /**
- * Represents a `/` character in a URL path.
- */
+  * Represents a `/` character in a URL path.
+  */
 case object SlashUrlComponent extends UrlComponent
 
 /**
- * Represents a value used in a function.
- */
+  * Represents a value used in a function.
+  */
 trait Value extends UrlComponent
 
 /**
- * Represents a literal value.
- */
+  * Represents a literal value.
+  */
 trait LiteralValue extends Value
 
 /**
- * Represents a string literal value.
- *
- * @param value the value of the string literal.
- */
+  * Represents a string literal value.
+  *
+  * @param value the value of the string literal.
+  */
 case class StringLiteralValue(value: String) extends LiteralValue {
     override def toString: String = value
 }
 
 /**
- * Represents a boolean literal value.
- *
- * @param value the value of the boolean literal.
- */
+  * Represents a boolean literal value.
+  *
+  * @param value the value of the boolean literal.
+  */
 case class BooleanLiteralValue(value: Boolean) extends LiteralValue {
     override def toString: String = value.toString
 }
 
 /**
- * Represents an integer literal value.
- *
- * @param value the value of the integer literal.
- */
+  * Represents an integer literal value.
+  *
+  * @param value the value of the integer literal.
+  */
 case class IntegerLiteralValue(value: Int) extends LiteralValue {
     override def toString: String = value.toString
 }
 
 /**
- * Represents a function argument.
- *
- * @param name               the name of the parameter whose value is the argument.
- * @param memberVariableName if provided, the name of a member variable of the argument, to be used instead of
- *                           the argument itself.
- * @param convertTo          if provided, the type that the argument should be converted to.
- */
+  * Represents a function argument.
+  *
+  * @param name               the name of the parameter whose value is the argument.
+  * @param memberVariableName if provided, the name of a member variable of the argument, to be used instead of
+  *                           the argument itself.
+  * @param convertTo          if provided, the type that the argument should be converted to.
+  */
 case class ArgValue(name: String, memberVariableName: Option[String] = None, convertTo: Option[ClientObjectType] = None) extends Value with HttpRequestBody {
     def as(convertTo: ClientObjectType): ArgValue = copy(convertTo = Some(convertTo))
 }
 
 /**
- * Represents the body of an HTTP request.
- */
+  * Represents the body of an HTTP request.
+  */
 trait HttpRequestBody
 
 /**
- * Represents a JSON object to be sent as an HTTP request body.
- *
- * @param jsonObject the keys and values of the object.
- */
+  * Represents a JSON object to be sent as an HTTP request body.
+  *
+  * @param jsonObject the keys and values of the object.
+  */
 case class JsonRequestBody(jsonObject: Seq[(String, Value)]) extends HttpRequestBody
 
 /**
- * A definition of a Knora API class, which can be used by a [[GeneratorBackEnd]] to generate client code.
- *
- * @param className        the name of the class.
- * @param classDescription a description of the class.
- * @param classIri         the IRI of the class in the Knora API.
- * @param properties       definitions of the properties used in the class.
- * @param subClassOf       the IRI of the class's base class (used only in generated subclasses).
- */
+  * A definition of a Knora API class, which can be used by a [[GeneratorBackEnd]] to generate client code.
+  *
+  * @param className        the name of the class.
+  * @param classDescription a description of the class.
+  * @param classIri         the IRI of the class in the Knora API.
+  * @param properties       definitions of the properties used in the class.
+  * @param subClassOf       the IRI of the class's base class (used only in generated subclasses).
+  */
 case class ClientClassDefinition(className: String,
                                  classDescription: Option[String],
                                  classIri: SmartIri,
                                  properties: Vector[ClientPropertyDefinition],
                                  subClassOf: Option[SmartIri] = None) {
     /**
-     * The classes used by this class.
-     */
+      * The classes used by this class.
+      */
     lazy val classObjectTypesUsed: Set[ClassRef] = properties.foldLeft(Set.empty[ClassRef]) {
         (acc, property) =>
             property.objectType match {
@@ -632,15 +632,15 @@ case class ClientClassDefinition(className: String,
 }
 
 /**
- * A definition of a Knora property as used in a particular class.
- *
- * @param propertyName        the name of the property.
- * @param propertyDescription a description of the property.
- * @param propertyIri         the IRI of the property in the Knora API.
- * @param objectType          the type of object that the property points to.
- * @param cardinality         the cardinality of the property in the class.
- * @param isEditable          `true` if the property's value is editable via the API.
- */
+  * A definition of a Knora property as used in a particular class.
+  *
+  * @param propertyName        the name of the property.
+  * @param propertyDescription a description of the property.
+  * @param propertyIri         the IRI of the property in the Knora API.
+  * @param objectType          the type of object that the property points to.
+  * @param cardinality         the cardinality of the property in the class.
+  * @param isEditable          `true` if the property's value is editable via the API.
+  */
 case class ClientPropertyDefinition(propertyName: String,
                                     propertyDescription: Option[String],
                                     propertyIri: SmartIri,
@@ -649,62 +649,97 @@ case class ClientPropertyDefinition(propertyName: String,
                                     isEditable: Boolean)
 
 /**
- * A trait for types used in client API endpoints.
- */
+  * A trait for types used in client API endpoints.
+  */
 sealed trait ClientObjectType
 
 /**
- * A trait for datatypes.
- */
-sealed trait ClientDatatype extends ClientObjectType
+  * A trait for datatypes.
+  */
+sealed trait ClientDatatype extends MapValueType with ArrayElementType
 
 /**
- * The type of string datatype values.
- */
-case object StringDatatype extends ClientDatatype
+  * The type of string datatype values.
+  */
+case object StringDatatype extends ClientDatatype with MapKeyDatatype
 
 /**
- * The type of boolean datatype values.
- */
+  * The type of boolean datatype values.
+  */
 case object BooleanDatatype extends ClientDatatype
 
 /**
- * The type of integer datatype values.
- */
+  * The type of integer datatype values.
+  */
 case object IntegerDatatype extends ClientDatatype
 
 /**
- * The type of decimal datatype values.
- */
+  * The type of decimal datatype values.
+  */
 case object DecimalDatatype extends ClientDatatype
 
 /**
- * The type of URI datatype values.
- */
-case object UriDatatype extends ClientDatatype
+  * The type of URI datatype values.
+  */
+case object UriDatatype extends ClientDatatype with MapKeyDatatype
 
 /**
- * The type of timestamp datatype values.
- */
+  * The type of timestamp datatype values.
+  */
 case object DateTimeStampDatatype extends ClientDatatype
 
 /**
- * The type of enums.
- *
- * @param values the values of the enum.
- */
+  * A trait for types representing collections in the target language.
+  */
+sealed trait CollectionType extends ClientObjectType
+
+/**
+  * A trait for types that can be keys in [[MapType]] data structures.
+  */
+sealed trait MapKeyDatatype extends ClientObjectType
+
+/**
+  * A trait for types that can be values in [[MapType]] data structures.
+  */
+sealed trait MapValueType extends ClientObjectType
+
+/**
+  * Represents a map-like data structure in the target language.
+  *
+  * @param keyType   the type of the keys of the map.
+  * @param valueType the type of the values of the map.
+  */
+case class MapType(keyType: MapKeyDatatype, valueType: MapValueType) extends CollectionType with MapValueType with ArrayElementType
+
+/**
+  * A trait for types that can be elements in an [[ArrayType]] data structure.
+  */
+sealed trait ArrayElementType extends ClientObjectType
+
+/**
+  * Represents an array-like data structure in the target language.
+  *
+  * @param elementType the type of the elements of the array.
+  */
+case class ArrayType(elementType: ArrayElementType) extends CollectionType with MapValueType with ArrayElementType
+
+/**
+  * The type of enums.
+  *
+  * @param values the values of the enum.
+  */
 case class EnumDatatype(values: Set[String]) extends ClientDatatype
 
 /**
- * The type of instances of classes.
- *
- * @param className the name of the class.
- * @param classIri  the IRI of the class.
- */
-case class ClassRef(className: String, classIri: SmartIri) extends ClientObjectType {
+  * The type of instances of classes.
+  *
+  * @param className the name of the class.
+  * @param classIri  the IRI of the class.
+  */
+case class ClassRef(className: String, classIri: SmartIri) extends MapValueType with ArrayElementType {
     /**
-     * Converts this [[ClassRef]] to one that represents a `Stored*` derived class.
-     */
+      * Converts this [[ClassRef]] to one that represents a `Stored*` derived class.
+      */
     def toStoredClassRef: ClassRef = {
         val storedClassName = ClassRef.makeStoredClassName(className)
         val storedClassIri = classIri.getOntologyFromEntity.makeEntityIri(storedClassName)
@@ -712,8 +747,8 @@ case class ClassRef(className: String, classIri: SmartIri) extends ClientObjectT
     }
 
     /**
-     * Converts this [[ClassRef]] to one that represents a `Read*` derived class.
-     */
+      * Converts this [[ClassRef]] to one that represents a `Read*` derived class.
+      */
     def toReadClassRef: ClassRef = {
         val readClassName = ClassRef.makeReadClassName(className)
         val readClassIri = classIri.getOntologyFromEntity.makeEntityIri(readClassName)
@@ -745,118 +780,118 @@ object ClassRef {
     }
 
     /**
-     * Converts a base class name to a `Stored*` derived class name.
-     */
+      * Converts a base class name to a `Stored*` derived class name.
+      */
     def makeStoredClassName(className: String): String = {
         s"Stored$className"
     }
 
     /**
-     * Converts a base class name to a `Read*` derived class name.
-     */
+      * Converts a base class name to a `Read*` derived class name.
+      */
     def makeReadClassName(className: String): String = {
         s"Read$className"
     }
 }
 
 /**
- * A trait for Knora value types.
- */
+  * A trait for Knora value types.
+  */
 sealed trait KnoraVal extends ClientObjectType
 
 /**
- * The type of abstract Knora values.
- */
+  * The type of abstract Knora values.
+  */
 case object AbstractKnoraVal extends KnoraVal
 
 /**
- * The type of text values.
- */
+  * The type of text values.
+  */
 case object TextVal extends KnoraVal
 
 /**
- * The type of integer values.
- */
+  * The type of integer values.
+  */
 case object IntVal extends KnoraVal
 
 /**
- * The type of boolean values.
- */
+  * The type of boolean values.
+  */
 case object BooleanVal extends KnoraVal
 
 /**
- * The type of URI values.
- */
+  * The type of URI values.
+  */
 case object UriVal extends KnoraVal
 
 /**
- * The type of decimal values.
- */
+  * The type of decimal values.
+  */
 case object DecimalVal extends KnoraVal
 
 /**
- * The type of date values.
- */
+  * The type of date values.
+  */
 case object DateVal extends KnoraVal
 
 /**
- * The type of color values.
- */
+  * The type of color values.
+  */
 case object ColorVal extends KnoraVal
 
 /**
- * The type of geometry values.
- */
+  * The type of geometry values.
+  */
 case object GeomVal extends KnoraVal
 
 /**
- * The type of list values.
- */
+  * The type of list values.
+  */
 case object ListVal extends KnoraVal
 
 /**
- * The type of interval values.
- */
+  * The type of interval values.
+  */
 case object IntervalVal extends KnoraVal
 
 /**
- * The type of Geoname values.
- */
+  * The type of Geoname values.
+  */
 case object GeonameVal extends KnoraVal
 
 /**
- * The type of audio file values.
- */
+  * The type of audio file values.
+  */
 case object AudioFileVal extends KnoraVal
 
 /**
- * The type of 3D file values.
- */
+  * The type of 3D file values.
+  */
 case object DDDFileVal extends KnoraVal
 
 /**
- * The type of document file values.
- */
+  * The type of document file values.
+  */
 case object DocumentFileVal extends KnoraVal
 
 /**
- * The type of still image file values.
- */
+  * The type of still image file values.
+  */
 case object StillImageFileVal extends KnoraVal
 
 /**
- * The type of moving image values.
- */
+  * The type of moving image values.
+  */
 case object MovingImageFileVal extends KnoraVal
 
 /**
- * The type of text file values.
- */
+  * The type of text file values.
+  */
 case object TextFileVal extends KnoraVal
 
 /**
- * The type of link values.
- *
- * @param classIri the IRI of the class that is the target of the link.
- */
+  * The type of link values.
+  *
+  * @param classIri the IRI of the class that is the target of the link.
+  */
 case class LinkVal(classIri: SmartIri) extends KnoraVal

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientCollectionTypeParser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/ClientCollectionTypeParser.scala
@@ -1,0 +1,493 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.util.clientapi
+
+import org.knora.webapi.{ClientApiGenerationException, IRI}
+import org.knora.webapi.util.StringFormatter
+import org.knora.webapi.util.IriConversions._
+
+/**
+  * Parses type annotations representing collection types.
+  */
+object ClientCollectionTypeParser {
+
+    /**
+      * Parses a collection type annotation.
+      *
+      * @param typeStr the type annotation to be parsed.
+      * @param namespace the RDF namespace supplied with the type annotation.
+      * @return the parsed collection type annotation.
+      */
+    def parse(typeStr: String, namespace: IRI): CollectionType = {
+        implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
+
+        // Tokenise the input.
+        val tokens: Vector[TypeToken] = tokenise(typeStr)
+
+        // Parse the type annotation.
+        val (objectType, remainingTokens) = parseType(
+            typeStr = typeStr,
+            tokens = tokens,
+            namespace = namespace
+        )
+
+        // Are there any tokens left?
+        if (remainingTokens.isEmpty) {
+            // No. Validate the collection type.
+            objectType match {
+                case collectionType: CollectionType => collectionType
+                case _ => throw ClientApiGenerationException(s"Expected a collection type: $typeStr")
+            }
+        } else {
+            throw ClientApiGenerationException(s"Invalid type: $typeStr")
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Token classes
+
+    /**
+      * A token in a type annotation.
+      */
+    private trait TypeToken
+
+    /**
+      * An identifier.
+      */
+    private trait Identifier extends TypeToken
+
+    /**
+      * A built-in identifier.
+      */
+    private trait BuiltInIdentifier extends Identifier
+
+    /**
+      * The name of a datatype.
+      */
+    private trait DatatypeIdentifier extends BuiltInIdentifier {
+        def toClientDatatype: ClientDatatype
+    }
+
+    /**
+      * The string datatype.
+      */
+    private case object StringIdentifier extends DatatypeIdentifier {
+        override def toString: String = "String"
+
+        override def toClientDatatype: ClientDatatype = StringDatatype
+    }
+
+    /**
+      * The boolean datatype.
+      */
+    private case object BooleanIdentifier extends DatatypeIdentifier {
+        override def toString: String = "Boolean"
+
+        override def toClientDatatype: ClientDatatype = BooleanDatatype
+    }
+
+    /**
+      * The integer datatype.
+      */
+    private case object IntegerIdentifier extends DatatypeIdentifier {
+        override def toString: String = "Integer"
+
+        override def toClientDatatype: ClientDatatype = IntegerDatatype
+    }
+
+    /**
+      * The decimal datatype.
+      */
+    private case object DecimalIdentifier extends DatatypeIdentifier {
+        override def toString: String = "Decimal"
+
+        override def toClientDatatype: ClientDatatype = DecimalDatatype
+    }
+
+    /**
+      * The URI datatype.
+      */
+    private case object UriIdentifier extends DatatypeIdentifier {
+        override def toString: String = "URI"
+
+        override def toClientDatatype: ClientDatatype = UriDatatype
+    }
+
+    /**
+      * The `xsd:dateTimeStamp` datatype.
+      */
+    private case object DateTimeStampIdentifier extends DatatypeIdentifier {
+        override def toString: String = "DateTimeStamp"
+
+        override def toClientDatatype: ClientDatatype = DateTimeStampDatatype
+    }
+
+    /**
+      * The `Map` collection type.
+      */
+    private case object MapIdentifier extends BuiltInIdentifier {
+        override def toString: String = "Map"
+    }
+
+    /**
+      * The `Array` collection type.
+      */
+    private case object ArrayIdentifier extends BuiltInIdentifier {
+        override def toString: String = "Array"
+    }
+
+    /**
+      * A map of identifier names to built-in identifiers.
+      */
+    private val builtInIdentifiers: Map[String, BuiltInIdentifier] = Seq(
+        StringIdentifier,
+        BooleanIdentifier,
+        IntegerIdentifier,
+        DecimalIdentifier,
+        UriIdentifier,
+        DateTimeStampIdentifier,
+        MapIdentifier,
+        ArrayIdentifier
+    ).map {
+        token => token.toString -> token
+    }.toMap
+
+    /**
+      * A token representing punctuation.
+      */
+    sealed trait PunctuationToken extends TypeToken {
+        def toChar: Char
+    }
+
+    /**
+      * The `[` token.
+      */
+    private case object OpenBracketToken extends PunctuationToken {
+        def toChar: Char = '['
+    }
+
+    /**
+      * The `]` token.
+      */
+    private case object CloseBracketToken extends PunctuationToken {
+        def toChar: Char = ']'
+    }
+
+    /**
+      * The `,` token.
+      */
+    private case object CommaToken extends PunctuationToken {
+        def toChar: Char = ','
+    }
+
+    /**
+      * A map of characters to punctuation tokens.
+      */
+    private val punctuation: Map[Char, PunctuationToken] = Seq(
+        OpenBracketToken,
+        CloseBracketToken,
+        CommaToken
+    ).map {
+        token => token.toChar -> token
+    }.toMap
+
+    /**
+      * An identifier representing a class name in the target language.
+      */
+    private case class ClassRefIdentifier(className: String) extends Identifier {
+        override def toString: String = className
+
+        /**
+          * Converts this token to a [[ClassRef]], using the specified RDF namespace.
+          *
+          * @param namespace the RDF namespace.
+          */
+        def toClassRef(namespace: IRI)(implicit stringFormatter: StringFormatter): ClassRef = {
+            ClassRef(className = className, classIri = (namespace + className).toSmartIri)
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Tokeniser
+
+    /**
+      * Tokenises a type annotation.
+      *
+      * @param typeStr the string to be tokenised.
+      * @return the tokens representing the type annotation.
+      */
+    private def tokenise(typeStr: String): Vector[TypeToken] = {
+        tokeniseRec(
+            typeStr = typeStr,
+            pos = 0,
+            currentIdentifier = "",
+            tokens = Vector.empty
+        )
+    }
+
+    /**
+      * Recursively tokenises a type annotation.
+      *
+      * @param typeStr           the string to be tokenised.
+      * @param pos               the current position in the string.
+      * @param currentIdentifier the identifier currently being tokenised.
+      * @param tokens            the tokens that have been collected so far.
+      * @return the tokens representing the type annotation.
+      */
+    @scala.annotation.tailrec
+    private def tokeniseRec(typeStr: String, pos: Int, currentIdentifier: String, tokens: Vector[TypeToken]): Vector[TypeToken] = {
+        /**
+          * Returns the tokens that have been collected so far, including a token representing `currentIdentifier`
+          * if it is not empty.
+          */
+        def collectTokens: Vector[TypeToken] = {
+            // Are there characters in currentIdentifier?
+            if (currentIdentifier.nonEmpty) {
+                // Yes. Is it a built-in identifier?
+                val identifierToken = builtInIdentifiers.get(currentIdentifier) match {
+                    case Some(builtInIdentifier) =>
+                        // Yes.
+                        builtInIdentifier
+
+                    case None =>
+                        // No. It must be a class reference.
+                        ClassRefIdentifier(currentIdentifier)
+                }
+
+                // Return the tokens collected so far, plus the identifier token.
+                tokens :+ identifierToken
+            } else {
+                // There are no characters in currentIdentifier. Just return the tokens collected so far.
+                tokens
+            }
+        }
+
+        // Are we at the end of the input?
+        if (pos == typeStr.length) {
+            // Yes. Return the tokens collected so far, including currentIdentifier if it is not empty.
+            collectTokens
+        } else {
+            // Get the next character.
+            val char: Char = typeStr.charAt(pos)
+
+            // Skip whitespace.
+            if (char == ' ') {
+                tokeniseRec(
+                    typeStr = typeStr,
+                    pos = pos + 1,
+                    currentIdentifier = currentIdentifier,
+                    tokens = tokens
+                )
+            } else {
+                // Is this a punctuation character?
+                punctuation.get(char) match {
+                    case Some(punctuationToken) =>
+                        // Yes. Get any identifier preceding the punctuation, add the punctuation token,
+                        // and recurse.
+                        val collectedTokens = collectTokens :+ punctuationToken
+
+                        tokeniseRec(
+                            typeStr = typeStr,
+                            pos = pos + 1,
+                            currentIdentifier = "",
+                            tokens = collectedTokens
+                        )
+
+                    case None =>
+                        // This is not a punctuation character. Is it a Unicode letter?
+                        if (Character.isLetter(char)) {
+                            // Yes. It must be part of an identifier. Recurse.
+                            tokeniseRec(
+                                typeStr = typeStr,
+                                pos = pos + 1,
+                                currentIdentifier = currentIdentifier + char,
+                                tokens = tokens
+                            )
+                        } else {
+                            // It's not a Unicode letter, so it's an invalid character.
+                            throw ClientApiGenerationException(s"Unexpected character '$char' in object type name: $typeStr")
+                        }
+                }
+            }
+        }
+    }
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // Parser
+
+    /**
+      * Recursively parses a type annotation.
+      *
+      * @param typeStr the string representation of the type annotation being parsed.
+      * @param tokens the tokens not yet parsed.
+      * @param namespace the RDF namespace supplied with the type annotation.
+      * @return the parsed type annotation and the tokens that follow it.
+      */
+    private def parseType(typeStr: String, tokens: Vector[TypeToken], namespace: IRI)(implicit stringFormatter: StringFormatter): (ClientObjectType, Vector[TypeToken]) = {
+        tokens.headOption match {
+            case Some(token) =>
+                token match {
+                    case MapIdentifier =>
+                        parseMap(
+                            typeStr = typeStr,
+                            tokens = tokens.tail,
+                            namespace = namespace
+                        )
+
+                    case ArrayIdentifier =>
+                        parseArray(
+                            typeStr = typeStr,
+                            tokens = tokens.tail,
+                            namespace = namespace
+                        )
+
+                    case datatypeToken: DatatypeIdentifier => (datatypeToken.toClientDatatype, tokens.tail)
+
+                    case classRefToken: ClassRefIdentifier => (classRefToken.toClassRef(namespace), tokens.tail)
+
+                    case _ => throw ClientApiGenerationException(s"Invalid type: $typeStr")
+                }
+
+            case None => throw ClientApiGenerationException(s"Invalid type: $typeStr")
+        }
+    }
+
+    /**
+      * Parses a `Map` type annotation.
+      *
+      * @param typeStr the string representation of the type annotation being parsed.
+      * @param tokens the tokens not yet parsed.
+      * @param namespace the RDF namespace supplied with the type annotation.
+      * @return a [[MapType]] and the tokens that follow it.
+      */
+    private def parseMap(typeStr: String, tokens: Vector[TypeToken], namespace: IRI)(implicit stringFormatter: StringFormatter): (MapType, Vector[TypeToken]) = {
+        // Consume the open bracket.
+        val afterOpenBracket: Vector[TypeToken] = consumePunctuation(
+            typeStr = typeStr,
+            tokens = tokens,
+            punctuationToken = OpenBracketToken
+        )
+
+        // Get the key type.
+        val (keyType: ClientObjectType, afterKeyType: Vector[TypeToken]) = parseType(
+            typeStr = typeStr,
+            tokens = afterOpenBracket,
+            namespace = namespace
+        )
+
+        // Validate the key type.
+        val validKeyType: MapKeyDatatype = keyType match {
+            case mapKeyDatatype: MapKeyDatatype => mapKeyDatatype
+            case _ => throw ClientApiGenerationException(s"Invalid map key type: $typeStr")
+        }
+
+        // Consume the comma separating the key type from the value type.
+        val afterComma: Vector[TypeToken] = consumePunctuation(
+            typeStr = typeStr,
+            tokens = afterKeyType,
+            punctuationToken = CommaToken
+        )
+
+        // Get the value type.
+        val (valueType: ClientObjectType, afterValueType: Vector[TypeToken]) = parseType(
+            typeStr = typeStr,
+            tokens = afterComma,
+            namespace = namespace
+        )
+
+        // Validate the value type.
+        val validValueType: MapValueType = valueType match {
+            case mapValueType: MapValueType => mapValueType
+            case _ => throw ClientApiGenerationException(s"Invalid map value type: $typeStr")
+        }
+
+        // Consume the close bracket.
+        val afterCloseBracket = consumePunctuation(
+            typeStr = typeStr,
+            tokens = afterValueType,
+            punctuationToken = CloseBracketToken
+        )
+
+        (MapType(keyType = validKeyType, valueType = validValueType), afterCloseBracket)
+    }
+
+    /**
+      * Parses an `Array` type annotation.
+      *
+      * @param typeStr the string representation of the type annotation being parsed.
+      * @param tokens the tokens not yet parsed.
+      * @param namespace the RDF namespace supplied with the type annotation.
+      * @return a [[ArrayType]] and the tokens that follow it.
+      */
+    private def parseArray(typeStr: String, tokens: Vector[TypeToken], namespace: IRI)(implicit stringFormatter: StringFormatter): (ArrayType, Vector[TypeToken]) = {
+        // Consume the open bracket.
+        val afterOpenBracket: Vector[TypeToken] = consumePunctuation(
+            typeStr = typeStr,
+            tokens = tokens,
+            punctuationToken = OpenBracketToken
+        )
+
+        // Get the element type.
+        val (elementType: ClientObjectType, afterKeyType: Vector[TypeToken]) = parseType(
+            typeStr = typeStr,
+            tokens = afterOpenBracket,
+            namespace = namespace
+        )
+
+        // Validate the element type.
+        val validElementType = elementType match {
+            case arrayElementType: ArrayElementType => arrayElementType
+            case _ => throw ClientApiGenerationException(s"Invalid array element type: $typeStr")
+        }
+
+        // Consume the close bracket.
+        val afterCloseBracket = consumePunctuation(
+            typeStr = typeStr,
+            tokens = afterKeyType,
+            punctuationToken = CloseBracketToken
+        )
+
+        (ArrayType(elementType = validElementType), afterCloseBracket)
+    }
+
+    /**
+      * Consumes a punctuation token.
+      *
+      * @param typeStr the string representation of the type annotation being parsed.
+      * @param tokens the tokens not yet parsed.
+      * @param punctuationToken the expected punctuation token.
+      * @return the tokens following the punctuation token.
+      */
+    private def consumePunctuation(typeStr: String, tokens: Vector[TypeToken], punctuationToken: PunctuationToken): Vector[TypeToken] = {
+        // Is there a next token?
+        tokens.headOption match {
+            case Some(token) =>
+                // Yes. Is it the expected punctuation token?
+                if (token == punctuationToken) {
+                    // Yes. Return the tokens following the punctuation token.
+                    tokens.tail
+                } else {
+                    throw ClientApiGenerationException(s"Expected '${punctuationToken.toChar}': $typeStr")
+                }
+
+            case None => throw ClientApiGenerationException(s"Expected '${punctuationToken.toChar}': $typeStr")
+        }
+    }
+}

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/GeneratorFrontEnd.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/GeneratorFrontEnd.scala
@@ -245,15 +245,15 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
         // A class that has an ID property needs a Stored* subclass.
         val classIrisNeedingStoredClasses: Set[SmartIri] = clientDefs.collect {
             case (classIri, classDef) if classDef.properties.exists(propDef => clientApi.idProperties.contains(propDef.propertyIri)) => classIri
-        }.toSet
+        }.toSet -- clientApi.inherentlyReadOnlyClasses
 
         // A map of the IRIs of classes that need Stored* classes, to the IRIs of their Stored* classes.
-        val storedClassIris: Map[SmartIri, SmartIri] = clientDefs.keySet.map {
+        val storedClassIris: Map[SmartIri, SmartIri] = classIrisNeedingStoredClasses.map {
             classIri => classIri -> classIri.getOntologyFromEntity.makeEntityIri(ClassRef.makeStoredClassName(classIri.getEntityName))
         }.toMap
 
         // A class that has one or more read-only properties needs a Read* subclass.
-        val classIrisNeedingReadClasses: Set[SmartIri] = clientApi.classesWithReadOnlyProperties.keySet
+        val classIrisNeedingReadClasses: Set[SmartIri] = clientApi.classesWithReadOnlyProperties.keySet -- clientApi.inherentlyReadOnlyClasses
 
         // A map of the IRIs of classes that need Read* classes, to the IRIs of their Read* classes.
         val readClassIris: Map[SmartIri, SmartIri] = classIrisNeedingReadClasses.map {

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/GeneratorFrontEnd.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/GeneratorFrontEnd.scala
@@ -34,9 +34,9 @@ import org.knora.webapi.util.{SmartIri, StringFormatter}
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
- * The front end of the client code generator. It is responsible for producing [[ClientClassDefinition]] objects
- * representing the Knora classes used in an API.
- */
+  * The front end of the client code generator. It is responsible for producing [[ClientClassDefinition]] objects
+  * representing the Knora classes used in an API.
+  */
 class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     implicit protected val system: ActorSystem = routeData.system
     implicit protected val responderManager: ActorRef = routeData.appActor
@@ -49,24 +49,24 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     private val userWithLang = requestingUser.copy(lang = LanguageCodes.EN)
 
     /**
-     * Returns a set of [[ClientClassDefinition]] instances representing the Knora classes used by a client API.
-     */
+      * Returns a set of [[ClientClassDefinition]] instances representing the Knora classes used by a client API.
+      */
     def getClientClassDefs(clientApi: ClientApi): Future[Set[ClientClassDefinition]] = {
         /**
-         * An accumulator for client class definitions and ontologies.
-         *
-         * @param clientDefs the client class definitions accumulated so far.
-         * @param ontologies the ontologies accumulated so far.
-         */
+          * An accumulator for client class definitions and ontologies.
+          *
+          * @param clientDefs the client class definitions accumulated so far.
+          * @param ontologies the ontologies accumulated so far.
+          */
         case class ClientDefsWithOntologies(clientDefs: Map[SmartIri, ClientClassDefinition], ontologies: Map[SmartIri, InputOntologyV2])
 
         /**
-         * Recursively gets class definitions.
-         *
-         * @param classIri      the IRI of a class whose definition is needed.
-         * @param definitionAcc the class definitions and ontologies collected so far.
-         * @return the class definitions and ontologies resulting from recursion.
-         */
+          * Recursively gets class definitions.
+          *
+          * @param classIri      the IRI of a class whose definition is needed.
+          * @param definitionAcc the class definitions and ontologies collected so far.
+          * @return the class definitions and ontologies resulting from recursion.
+          */
         def getClassDefsRec(classIri: SmartIri, definitionAcc: ClientDefsWithOntologies): Future[ClientDefsWithOntologies] = {
             val className: String = classIri.getEntityName
 
@@ -185,21 +185,21 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Transforms client class definitions by adding `Stored*` and `Read*` classes, transforming the properties of their base
-     * classes, and transforming the properties of response classes.
-     *
-     * @param clientApi  the client API definition.
-     * @param clientDefs the client class definitions used by the API.
-     * @return the transformed class definitions.
-     */
+      * Transforms client class definitions by adding `Stored*` and `Read*` classes, transforming the properties of their base
+      * classes, and transforming the properties of response classes.
+      *
+      * @param clientApi  the client API definition.
+      * @param clientDefs the client class definitions used by the API.
+      * @return the transformed class definitions.
+      */
     private def transformClientClassDefs(clientApi: ClientApi, clientDefs: Map[SmartIri, ClientClassDefinition]): Set[ClientClassDefinition] = {
         /**
-         * Transforms the class reference object types of properties.
-         *
-         * @param properties         the properties to transform.
-         * @param classIrisToReplace A map of source class IRIs to replacement class IRIs.
-         * @return the transformed properties.
-         */
+          * Transforms the class reference object types of properties.
+          *
+          * @param properties         the properties to transform.
+          * @param classIrisToReplace A map of source class IRIs to replacement class IRIs.
+          * @return the transformed properties.
+          */
         def transformPropertyObjectTypes(properties: Vector[ClientPropertyDefinition],
                                          classIrisToReplace: Map[SmartIri, SmartIri]): Vector[ClientPropertyDefinition] = {
             properties.map {
@@ -339,12 +339,12 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Gets an ontology from Knora.
-     *
-     * @param ontologyIri the IRI of the ontology.
-     * @param ontologies  the ontologies collected so far.
-     * @return `ontologies` plus the requested ontology.
-     */
+      * Gets an ontology from Knora.
+      *
+      * @param ontologyIri the IRI of the ontology.
+      * @param ontologies  the ontologies collected so far.
+      * @return `ontologies` plus the requested ontology.
+      */
     private def getOntology(ontologyIri: SmartIri, ontologies: Map[SmartIri, InputOntologyV2]): Future[Map[SmartIri, InputOntologyV2]] = {
         val requestMessage = OntologyEntitiesGetRequestV2(
             ontologyIri = ontologyIri,
@@ -366,12 +366,12 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Converts RDF class definitions into [[ClientClassDefinition]] instances.
-     *
-     * @param rdfClassDef     the class definition to be converted.
-     * @param rdfPropertyDefs the definitions of the properties used in the class.
-     * @return a [[ClientClassDefinition]] describing the class.
-     */
+      * Converts RDF class definitions into [[ClientClassDefinition]] instances.
+      *
+      * @param rdfClassDef     the class definition to be converted.
+      * @param rdfPropertyDefs the definitions of the properties used in the class.
+      * @return a [[ClientClassDefinition]] describing the class.
+      */
     private def rdfClassDef2ClientClassDef(rdfClassDef: ClassInfoContentV2, rdfPropertyDefs: Map[SmartIri, PropertyInfoContentV2]): ClientClassDefinition = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -385,12 +385,12 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Converts Knora resource class definitions into [[ClientClassDefinition]] instances.
-     *
-     * @param rdfClassDef     the class definition to be converted.
-     * @param rdfPropertyDefs the definitions of the properties used in the class.
-     * @return a [[ClientClassDefinition]] describing the class.
-     */
+      * Converts Knora resource class definitions into [[ClientClassDefinition]] instances.
+      *
+      * @param rdfClassDef     the class definition to be converted.
+      * @param rdfPropertyDefs the definitions of the properties used in the class.
+      * @return a [[ClientClassDefinition]] describing the class.
+      */
     private def rdfResourceClassDef2ClientClassDef(rdfClassDef: ClassInfoContentV2, rdfPropertyDefs: Map[SmartIri, PropertyInfoContentV2]): ClientClassDefinition = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -463,12 +463,12 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Converts Knora non-resource class definitions into [[ClientClassDefinition]] instances.
-     *
-     * @param rdfClassDef     the class definition to be converted.
-     * @param rdfPropertyDefs the definitions of the properties used in the class.
-     * @return a [[ClientClassDefinition]] describing the class.
-     */
+      * Converts Knora non-resource class definitions into [[ClientClassDefinition]] instances.
+      *
+      * @param rdfClassDef     the class definition to be converted.
+      * @param rdfPropertyDefs the definitions of the properties used in the class.
+      * @return a [[ClientClassDefinition]] describing the class.
+      */
     private def rdfNonResourceClassDef2ClientClassDef(rdfClassDef: ClassInfoContentV2, rdfPropertyDefs: Map[SmartIri, PropertyInfoContentV2]): ClientClassDefinition = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -512,21 +512,21 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Given the IRI of an RDF class, creates a client class name for it.
-     *
-     * @param classIri the class IRI.
-     * @return the client class name.
-     */
+      * Given the IRI of an RDF class, creates a client class name for it.
+      *
+      * @param classIri the class IRI.
+      * @return the client class name.
+      */
     private def makeClientClassName(classIri: SmartIri): String = {
         classIri.getEntityName.capitalize
     }
 
     /**
-     * Given a Knora value object type, returns the corresponding [[ClientObjectType]].
-     *
-     * @param ontologyObjectType the RDF type.
-     * @return the corresponding [[ClientObjectType]].
-     */
+      * Given a Knora value object type, returns the corresponding [[ClientObjectType]].
+      *
+      * @param ontologyObjectType the RDF type.
+      * @return the corresponding [[ClientObjectType]].
+      */
     private def resourcePropObjectTypeToClientObjectType(ontologyObjectType: SmartIri): ClientObjectType = {
         ontologyObjectType.toString match {
             case OntologyConstants.KnoraApiV2Complex.Value => AbstractKnoraVal
@@ -552,11 +552,11 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
     }
 
     /**
-     * Given an object type that is not a Knora value type, returns the corresponding [[ClientObjectType]].
-     *
-     * @param ontologyObjectType the RDF type.
-     * @return the corresponding [[ClientObjectType]].
-     */
+      * Given an object type that is not a Knora value type, returns the corresponding [[ClientObjectType]].
+      *
+      * @param ontologyObjectType the RDF type.
+      * @return the corresponding [[ClientObjectType]].
+      */
     private def nonResourcePropObjectTypeToClientObjectType(ontologyObjectType: SmartIri): ClientObjectType = {
         ontologyObjectType.toString match {
             case OntologyConstants.Xsd.String => StringDatatype

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/GeneratorFrontEnd.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/GeneratorFrontEnd.scala
@@ -245,7 +245,7 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
         // A class that has an ID property needs a Stored* subclass.
         val classIrisNeedingStoredClasses: Set[SmartIri] = clientDefs.collect {
             case (classIri, classDef) if classDef.properties.exists(propDef => clientApi.idProperties.contains(propDef.propertyIri)) => classIri
-        }.toSet -- clientApi.inherentlyReadOnlyClasses
+        }.toSet
 
         // A map of the IRIs of classes that need Stored* classes, to the IRIs of their Stored* classes.
         val storedClassIris: Map[SmartIri, SmartIri] = classIrisNeedingStoredClasses.map {
@@ -253,7 +253,7 @@ class GeneratorFrontEnd(routeData: KnoraRouteData, requestingUser: UserADM) {
         }.toMap
 
         // A class that has one or more read-only properties needs a Read* subclass.
-        val classIrisNeedingReadClasses: Set[SmartIri] = clientApi.classesWithReadOnlyProperties.keySet -- clientApi.inherentlyReadOnlyClasses
+        val classIrisNeedingReadClasses: Set[SmartIri] = clientApi.classesWithReadOnlyProperties.keySet
 
         // A map of the IRIs of classes that need Read* classes, to the IRIs of their Read* classes.
         val readClassIris: Map[SmartIri, SmartIri] = classIrisNeedingReadClasses.map {

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/TypeScriptBackEnd.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/TypeScriptBackEnd.scala
@@ -23,12 +23,14 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 
 import org.knora.webapi.ClientApiGenerationException
+import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.Cardinality
+import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality._
 import org.knora.webapi.util.clientapi.TypeScriptBackEnd.ImportInfo
 import org.knora.webapi.util.{FileUtil, SmartIri, StringFormatter}
 
 /**
- * Generates client API source code in TypeScript.
- */
+  * Generates client API source code in TypeScript.
+  */
 class TypeScriptBackEnd extends GeneratorBackEnd {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -36,26 +38,26 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     private val mockCodeDir: Path = Paths.get("_test_data/typescript-client-mock-src").toAbsolutePath
 
     /**
-     * Represents information about an endpoint and its source code.
-     *
-     * @param className    the name of the endpoint class.
-     * @param description  a description of the endpoint.
-     * @param variableName a variable name that can be used for an instance of the endpoint class.
-     * @param urlPath      the URL path of the endpoint, relative to the API path.
-     * @param fileContent  the endpoint's source code.
-     */
+      * Represents information about an endpoint and its source code.
+      *
+      * @param className    the name of the endpoint class.
+      * @param description  a description of the endpoint.
+      * @param variableName a variable name that can be used for an instance of the endpoint class.
+      * @param urlPath      the URL path of the endpoint, relative to the API path.
+      * @param fileContent  the endpoint's source code.
+      */
     private case class EndpointInfo(className: String,
                                     description: String,
                                     variableName: String,
                                     urlPath: String,
                                     fileContent: SourceCodeFileContent) {
         /**
-         * Converts this [[EndpointInfo]] to an [[ImportInfo]] so the endpoint can be imported in another class.
-         *
-         * @param importedIn           the path of the class in which the endpoint is to be imported.
-         * @param includeFileExtension if `true`, include the file extension in the import.
-         * @return an [[ImportInfo]] referring to this endpoint.
-         */
+          * Converts this [[EndpointInfo]] to an [[ImportInfo]] so the endpoint can be imported in another class.
+          *
+          * @param importedIn           the path of the class in which the endpoint is to be imported.
+          * @param includeFileExtension if `true`, include the file extension in the import.
+          * @return an [[ImportInfo]] referring to this endpoint.
+          */
         def toImportInfo(importedIn: SourceCodeFilePath, includeFileExtension: Boolean = true): ImportInfo = {
             val importPath: String = importedIn.makeImportPath(thatSourceCodeFilePath = fileContent.filePath, includeFileExtension = includeFileExtension)
 
@@ -70,16 +72,16 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates client API source code.
-     *
-     * @param apis the APIs from which source code is to be generated.
-     * @return the generated source code.
-     */
+      * Generates client API source code.
+      *
+      * @param apis the APIs from which source code is to be generated.
+      * @return the generated source code.
+      */
     override def generateClientSourceCode(apis: Set[ClientApiBackendInput], params: Map[String, String]): Set[SourceCodeFileContent] = {
         /**
           * Returns the files containing mock knora-api-js-lib code, used for testing the generated code.
           *
-          * @param startDir the directory to look for mock code in.
+          * @param startDir       the directory to look for mock code in.
           * @param fileContentAcc the mock code collected so far.
           * @return the collected mock code.
           */
@@ -142,11 +144,11 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates TypeScript source code for an API.
-     *
-     * @param api the API for which source code is to be generated.
-     * @return a set of [[SourceCodeFileContent]] objects containing the generated source code.
-     */
+      * Generates TypeScript source code for an API.
+      *
+      * @param api the API for which source code is to be generated.
+      * @return a set of [[SourceCodeFileContent]] objects containing the generated source code.
+      */
     private def generateApiSourceCode(api: ClientApiBackendInput): Set[SourceCodeFileContent] = {
         // Generate file paths for class definitions.
         val clientClassCodePaths: Map[String, SourceCodeFilePath] = api.clientClassDefs.map {
@@ -182,11 +184,11 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates knora-api-connection.ts.
-     *
-     * @param apiDefs the API definitions to be used.
-     * @return the source code of knora-api-connection.ts.
-     */
+      * Generates knora-api-connection.ts.
+      *
+      * @param apiDefs the API definitions to be used.
+      * @return the source code of knora-api-connection.ts.
+      */
     private def generateKnoraApiConnectionSourceCode(apiDefs: Set[ClientApi]): SourceCodeFileContent = {
         val knoraApiConnectionFilePath = SourceCodeFilePath(
             directoryPath = Seq.empty,
@@ -223,12 +225,12 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates source code for the main endpoint of an API.
-     *
-     * @param apiDef        the API definition.
-     * @param endpointInfos information about the endpoints that belong to the API.
-     * @return the source code for the main endpoint.
-     */
+      * Generates source code for the main endpoint of an API.
+      *
+      * @param apiDef        the API definition.
+      * @param endpointInfos information about the endpoints that belong to the API.
+      * @return the source code for the main endpoint.
+      */
     private def generateMainEndpointSourceCode(apiDef: ClientApi,
                                                endpointInfos: Seq[EndpointInfo]): SourceCodeFileContent = {
         // Generate the main endpoint's file path.
@@ -245,14 +247,14 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates source code for an API endpoint.
-     *
-     * @param apiDef               the API definition.
-     * @param endpoint             the endpoint definition.
-     * @param clientClassDefs      the definitions of the classes used in the API.
-     * @param clientClassCodePaths the file paths of generated class definitions.
-     * @return the source code of the endpoint.
-     */
+      * Generates source code for an API endpoint.
+      *
+      * @param apiDef               the API definition.
+      * @param endpoint             the endpoint definition.
+      * @param clientClassDefs      the definitions of the classes used in the API.
+      * @param clientClassCodePaths the file paths of generated class definitions.
+      * @return the source code of the endpoint.
+      */
     private def generateEndpointInfo(apiDef: ClientApi,
                                      endpoint: ClientEndpoint,
                                      clientClassDefs: Set[ClientClassDefinition],
@@ -295,12 +297,12 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates source code for classes.
-     *
-     * @param clientClassDefs          the definitions of the classes for which source code is to be generated.
-     * @param clientClassCodePaths     the file paths to be used for the generated classes.
-     * @return the generated source code.
-     */
+      * Generates source code for classes.
+      *
+      * @param clientClassDefs      the definitions of the classes for which source code is to be generated.
+      * @param clientClassCodePaths the file paths to be used for the generated classes.
+      * @return the generated source code.
+      */
     private def generateClassSourceCode(clientClassDefs: Set[ClientClassDefinition],
                                         clientClassCodePaths: Map[String, SourceCodeFilePath]): Set[SourceCodeFileContent] = {
         clientClassDefs.map {
@@ -334,11 +336,11 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates the file path of an API's main endpoint.
-     *
-     * @param apiDef the API definition.
-     * @return the file path of the API's main endpoint.
-     */
+      * Generates the file path of an API's main endpoint.
+      *
+      * @param apiDef the API definition.
+      * @return the file path of the API's main endpoint.
+      */
     private def makeMainEndpointFilePath(apiDef: ClientApi): SourceCodeFilePath = {
         val apiLocalName: String = stringFormatter.camelCaseToSeparatedLowerCase(apiDef.name)
 
@@ -350,12 +352,12 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates the file path of an endpoint.
-     *
-     * @param apiDef   the API definition.
-     * @param endpoint the definition of the endpoint.
-     * @return the file path of the endpoint.
-     */
+      * Generates the file path of an endpoint.
+      *
+      * @param apiDef   the API definition.
+      * @param endpoint the definition of the endpoint.
+      * @return the file path of the endpoint.
+      */
     private def makeEndpointFilePath(apiDef: ClientApi, endpoint: ClientEndpoint): SourceCodeFilePath = {
         val endpointLocalName: String = stringFormatter.camelCaseToSeparatedLowerCase(endpoint.name)
 
@@ -367,12 +369,12 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates the file path of a class.
-     *
-     * @param apiDef    the API definition.
-     * @param className the name of the class.
-     * @return the file path of the generated class.
-     */
+      * Generates the file path of a class.
+      *
+      * @param apiDef    the API definition.
+      * @param className the name of the class.
+      * @return the file path of the generated class.
+      */
     private def makeClassFilePath(apiDef: ClientApi, className: String): SourceCodeFilePath = {
         val classLocalName: String = stringFormatter.camelCaseToSeparatedLowerCase(className)
 
@@ -384,34 +386,128 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
     }
 
     /**
-     * Generates a variable name that can be used for an instance of a class.
-     *
-     * @param className the name of the class.
-     * @return a variable name that can be used for an instance of the class.
-     */
+      * Generates a variable name that can be used for an instance of a class.
+      *
+      * @param className the name of the class.
+      * @return a variable name that can be used for an instance of the class.
+      */
     private def makeVariableName(className: String): String = {
         className.substring(0, 1).toLowerCase + className.substring(1)
     }
 }
 
 /**
- * Classes used by Twirl templates.
- */
+  * Classes and functions used by Twirl templates.
+  */
 object TypeScriptBackEnd {
 
     /**
-     * Represents information about an imported class or interface.
-     *
-     * @param className    the name of the class.
-     * @param importPath   the file path to be used for importing the class.
-     * @param description  a description of the class.
-     * @param variableName a variable name that can be used for an instance of the class.
-     * @param urlPath      if this class represents an endpoint, the URL path of the endpoint.
-     */
+      * Represents information about an imported class or interface.
+      *
+      * @param className    the name of the class.
+      * @param importPath   the file path to be used for importing the class.
+      * @param description  a description of the class.
+      * @param variableName a variable name that can be used for an instance of the class.
+      * @param urlPath      if this class represents an endpoint, the URL path of the endpoint.
+      */
     case class ImportInfo(className: String,
                           importPath: String,
                           description: Option[String] = None,
                           variableName: Option[String] = None,
                           urlPath: Option[String] = None)
 
+
+    /**
+      * Generates a type annotation for an object type.
+      *
+      * @param objectType the object type.
+      * @return the corresponding type annotation.
+      */
+    def makeTypeScriptType(objectType: ClientObjectType): String = {
+        objectType match {
+            case StringDatatype => "string"
+            case BooleanDatatype => "boolean"
+            case IntegerDatatype => "number"
+            case DecimalDatatype => "number"
+            case UriDatatype => "string"
+            case DateTimeStampDatatype => "string"
+            case classRef: ClassRef => classRef.className
+            case arrayType: ArrayType => s"[${makeTypeScriptType(arrayType.elementType)}]"
+            case mapType: MapType => s"{ [key: ${makeTypeScriptType(mapType.keyType)}]: ${makeTypeScriptType(mapType.valueType)} }"
+            case _ => throw ClientApiGenerationException(s"Type $objectType not yet supported")
+        }
+    }
+
+    /**
+      * Generates the default value for an object type.
+      *
+      * @param objectType  the object type.
+      * @param cardinality the property's cardinality.
+      * @return the default value.
+      */
+    def makeDefaultValue(objectType: ClientObjectType, cardinality: Cardinality): String = {
+        cardinality match {
+            case MayHaveMany | MustHaveSome => "[]"
+
+            case MayHaveOne => "undefined"
+
+            case MustHaveOne =>
+                objectType match {
+                    case StringDatatype => "\"\""
+                    case BooleanDatatype => "false"
+                    case IntegerDatatype => "0"
+                    case DecimalDatatype => "0"
+                    case UriDatatype => "\"\""
+                    case DateTimeStampDatatype => "\"\""
+                    case classRef: ClassRef => s"new ${classRef.className}()"
+                    case _: ArrayType => "[]"
+                    case _: MapType => "{}"
+                    case _ => throw ClientApiGenerationException(s"Type $objectType not supported in this template")
+                }
+        }
+    }
+
+    /**
+      * Wraps an type in brackets if the cardinality allows it to be an array.
+      *
+      * @param typeScriptType a TypeScript type.
+      * @param cardinality    the property's cardinality.
+      * @return the type, wrapped in brackets if necessary.
+      */
+    def wrapInBracketsForCardinality(typeScriptType: String, cardinality: Cardinality): String = {
+        if (cardinality == MayHaveMany || cardinality == MustHaveSome) {
+            s"[$typeScriptType]"
+        } else {
+            typeScriptType
+        }
+    }
+
+    /**
+      * Adds `[]` to the end of a type if the cardinality allows it to be an array.
+      *
+      * @param typeScriptType a TypeScript type.
+      * @param cardinality    the property's cardinality.
+      * @return the type, followed by `[]` if necessary.
+      */
+    def addBracketsForCardinality(typeScriptType: String, cardinality: Cardinality): String = {
+        if (cardinality == MayHaveMany || cardinality == MustHaveSome) {
+            s"$typeScriptType[]"
+        } else {
+            typeScriptType
+        }
+    }
+
+    /**
+      * Returns `?` if a cardinality represents an optional value.
+      *
+      * @param cardinality the cardinality on the property.
+      * @return `?` if the cardinality represents an optional value, otherwise the empty string.
+      */
+    def handleOption(cardinality: Cardinality): String = {
+        if (cardinality == MayHaveOne) {
+            "?"
+        } else {
+            ""
+        }
+    }
 }

--- a/webapi/src/main/scala/org/knora/webapi/util/clientapi/TypeScriptBackEnd.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/clientapi/TypeScriptBackEnd.scala
@@ -23,7 +23,6 @@ import java.io.File
 import java.nio.file.{Path, Paths}
 
 import org.knora.webapi.ClientApiGenerationException
-import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality.Cardinality
 import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality._
 import org.knora.webapi.util.clientapi.TypeScriptBackEnd.ImportInfo
 import org.knora.webapi.util.{FileUtil, SmartIri, StringFormatter}
@@ -318,7 +317,7 @@ class TypeScriptBackEnd extends GeneratorBackEnd {
 
                 val propertiesNeedingCustomConverters: Vector[ClientPropertyDefinition] = clientClassDef.properties.filter {
                     propertyDef => propertyDef.objectType match {
-                        case collectionType: CollectionType => true
+                        case _: CollectionType => true
                         case _ => false
                     }
                 }

--- a/webapi/src/main/twirl/clientapi/typescript/generateTypeScriptClass.scala.txt
+++ b/webapi/src/main/twirl/clientapi/typescript/generateTypeScriptClass.scala.txt
@@ -20,12 +20,12 @@
 @import org.knora.webapi._
 @import org.knora.webapi.util._
 @import org.knora.webapi.util.clientapi._
-@import org.knora.webapi.util.clientapi.TypeScriptBackEnd.ImportInfo
+@import org.knora.webapi.util.clientapi.TypeScriptBackEnd
 @import org.knora.webapi.messages.v2.responder.ontologymessages.Cardinality._
 
 @(classDef: ClientClassDefinition,
   subClassOf: Option[ClassRef],
-  importedClasses: Seq[ImportInfo])import { JsonObject, JsonProperty } from "json2typescript";
+  importedClasses: Seq[TypeScriptBackEnd.ImportInfo])import { JsonObject, JsonProperty } from "json2typescript";
 
 @for(classInfo <- importedClasses) {import { @classInfo.className } from "@classInfo.importPath";
 }@classDef.classDescription match {
@@ -44,61 +44,14 @@ export class @{classDef.className}@{
     }
 } {
 @for(property <- classDef.properties) {
-@defining(makeTypeScriptType(property.objectType)) { typeScriptType => @property.propertyDescription match {
+@defining(TypeScriptBackEnd.makeTypeScriptType(property.objectType)) { typeScriptType => @property.propertyDescription match {
     case Some(propDescStr) => {   /**
      * @propDescStr
      */}
 
     case None => {}
     }
-    @@JsonProperty("@{property.propertyName}", @wrapInArrayForCardinality(typeScriptType.capitalize, property.cardinality)@if(property.cardinality == MayHaveOne) {, true})
-    @{property.propertyName}@handleOption(property.cardinality): @addForCardinality(property.objectType, typeScriptType, property.cardinality) = @makeDefaultValue(property.objectType, property.cardinality);
+    @@JsonProperty("@{property.propertyName}", @TypeScriptBackEnd.wrapInBracketsForCardinality(typeScriptType.capitalize, property.cardinality)@if(property.cardinality == MayHaveOne) {, true})
+    @{property.propertyName}@TypeScriptBackEnd.handleOption(property.cardinality): @TypeScriptBackEnd.addBracketsForCardinality(typeScriptType, property.cardinality) = @TypeScriptBackEnd.makeDefaultValue(property.objectType, property.cardinality);
 }}
-}@makeTypeScriptType(objectType: ClientObjectType) = @{
-    objectType match {
-        case StringDatatype => "string"
-        case BooleanDatatype => "boolean"
-        case IntegerDatatype => "number"
-        case DecimalDatatype => "number"
-        case UriDatatype => "string"
-        case DateTimeStampDatatype => "string"
-        case classRef: ClassRef => classRef.className
-        case other => throw ClientApiGenerationException(s"Type $other not yet supported")
-    }
-}@makeDefaultValue(objectType: ClientObjectType, cardinality: Cardinality) = @{
-    cardinality match {
-        case MayHaveMany | MustHaveSome => "[]"
-
-        case MayHaveOne => "undefined"
-
-        case MustHaveOne =>
-            objectType match {
-                case StringDatatype => "\"\""
-                case BooleanDatatype => "false"
-                case IntegerDatatype => "0"
-                case DecimalDatatype => "0"
-                case UriDatatype => "\"\""
-                case DateTimeStampDatatype => "\"\""
-                case classRef: ClassRef => s"new ${classRef.className}()"
-                case other => throw ClientApiGenerationException(s"Type $other not supported in this template")
-            }
-    }
-}@wrapInArrayForCardinality(typeScriptType: String, cardinality: Cardinality) = @{
-    if (cardinality == MayHaveMany || cardinality == MustHaveSome) {
-        s"[$typeScriptType]"
-    } else {
-        typeScriptType
-    }
-}@handleOption(cardinality: Cardinality) = @{
-    if (cardinality == MayHaveOne) {
-        "?"
-    } else {
-        ""
-    }
-}@addForCardinality(objectType: ClientObjectType, typeScriptType: String, cardinality: Cardinality) = @{
-    if (cardinality == MayHaveMany || cardinality == MustHaveSome) {
-        s"$typeScriptType[]"
-    } else {
-        typeScriptType
-    }
 }

--- a/webapi/src/main/twirl/clientapi/typescript/generateTypeScriptClass.scala.txt
+++ b/webapi/src/main/twirl/clientapi/typescript/generateTypeScriptClass.scala.txt
@@ -44,14 +44,14 @@ export class @{classDef.className}@{
     }
 } {
 @for(property <- classDef.properties) {
-@defining(TypeScriptBackEnd.makeTypeScriptType(property.objectType)) { typeScriptType => @property.propertyDescription match {
+@defining(TypeScriptBackEnd.makePropertyObjectType(property.objectType)) { propertyObjectType => @property.propertyDescription match {
     case Some(propDescStr) => {   /**
      * @propDescStr
      */}
 
     case None => {}
     }
-    @@JsonProperty("@{property.propertyName}", @TypeScriptBackEnd.wrapInBracketsForCardinality(typeScriptType.capitalize, property.cardinality)@if(property.cardinality == MayHaveOne) {, true})
-    @{property.propertyName}@TypeScriptBackEnd.handleOption(property.cardinality): @TypeScriptBackEnd.addBracketsForCardinality(typeScriptType, property.cardinality) = @TypeScriptBackEnd.makeDefaultValue(property.objectType, property.cardinality);
+    @@JsonProperty("@{property.propertyName}", @TypeScriptBackEnd.makeJson2TypeScriptType(property)@if(property.cardinality == MayHaveOne) {, true})
+    @{property.propertyName}@TypeScriptBackEnd.handleOption(property.cardinality): @TypeScriptBackEnd.addBracketsForCardinality(propertyObjectType, property.cardinality) = @TypeScriptBackEnd.makeDefaultValue(property.objectType, property.cardinality);
 }}
 }

--- a/webapi/src/main/twirl/clientapi/typescript/generateTypeScriptEndpoint.scala.txt
+++ b/webapi/src/main/twirl/clientapi/typescript/generateTypeScriptEndpoint.scala.txt
@@ -108,7 +108,7 @@ export class @name extends Endpoint {
                     }.mkString(", ") +
                     " }"
 
-                case arg: ArgValue => makeValue(arg)
+                case arg: ArgValue => s"this.jsonConvert.serializeObject(${makeValue(arg)})"
             }
 
             ", " + requestBodyContent

--- a/webapi/src/test/scala/org/knora/webapi/util/clientapi/ClientCollectionTypeParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/util/clientapi/ClientCollectionTypeParserSpec.scala
@@ -1,0 +1,175 @@
+/*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.knora.webapi.util.clientapi
+
+import org.knora.webapi.util.IriConversions._
+import org.knora.webapi.util.{SmartIri, StringFormatter}
+import org.knora.webapi.{ClientApiGenerationException, CoreSpec, OntologyConstants}
+
+/**
+  * Tests [[ClientCollectionTypeParser]].
+  */
+class ClientCollectionTypeParserSpec extends CoreSpec() {
+    private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
+    private val ontologyIri: SmartIri = OntologyConstants.KnoraAdminV2.KnoraAdminOntologyIri.toSmartIri
+    private val permissionClassIri: SmartIri = ontologyIri.makeEntityIri("Permission")
+    private val permissionClassRef = ClassRef(className = "Permission", classIri = permissionClassIri)
+
+    "The ClientCollectionTypeParser class" should {
+        "parse Array[String]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Array[String]", ontologyIri = ontologyIri)
+            assert(collectionType == ArrayType(elementType = StringDatatype))
+            assert(collectionType.getClassIri.isEmpty)
+        }
+
+        "parse Array[URI]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Array[URI]", ontologyIri = ontologyIri)
+            assert(collectionType == ArrayType(elementType = UriDatatype))
+            assert(collectionType.getClassIri.isEmpty)
+        }
+
+        "parse Array[Permission]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Array[Permission]", ontologyIri = ontologyIri)
+            assert(collectionType == ArrayType(elementType = permissionClassRef))
+            assert(collectionType.getClassIri.contains(permissionClassIri))
+        }
+
+        "parse Map[String, String]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Map[String, String]", ontologyIri = ontologyIri)
+            assert(collectionType == MapType(keyType = StringDatatype, valueType = StringDatatype))
+            assert(collectionType.getClassIri.isEmpty)
+        }
+
+        "parse Map[URI, String]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Map[URI, String]", ontologyIri = ontologyIri)
+            assert(collectionType == MapType(keyType = UriDatatype, valueType = StringDatatype))
+            assert(collectionType.getClassIri.isEmpty)
+        }
+
+        "parse Map[URI, Permission]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Map[URI, Permission]", ontologyIri = ontologyIri)
+
+            assert(collectionType == MapType(
+                keyType = UriDatatype,
+                valueType = permissionClassRef
+            ))
+
+            assert(collectionType.getClassIri.contains(permissionClassIri))
+        }
+
+        "parse Map[URI, Array[String]]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Map[URI, Array[String]]", ontologyIri = ontologyIri)
+
+            assert(collectionType == MapType(
+                keyType = UriDatatype,
+                valueType = ArrayType(elementType = StringDatatype)
+            ))
+
+            assert(collectionType.getClassIri.isEmpty)
+        }
+
+        "parse Map[URI, Array[Permission]]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Map[URI, Array[Permission]]", ontologyIri = ontologyIri)
+
+            assert(collectionType == MapType(
+                keyType = UriDatatype,
+                valueType = ArrayType(elementType = permissionClassRef)
+            ))
+
+            assert(collectionType.getClassIri.contains(permissionClassIri))
+        }
+
+        "parse Map[URI, Array[Map[URI, Permission]]]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Map[URI, Array[Map[URI, Permission]]]", ontologyIri = ontologyIri)
+
+            assert(collectionType == MapType(
+                keyType = UriDatatype,
+                valueType = ArrayType(
+                    elementType = MapType(
+                        keyType = UriDatatype,
+                        valueType = permissionClassRef
+                    )
+                )
+            ))
+
+            assert(collectionType.getClassIri.contains(permissionClassIri))
+        }
+
+        "parse Array[Map[URI, Array[Map[URI, Permission]]]]" in {
+            val collectionType = ClientCollectionTypeParser.parse(typeStr = "Array[Map[URI, Array[Map[URI, Permission]]]]", ontologyIri = ontologyIri)
+
+            assert(collectionType == ArrayType(
+                elementType = MapType(
+                    keyType = UriDatatype,
+                    valueType = ArrayType(
+                        elementType = MapType(
+                            keyType = UriDatatype,
+                            valueType = permissionClassRef
+                        )
+                    )
+                )
+            ))
+
+            assert(collectionType.getClassIri.contains(permissionClassIri))
+        }
+
+        "reject String" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = "String", ontologyIri = ontologyIri)
+            }
+        }
+
+        "reject Array[]" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = "Array[]", ontologyIri = ontologyIri)
+            }
+        }
+
+        "reject Array[Map[URI, Array[Map[URI, Permission]]]" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = "Array[Map[URI, Array[Map[URI, Permission]]]", ontologyIri = ontologyIri)
+            }
+        }
+
+        "reject Map[String, ]" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = "Map[String, ]", ontologyIri = ontologyIri)
+            }
+        }
+
+        "reject []" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = "[]", ontologyIri = ontologyIri)
+            }
+        }
+
+        "reject Array[String],Array[String]" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = "Array[String],Array[String]", ontologyIri = ontologyIri)
+            }
+        }
+
+        "reject ,Array[String]" in {
+            assertThrows[ClientApiGenerationException] {
+                ClientCollectionTypeParser.parse(typeStr = ",Array[String]", ontologyIri = ontologyIri)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for the collection types `Map` and `Array`, by allowing a collection type signature to be defined in an IRI. Collection types defined in this way can then be represented as collection types in the target language.

Resolves #1504.
Needs https://github.com/dasch-swiss/knora-api-js-lib/pull/99.
