### PR TITLE
feature(api-v2): Generate client test data for ontologies, resources, search, and lists

### DIFF
--- a/webapi/scripts/graphdb-knora-test-data.expect
+++ b/webapi/scripts/graphdb-knora-test-data.expect
@@ -36,6 +36,8 @@ send "load ../_test_data/ontologies/anything-onto.ttl into http://www.knora.org/
 expect $prompt
 send "load ../_test_data/all_data/anything-data.ttl into http://www.knora.org/data/0001/anything .\r"
 expect $prompt
+send "load ../_test_data/ontologies/minimal-onto.ttl into http://www.knora.org/ontology/0001/minimal .\r"
+expect $prompt
 send "load ../_test_data/ontologies/something-onto.ttl into http://www.knora.org/ontology/0001/something .\r"
 expect $prompt
 send "load ../_test_data/ontologies/beol-onto.ttl into http://www.knora.org/ontology/0801/beol .\r"

--- a/webapi/src/main/resources/application.conf
+++ b/webapi/src/main/resources/application.conf
@@ -113,7 +113,7 @@ akka {
             # Note that with N concurrent materializations the max number of open request in the pool
             # will never exceed N * max-connections * pipelining-limit.
             # Must be a power of 2 and > 0!
-            max-open-requests = 32
+            max-open-requests = 64
 
             # The maximum number of requests that are dispatched to the target host in
             # batch-mode across a single connection (HTTP pipelining).

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -1447,6 +1447,39 @@ object SharedTestDataADM {
            |}""".stripMargin
     }
 
+    val gravsearchComplexThingSmallerThanDecimal: String =
+        """PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+          |
+          |CONSTRUCT {
+          |     ?thing knora-api:isMainResource true .
+          |     ?thing anything:hasDecimal ?decimal .
+          |} WHERE {
+          |     ?thing a anything:Thing .
+          |     ?thing anything:hasDecimal ?decimal .
+          |     ?decimal knora-api:decimalValueAsDecimal ?decimalDec .
+          |     FILTER(?decimalDec < "3"^^xsd:decimal)
+          |}""".stripMargin
+
+
+    val gravsearchComplexRegionsForPage: String =
+        """PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+          |
+          |CONSTRUCT {
+          |    ?region knora-api:isMainResource true .
+          |    ?region knora-api:isRegionOf <http://rdfh.ch/0803/9d626dc76c03> .
+          |    ?region knora-api:hasGeometry ?geom .
+          |    ?region knora-api:hasComment ?comment .
+          |    ?region knora-api:hasColor ?color .
+          |} WHERE {
+          |    ?region a knora-api:Region .
+          |    ?region knora-api:isRegionOf <http://rdfh.ch/0803/9d626dc76c03> .
+          |    ?region knora-api:hasGeometry ?geom .
+          |    ?region knora-api:hasComment ?comment .
+          |    ?region knora-api:hasColor ?color .
+          |}""".stripMargin
+
     object AThing {
         val iri: IRI = "http://rdfh.ch/0001/a-thing"
         val iriEncoded: String = URLEncoder.encode(iri, "UTF-8")

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -1524,4 +1524,9 @@ object SharedTestDataADM {
         val linkValueUuid = "uvRVxzL1RD-t9VIQ1TpfUw"
     }
 
+    val treeList: IRI = "http://rdfh.ch/lists/0001/treeList"
+
+    val treeListNode: IRI = "http://rdfh.ch/lists/0001/treeList01"
+
+    val otherTreeList: IRI = "http://rdfh.ch/lists/0001/otherTreeList"
 }

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -1628,27 +1628,63 @@ object SharedTestDataADM {
     }
 
     def updateResourceMetadata(resourceIri: IRI,
+                               lastModificationDate: Option[Instant],
                                newLabel: String,
                                newPermissions: String,
                                newModificationDate: Instant): String = {
-        s"""|{
-            |  "@id" : "$resourceIri",
-            |  "@type" : "anything:Thing",
-            |  "rdfs:label" : "$newLabel",
-            |  "knora-api:hasPermissions" : "$newPermissions",
-            |  "knora-api:newModificationDate" : {
-            |    "@type" : "xsd:dateTimeStamp",
-            |    "@value" : "$newModificationDate"
-            |  },
-            |  "@context" : {
-            |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-            |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-            |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-            |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-            |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-            |  }
-            |}""".stripMargin
+        lastModificationDate match {
+            case Some(definedLastModificationDate) =>
+                s"""|{
+                    |  "@id" : "$resourceIri",
+                    |  "@type" : "anything:Thing",
+                    |  "rdfs:label" : "$newLabel",
+                    |  "knora-api:hasPermissions" : "$newPermissions",
+                    |  "knora-api:lastModificationDate" : {
+                    |    "@type" : "xsd:dateTimeStamp",
+                    |    "@value" : "$definedLastModificationDate"
+                    |  },
+                    |  "knora-api:newModificationDate" : {
+                    |    "@type" : "xsd:dateTimeStamp",
+                    |    "@value" : "$newModificationDate"
+                    |  },
+                    |  "@context" : {
+                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                    |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                    |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                    |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                    |  }
+                    |}""".stripMargin
+
+            case None =>
+                s"""|{
+                    |  "@id" : "$resourceIri",
+                    |  "@type" : "anything:Thing",
+                    |  "rdfs:label" : "$newLabel",
+                    |  "knora-api:hasPermissions" : "$newPermissions",
+                    |  "knora-api:newModificationDate" : {
+                    |    "@type" : "xsd:dateTimeStamp",
+                    |    "@value" : "$newModificationDate"
+                    |  },
+                    |  "@context" : {
+                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+                    |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+                    |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+                    |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+                    |  }
+                    |}""".stripMargin
+
+        }
     }
+
+    def successResponse(message: String): String =
+        s"""{
+          |  "knora-api:result" : "$message",
+          |  "@context" : {
+          |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#"
+          |  }
+          |}""".stripMargin
 
     def deleteResource(resourceIri: IRI,
                        lastModificationDate: Instant): String = {

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi
 
 import java.net.URLEncoder
+import java.time.Instant
 
 import org.knora.webapi.SharedOntologyTestDataADM._
 import org.knora.webapi.messages.admin.responder.groupsmessages.GroupADM
@@ -30,9 +31,9 @@ import org.knora.webapi.messages.store.triplestoremessages.StringLiteralV2
 import org.knora.webapi.util.StringFormatter
 
 /**
-  * This object holds the same user which are loaded with '_test_data/all_data/admin-data.ttl'. Using this object
-  * in tests, allows easier updating of details as they change over time.
-  */
+ * This object holds the same user which are loaded with '_test_data/all_data/admin-data.ttl'. Using this object
+ * in tests, allows easier updating of details as they change over time.
+ */
 object SharedTestDataADM {
 
     /** ***********************************/
@@ -1479,6 +1480,214 @@ object SharedTestDataADM {
           |    ?region knora-api:hasComment ?comment .
           |    ?region knora-api:hasColor ?color .
           |}""".stripMargin
+
+    val createResourceWithValues: String =
+        """{
+          |  "@type" : "anything:Thing",
+          |  "anything:hasBoolean" : {
+          |    "@type" : "knora-api:BooleanValue",
+          |    "knora-api:booleanValueAsBoolean" : true
+          |  },
+          |  "anything:hasColor" : {
+          |    "@type" : "knora-api:ColorValue",
+          |    "knora-api:colorValueAsColor" : "#ff3333"
+          |  },
+          |  "anything:hasDate" : {
+          |    "@type" : "knora-api:DateValue",
+          |    "knora-api:dateValueHasCalendar" : "GREGORIAN",
+          |    "knora-api:dateValueHasEndEra" : "CE",
+          |    "knora-api:dateValueHasEndYear" : 1489,
+          |    "knora-api:dateValueHasStartEra" : "CE",
+          |    "knora-api:dateValueHasStartYear" : 1489
+          |  },
+          |  "anything:hasDecimal" : {
+          |    "@type" : "knora-api:DecimalValue",
+          |    "knora-api:decimalValueAsDecimal" : {
+          |      "@type" : "xsd:decimal",
+          |      "@value" : "100000000000000.000000000000001"
+          |    }
+          |  },
+          |  "anything:hasGeometry" : {
+          |    "@type" : "knora-api:GeomValue",
+          |    "knora-api:geometryValueAsGeometry" : "{\"status\":\"active\",\"lineColor\":\"#ff3333\",\"lineWidth\":2,\"points\":[{\"x\":0.08098591549295775,\"y\":0.16741071428571427},{\"x\":0.7394366197183099,\"y\":0.7299107142857143}],\"type\":\"rectangle\",\"original_index\":0}"
+          |  },
+          |  "anything:hasGeoname" : {
+          |    "@type" : "knora-api:GeonameValue",
+          |    "knora-api:geonameValueAsGeonameCode" : "2661604"
+          |  },
+          |  "anything:hasInteger" : [ {
+          |    "@type" : "knora-api:IntValue",
+          |    "knora-api:hasPermissions" : "CR knora-admin:Creator|V http://rdfh.ch/groups/0001/thing-searcher",
+          |    "knora-api:intValueAsInt" : 5,
+          |    "knora-api:valueHasComment" : "this is the number five"
+          |  }, {
+          |    "@type" : "knora-api:IntValue",
+          |    "knora-api:intValueAsInt" : 6
+          |  } ],
+          |  "anything:hasInterval" : {
+          |    "@type" : "knora-api:IntervalValue",
+          |    "knora-api:intervalValueHasEnd" : {
+          |      "@type" : "xsd:decimal",
+          |      "@value" : "3.4"
+          |    },
+          |    "knora-api:intervalValueHasStart" : {
+          |      "@type" : "xsd:decimal",
+          |      "@value" : "1.2"
+          |    }
+          |  },
+          |  "anything:hasListItem" : {
+          |    "@type" : "knora-api:ListValue",
+          |    "knora-api:listValueAsListNode" : {
+          |      "@id" : "http://rdfh.ch/lists/0001/treeList03"
+          |    }
+          |  },
+          |  "anything:hasOtherThingValue" : {
+          |    "@type" : "knora-api:LinkValue",
+          |    "knora-api:linkValueHasTargetIri" : {
+          |      "@id" : "http://rdfh.ch/0001/a-thing"
+          |    }
+          |  },
+          |  "anything:hasRichtext" : {
+          |    "@type" : "knora-api:TextValue",
+          |    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<text><p><strong>this is</strong> text</p> with standoff</text>",
+          |    "knora-api:textValueHasMapping" : {
+          |      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
+          |    }
+          |  },
+          |  "anything:hasText" : {
+          |    "@type" : "knora-api:TextValue",
+          |    "knora-api:valueAsString" : "this is text without standoff"
+          |  },
+          |  "anything:hasUri" : {
+          |    "@type" : "knora-api:UriValue",
+          |    "knora-api:uriValueAsUri" : {
+          |      "@type" : "xsd:anyURI",
+          |      "@value" : "https://www.knora.org"
+          |    }
+          |  },
+          |  "knora-api:attachedToProject" : {
+          |    "@id" : "http://rdfh.ch/projects/0001"
+          |  },
+          |  "rdfs:label" : "test thing",
+          |  "@context" : {
+          |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+          |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+          |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+          |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+          |  }
+          |}""".stripMargin
+
+    def createResourceWithCustomCreationDate(creationDate: Instant): String = {
+        s"""{
+           |  "@type" : "anything:Thing",
+           |  "knora-api:attachedToProject" : {
+           |    "@id" : "http://rdfh.ch/projects/0001"
+           |  },
+           |  "anything:hasBoolean" : {
+           |    "@type" : "knora-api:BooleanValue",
+           |    "knora-api:booleanValueAsBoolean" : true
+           |  },
+           |  "rdfs:label" : "test thing",
+           |  "knora-api:creationDate" : {
+           |    "@type" : "xsd:dateTimeStamp",
+           |    "@value" : "$creationDate"
+           |  },
+           |  "@context" : {
+           |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+           |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+           |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+           |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+           |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+           |  }
+           |}""".stripMargin
+    }
+
+    def createResourceAsUser(userADM: UserADM): String = {
+        s"""{
+           |  "@type" : "anything:Thing",
+           |  "knora-api:attachedToProject" : {
+           |    "@id" : "http://rdfh.ch/projects/0001"
+           |  },
+           |  "anything:hasBoolean" : {
+           |    "@type" : "knora-api:BooleanValue",
+           |    "knora-api:booleanValueAsBoolean" : true
+           |  },
+           |  "rdfs:label" : "test thing",
+           |  "knora-api:attachedToUser" : {
+           |    "@id" : "${userADM.id}"
+           |  },
+           |  "@context" : {
+           |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+           |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+           |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+           |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+           |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+           |  }
+           |}""".stripMargin
+    }
+
+    def updateResourceMetadata(resourceIri: IRI,
+                               newLabel: String,
+                               newPermissions: String,
+                               newModificationDate: Instant): String = {
+        s"""|{
+            |  "@id" : "$resourceIri",
+            |  "@type" : "anything:Thing",
+            |  "rdfs:label" : "$newLabel",
+            |  "knora-api:hasPermissions" : "$newPermissions",
+            |  "knora-api:newModificationDate" : {
+            |    "@type" : "xsd:dateTimeStamp",
+            |    "@value" : "$newModificationDate"
+            |  },
+            |  "@context" : {
+            |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+            |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+            |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+            |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+            |  }
+            |}""".stripMargin
+    }
+
+    def deleteResource(resourceIri: IRI,
+                       lastModificationDate: Instant): String = {
+        s"""|{
+            |  "@id" : "$resourceIri",
+            |  "@type" : "anything:Thing",
+            |  "knora-api:lastModificationDate" : {
+            |    "@type" : "xsd:dateTimeStamp",
+            |    "@value" : "$lastModificationDate"
+            |  },
+            |  "knora-api:deleteComment" : "This resource is too boring.",
+            |  "@context" : {
+            |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+            |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+            |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+            |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+            |  }
+            |}""".stripMargin
+    }
+
+    def eraseResource(resourceIri: IRI,
+                      lastModificationDate: Instant): String = {
+        s"""|{
+            |  "@id" : "$resourceIri",
+            |  "@type" : "anything:Thing",
+            |  "knora-api:lastModificationDate" : {
+            |    "@type" : "xsd:dateTimeStamp",
+            |    "@value" : "$lastModificationDate"
+            |  },
+            |  "@context" : {
+            |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+            |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+            |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+            |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+            |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+            |  }
+            |}""".stripMargin
+    }
 
     object AThing {
         val iri: IRI = "http://rdfh.ch/0001/a-thing"

--- a/webapi/src/main/scala/org/knora/webapi/routing/AroundDirectives.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/AroundDirectives.scala
@@ -24,13 +24,13 @@ import akka.http.scaladsl.server.Directives._
 import org.knora.webapi.util.InstrumentationSupport
 
 /**
-  * Akka HTTP directives which can be wrapped around a [[akka.http.scaladsl.server.Route]]].
-  */
+ * Akka HTTP directives which can be wrapped around a [[akka.http.scaladsl.server.Route]]].
+ */
 trait AroundDirectives extends InstrumentationSupport {
 
     /**
-      * When wrapped around a [[akka.http.scaladsl.server.Route]], logs the time it took for the route to run.
-      */
+     * When wrapped around a [[akka.http.scaladsl.server.Route]], logs the time it took for the route to run.
+     */
     def logDuration: Directive0 = extractRequestContext.flatMap { ctx =>
         val start = System.currentTimeMillis()
         mapResponse { resp =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/Authenticator.scala
@@ -43,13 +43,14 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**
-  * This trait is used in routes that need authentication support. It provides methods that use the [[RequestContext]]
-  * to extract credentials, authenticate provided credentials, and look up cached credentials through the use of the
-  * session id. All private methods used in this trait can be found in the companion object.
-  */
+ * This trait is used in routes that need authentication support. It provides methods that use the [[RequestContext]]
+ * to extract credentials, authenticate provided credentials, and look up cached credentials through the use of the
+ * session id. All private methods used in this trait can be found in the companion object.
+ */
 trait Authenticator {
 
     // Import companion object
+
     import Authenticator._
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -57,14 +58,14 @@ trait Authenticator {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-      * Checks if the credentials provided in [[RequestContext]] are valid, and if so returns a message and cookie header
-      * with the generated session id for the client to save.
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @param system         the current [[ActorSystem]]
-      * @return a [[HttpResponse]] containing either a failure message or a message with a cookie header containing
-      *         the generated session id.
-      */
+     * Checks if the credentials provided in [[RequestContext]] are valid, and if so returns a message and cookie header
+     * with the generated session id for the client to save.
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @param system         the current [[ActorSystem]]
+     * @return a [[HttpResponse]] containing either a failure message or a message with a cookie header containing
+     *         the generated session id.
+     */
     def doLoginV1(requestContext: RequestContext)(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[HttpResponse] = {
 
         val settings = Settings(system)
@@ -95,13 +96,13 @@ trait Authenticator {
     }
 
     /**
-      * Checks if the provided credentials are valid, and if so returns a JWT token for the client to save.
-      *
-      * @param credentials the user supplied [[KnoraPasswordCredentialsV2]] containing the user's login information.
-      * @param system      the current [[ActorSystem]]
-      * @return a [[HttpResponse]] containing either a failure message or a message with a cookie header containing
-      *         the generated session id.
-      */
+     * Checks if the provided credentials are valid, and if so returns a JWT token for the client to save.
+     *
+     * @param credentials the user supplied [[KnoraPasswordCredentialsV2]] containing the user's login information.
+     * @param system      the current [[ActorSystem]]
+     * @return a [[HttpResponse]] containing either a failure message or a message with a cookie header containing
+     *         the generated session id.
+     */
     def doLoginV2(credentials: KnoraPasswordCredentialsV2)(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[HttpResponse] = {
 
         log.debug(s"doLoginV2 - credentials: $credentials")
@@ -156,9 +157,9 @@ trait Authenticator {
                |            </form>
                |        </div>
                |
-          |    </section>
+               |    </section>
                |
-          |    <section class="about">
+               |    <section class="about">
                |        <p class="about-author">
                |            &copy; 2015&ndash;2019 <a href="https://knora.org" target="_blank">Knora.org</a>
                |    </section>
@@ -181,13 +182,13 @@ trait Authenticator {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-      * Checks if the credentials provided in [[RequestContext]] are valid, and if so returns a message. No session is
-      * generated.
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @param system         the current [[ActorSystem]]
-      * @return a [[RequestContext]]
-      */
+     * Checks if the credentials provided in [[RequestContext]] are valid, and if so returns a message. No session is
+     * generated.
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @param system         the current [[ActorSystem]]
+     * @return a [[RequestContext]]
+     */
     def doAuthenticateV1(requestContext: RequestContext)(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[HttpResponse] = {
 
         val credentials: Option[KnoraCredentialsV2] = extractCredentialsV2(requestContext)
@@ -212,12 +213,12 @@ trait Authenticator {
     }
 
     /**
-      * Checks if the credentials provided in [[RequestContext]] are valid.
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @param system         the current [[ActorSystem]]
-      * @return a [[HttpResponse]]
-      */
+     * Checks if the credentials provided in [[RequestContext]] are valid.
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @param system         the current [[ActorSystem]]
+     * @return a [[HttpResponse]]
+     */
     def doAuthenticateV2(requestContext: RequestContext)(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[HttpResponse] = {
 
         val credentials: Option[KnoraCredentialsV2] = extractCredentialsV2(requestContext)
@@ -243,12 +244,12 @@ trait Authenticator {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-      * Used to logout the user, i.e. returns a header deleting the cookie and puts the token on the 'invalidated' list.
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @param system         the current [[ActorSystem]]
-      * @return a [[HttpResponse]]
-      */
+     * Used to logout the user, i.e. returns a header deleting the cookie and puts the token on the 'invalidated' list.
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @param system         the current [[ActorSystem]]
+     * @return a [[HttpResponse]]
+     */
     def doLogoutV2(requestContext: RequestContext)(implicit system: ActorSystem): HttpResponse = {
 
         val credentials = extractCredentialsV2(requestContext)
@@ -309,15 +310,15 @@ trait Authenticator {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-      * Returns a UserProfile of the supplied type that match the credentials found in the [[RequestContext]].
-      * The credentials can be email/password as parameters or auth headers, or session token in a cookie header. If no
-      * credentials are found, then a default UserProfile is returned. If the credentials are not correct, then the
-      * corresponding error is returned.
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @param system         the current [[ActorSystem]]
-      * @return a [[UserProfileV1]]
-      */
+     * Returns a UserProfile of the supplied type that match the credentials found in the [[RequestContext]].
+     * The credentials can be email/password as parameters or auth headers, or session token in a cookie header. If no
+     * credentials are found, then a default UserProfile is returned. If the credentials are not correct, then the
+     * corresponding error is returned.
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @param system         the current [[ActorSystem]]
+     * @return a [[UserProfileV1]]
+     */
     @deprecated("Please use: getUserADM()", "Knora v1.7.0")
     def getUserProfileV1(requestContext: RequestContext)(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[UserProfileV1] = {
 
@@ -344,15 +345,15 @@ trait Authenticator {
     }
 
     /**
-      * Returns a User that match the credentials found in the [[RequestContext]].
-      * The credentials can be email/password as parameters or auth headers, or session token in a cookie header. If no
-      * credentials are found, then a default UserProfile is returned. If the credentials are not correct, then the
-      * corresponding error is returned.
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @param system         the current [[ActorSystem]]
-      * @return a [[UserProfileV1]]
-      */
+     * Returns a User that match the credentials found in the [[RequestContext]].
+     * The credentials can be email/password as parameters or auth headers, or session token in a cookie header. If no
+     * credentials are found, then a default UserProfile is returned. If the credentials are not correct, then the
+     * corresponding error is returned.
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @param system         the current [[ActorSystem]]
+     * @return a [[UserProfileV1]]
+     */
     def getUserADM(requestContext: RequestContext)(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[UserADM] = {
 
         val settings = Settings(system)
@@ -379,10 +380,10 @@ trait Authenticator {
 }
 
 /**
-  * This companion object holds all private methods used in the trait. This division is needed so that we can test
-  * the private methods directly with scalatest as described in [[https://groups.google.com/forum/#!topic/scalatest-users/FeaO\_\_f1dN4]]
-  * and [[http://doc.scalatest.org/2.2.6/index.html#org.scalatest.PrivateMethodTester]]
-  */
+ * This companion object holds all private methods used in the trait. This division is needed so that we can test
+ * the private methods directly with scalatest as described in [[https://groups.google.com/forum/#!topic/scalatest-users/FeaO\_\_f1dN4]]
+ * and [[http://doc.scalatest.org/2.2.6/index.html#org.scalatest.PrivateMethodTester]]
+ */
 object Authenticator {
 
     val BAD_CRED_PASSWORD_MISMATCH = "bad credentials: user found, but password did not match"
@@ -402,18 +403,18 @@ object Authenticator {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * Tries to authenticate the supplied credentials (email/password or token). In the case of email/password,
-      * authentication is performed checking if the supplied email/password combination is valid by retrieving the
-      * user's profile. In the case of the token, the token itself is validated. If both are supplied, then both need
-      * to be valid.
-      *
-      * @param credentials the user supplied and extracted credentials.
-      * @param system      the current [[ActorSystem]]
-      * @return true if the credentials are valid. If the credentials are invalid, then the corresponding exception
-      *         will be thrown.
-      * @throws BadCredentialsException when no credentials are supplied; when user is not active;
-      *                                 when the password does not match; when the supplied token is not valid.
-      */
+     * Tries to authenticate the supplied credentials (email/password or token). In the case of email/password,
+     * authentication is performed checking if the supplied email/password combination is valid by retrieving the
+     * user's profile. In the case of the token, the token itself is validated. If both are supplied, then both need
+     * to be valid.
+     *
+     * @param credentials the user supplied and extracted credentials.
+     * @param system      the current [[ActorSystem]]
+     * @return true if the credentials are valid. If the credentials are invalid, then the corresponding exception
+     *         will be thrown.
+     * @throws BadCredentialsException when no credentials are supplied; when user is not active;
+     *                                 when the password does not match; when the supplied token is not valid.
+     */
     def authenticateCredentialsV2(credentials: Option[KnoraCredentialsV2])(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[Boolean] = {
 
         for {
@@ -464,11 +465,11 @@ object Authenticator {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-      * Tries to extract the credentials from the requestContext (parameters, auth headers, token)
-      *
-      * @param requestContext a [[RequestContext]] containing the http request
-      * @return [[KnoraCredentialsV2]].
-      */
+     * Tries to extract the credentials from the requestContext (parameters, auth headers, token)
+     *
+     * @param requestContext a [[RequestContext]] containing the http request
+     * @return [[KnoraCredentialsV2]].
+     */
     private def extractCredentialsV2(requestContext: RequestContext): Option[KnoraCredentialsV2] = {
         // log.debug("extractCredentialsV2 start ...")
 
@@ -490,11 +491,11 @@ object Authenticator {
     }
 
     /**
-      * Tries to extract credentials supplied as URL parameters.
-      *
-      * @param requestContext the HTTP request context.
-      * @return [[KnoraCredentialsV2]].
-      */
+     * Tries to extract credentials supplied as URL parameters.
+     *
+     * @param requestContext the HTTP request context.
+     * @return [[KnoraCredentialsV2]].
+     */
     private def extractCredentialsFromParametersV2(requestContext: RequestContext): Option[KnoraCredentialsV2] = {
         // extract email/password from parameters
 
@@ -547,20 +548,20 @@ object Authenticator {
     }
 
     /**
-      * Tries to extract the credentials (email/password, token) from the authorization header and the session token
-      * from the cookie header.
-      *
-      * The authorization header looks something like this: 'Authorization: Basic xyz, Bearer xyz.xyz.xyz'
-      * if both the email/password and token are sent.
-      *
-      * If more then one set of credentials is found, then they are selected as follows:
-      *    1. email/password
-      *    2. authorization token
-      *    3. session token
-      *
-      * @param requestContext the HTTP request context.
-      * @return an optional [[KnoraCredentialsV2]].
-      */
+     * Tries to extract the credentials (email/password, token) from the authorization header and the session token
+     * from the cookie header.
+     *
+     * The authorization header looks something like this: 'Authorization: Basic xyz, Bearer xyz.xyz.xyz'
+     * if both the email/password and token are sent.
+     *
+     * If more then one set of credentials is found, then they are selected as follows:
+     *    1. email/password
+     *    2. authorization token
+     *    3. session token
+     *
+     * @param requestContext the HTTP request context.
+     * @return an optional [[KnoraCredentialsV2]].
+     */
     private def extractCredentialsFromHeaderV2(requestContext: RequestContext): Option[KnoraCredentialsV2] = {
 
         // Session token from cookie header
@@ -589,7 +590,7 @@ object Authenticator {
                 val (maybeEmail, maybePassword) = maybeBasicAuthValue match {
                     case Some(value) =>
                         val trimmedValue = value.substring(5).trim() // remove 'Basic '
-                    val decodedValue = ByteString.fromArray(Base64.getDecoder.decode(trimmedValue)).decodeString("UTF8")
+                        val decodedValue = ByteString.fromArray(Base64.getDecoder.decode(trimmedValue)).decodeString("UTF8")
                         val decodedValueArr = decodedValue.split(":", 2)
                         (Some(decodedValueArr(0)), Some(decodedValueArr(1)))
                     case None =>
@@ -634,14 +635,14 @@ object Authenticator {
     }
 
     /**
-      * Tries to retrieve a [[UserADM]] based on the supplied credentials. If both email/password and session
-      * token are supplied, then the user profile for the session token is returned. This method should only be used
-      * with authenticated credentials.
-      *
-      * @param credentials the user supplied credentials.
-      * @return a [[UserADM]]
-      * @throws AuthenticationException when the IRI can not be found inside the token, which is probably a bug.
-      */
+     * Tries to retrieve a [[UserADM]] based on the supplied credentials. If both email/password and session
+     * token are supplied, then the user profile for the session token is returned. This method should only be used
+     * with authenticated credentials.
+     *
+     * @param credentials the user supplied credentials.
+     * @return a [[UserADM]]
+     * @throws AuthenticationException when the IRI can not be found inside the token, which is probably a bug.
+     */
     private def getUserADMThroughCredentialsV2(credentials: Option[KnoraCredentialsV2])(implicit system: ActorSystem, responderManager: ActorRef, executionContext: ExecutionContext): Future[UserADM] = {
 
         val settings = Settings(system)
@@ -690,15 +691,15 @@ object Authenticator {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
-      * Tries to get a [[UserADM]].
-      *
-      * @param identifier       the IRI, email, or username of the user to be queried
-      * @param system           the current akka actor system
-      * @param timeout          the timeout of the query
-      * @param executionContext the current execution context
-      * @return a [[UserADM]]
-      * @throws BadCredentialsException when either the supplied email is empty or no user with such an email could be found.
-      */
+     * Tries to get a [[UserADM]].
+     *
+     * @param identifier       the IRI, email, or username of the user to be queried
+     * @param system           the current akka actor system
+     * @param timeout          the timeout of the query
+     * @param executionContext the current execution context
+     * @return a [[UserADM]]
+     * @throws BadCredentialsException when either the supplied email is empty or no user with such an email could be found.
+     */
     private def getUserByIdentifier(identifier: UserIdentifierADM)(implicit system: ActorSystem, responderManager: ActorRef, timeout: Timeout, executionContext: ExecutionContext): Future[UserADM] = {
 
         val userADMFuture = for {
@@ -718,8 +719,8 @@ object Authenticator {
 }
 
 /**
-  * Provides functions for creating, decoding, and validating JWT tokens.
-  */
+ * Provides functions for creating, decoding, and validating JWT tokens.
+ */
 object JWTHelper {
 
     import Authenticator.AUTHENTICATION_INVALIDATION_CACHE_NAME
@@ -731,14 +732,14 @@ object JWTHelper {
     val log = Logger(LoggerFactory.getLogger(this.getClass))
 
     /**
-      * Creates a JWT.
-      *
-      * @param userIri   the user IRI that will be encoded into the token.
-      * @param secret    the secret key used for encoding.
-      * @param longevity the token's longevity.
-      * @param content   any other content to be included in the token.
-      * @return a [[String]] containing the JWT.
-      */
+     * Creates a JWT.
+     *
+     * @param userIri   the user IRI that will be encoded into the token.
+     * @param secret    the secret key used for encoding.
+     * @param longevity the token's longevity.
+     * @param content   any other content to be included in the token.
+     * @return a [[String]] containing the JWT.
+     */
     def createToken(userIri: IRI, secret: String, longevity: FiniteDuration, content: Map[String, JsValue] = Map.empty): String = {
         val stringFormatter = StringFormatter.getGeneralInstance
 
@@ -769,14 +770,14 @@ object JWTHelper {
     }
 
     /**
-      * Validates a JWT, taking the invalidation cache into account. The invalidation cache holds invalidated
-      * tokens, which would otherwise validate. This method also makes sure that the required headers and claims are
-      * present.
-      *
-      * @param token  the JWT.
-      * @param secret the secret used to encode the token.
-      * @return a [[Boolean]].
-      */
+     * Validates a JWT, taking the invalidation cache into account. The invalidation cache holds invalidated
+     * tokens, which would otherwise validate. This method also makes sure that the required headers and claims are
+     * present.
+     *
+     * @param token  the JWT.
+     * @param secret the secret used to encode the token.
+     * @return a [[Boolean]].
+     */
     def validateToken(token: String, secret: String): Boolean = {
         if (CacheUtil.get[UserADM](AUTHENTICATION_INVALIDATION_CACHE_NAME, token).nonEmpty) {
             // token invalidated so no need to decode
@@ -788,12 +789,12 @@ object JWTHelper {
     }
 
     /**
-      * Extracts the encoded user IRI. This method also makes sure that the required headers and claims are present.
-      *
-      * @param token  the JWT.
-      * @param secret the secret used to encode the token.
-      * @return an optional [[IRI]].
-      */
+     * Extracts the encoded user IRI. This method also makes sure that the required headers and claims are present.
+     *
+     * @param token  the JWT.
+     * @param secret the secret used to encode the token.
+     * @return an optional [[IRI]].
+     */
     def extractUserIriFromToken(token: String, secret: String): Option[IRI] = {
         decodeToken(token, secret) match {
             case Some((_: JwtHeader, claim: JwtClaim)) => claim.subject
@@ -802,14 +803,14 @@ object JWTHelper {
     }
 
     /**
-      * Extracts application-specific content from a JWT token.  This method also makes sure that the required headers
-      * and claims are present.
-      *
-      * @param token       the JWT.
-      * @param secret      the secret used to encode the token.
-      * @param contentName the name of the content field to be extracted.
-      * @return the string value of the specified content field.
-      */
+     * Extracts application-specific content from a JWT token.  This method also makes sure that the required headers
+     * and claims are present.
+     *
+     * @param token       the JWT.
+     * @param secret      the secret used to encode the token.
+     * @param contentName the name of the content field to be extracted.
+     * @return the string value of the specified content field.
+     */
     def extractContentFromToken(token: String, secret: String, contentName: String): Option[String] = {
         decodeToken(token, secret) match {
             case Some((_: JwtHeader, claim: JwtClaim)) =>
@@ -823,12 +824,12 @@ object JWTHelper {
     }
 
     /**
-      * Decodes and validates a JWT token.
-      *
-      * @param token  the token to be decoded.
-      * @param secret the secret used to encode the token.
-      * @return the token's header and claim, or `None` if the token is invalid.
-      */
+     * Decodes and validates a JWT token.
+     *
+     * @param token  the token to be decoded.
+     * @param secret the secret used to encode the token.
+     * @return the token's header and claim, or `None` if the token is invalid.
+     */
     private def decodeToken(token: String, secret: String): Option[(JwtHeader, JwtClaim)] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/ClientApiRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/ClientApiRoute.scala
@@ -45,7 +45,10 @@ class ClientApiRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
         new V2ClientApi(routeData)
     )
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("clientapi" / Segment) { target: String =>
             get {
@@ -101,11 +104,11 @@ class ClientApiRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
     }
 
     /**
-      * Generates a ZIP file containing generated client API source code.
-      *
-      * @param sourceCode the generated source code.
-      * @return a byte array representing the ZIP file.
-      */
+     * Generates a ZIP file containing generated client API source code.
+     *
+     * @param sourceCode the generated source code.
+     * @return a byte array representing the ZIP file.
+     */
     private def generateZipFile(sourceCode: Set[SourceCodeFileContent]): Array[Byte] = {
         val zipFileContents: Map[String, Array[Byte]] = sourceCode.map {
             fileContent: SourceCodeFileContent =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/HealthRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/HealthRoute.scala
@@ -38,8 +38,8 @@ case class HealthCheckResult(name: String,
                              message: String)
 
 /**
-  * Provides health check logic
-  */
+ * Provides health check logic
+ */
 trait HealthCheck {
     this: HealthRoute =>
 
@@ -106,10 +106,13 @@ trait HealthCheck {
 }
 
 /**
-  * Provides the '/health' endpoint serving the health status.
-  */
+ * Provides the '/health' endpoint serving the health status.
+ */
 class HealthRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) with HealthCheck {
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route = {
         path("health") {
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/KnoraRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/KnoraRoute.scala
@@ -20,6 +20,7 @@
 package org.knora.webapi.routing
 
 import akka.actor.{ActorRef, ActorSystem}
+import akka.event.LoggingAdapter
 import akka.http.scaladsl.server.Route
 import akka.stream.ActorMaterializer
 import akka.util.Timeout
@@ -30,17 +31,17 @@ import scala.concurrent.ExecutionContext
 
 
 /**
-  * Data needed to be passed to each route.
-  *
-  * @param system the actor system.
-  * @param appActor the main application actor ActorRef.
-  */
+ * Data needed to be passed to each route.
+ *
+ * @param system   the actor system.
+ * @param appActor the main application actor ActorRef.
+ */
 case class KnoraRouteData(system: ActorSystem, appActor: ActorRef)
 
 
 /**
-  * An abstract class providing values that are commonly used in Knora responders.
-  */
+ * An abstract class providing values that are commonly used in Knora responders.
+ */
 abstract class KnoraRoute(routeData: KnoraRouteData) {
 
     implicit protected val system: ActorSystem = routeData.system
@@ -53,12 +54,13 @@ abstract class KnoraRoute(routeData: KnoraRouteData) {
 
     protected val applicationStateActor: ActorRef = routeData.appActor
     protected val storeManager: ActorRef = routeData.appActor
-    protected val log = akka.event.Logging(system, this.getClass)
+    protected val log: LoggingAdapter = akka.event.Logging(system, this.getClass)
     protected val baseApiUrl: String = settings.internalKnoraApiBaseUrl
 
     /**
-      * Returns the route. Needs to be implemented in each subclass.
-      * @return [[Route]]
-      */
+     * Returns the route. Needs to be implemented in each subclass.
+     *
+     * @return [[Route]]
+     */
     def knoraApiPath: Route
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RejectingRoute.scala
@@ -29,8 +29,8 @@ import scala.util.{Failure, Success}
 
 
 /**
-  * Provides AppState actor access logic
-  */
+ * Provides AppState actor access logic
+ */
 trait AppStateAccess {
     this: RejectingRoute =>
 
@@ -45,15 +45,18 @@ trait AppStateAccess {
 }
 
 /**
-  * A route used for rejecting requests to certain paths depending on the state of the app or the configuration.
-  *
-  * If the current state of the application is anything other then [[AppState.Running]], then return [[StatusCodes.ServiceUnavailable]].
-  * If the current state of the application is [[AppState.Running]], then reject requests to paths as defined
-  * in 'application.conf'.
-  */
+ * A route used for rejecting requests to certain paths depending on the state of the app or the configuration.
+ *
+ * If the current state of the application is anything other then [[AppState.Running]], then return [[StatusCodes.ServiceUnavailable]].
+ * If the current state of the application is [[AppState.Running]], then reject requests to paths as defined
+ * in 'application.conf'.
+ */
 class RejectingRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) with AppStateAccess {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path(Remaining) { wholepath =>
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilADM.scala
@@ -32,22 +32,22 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 /**
-  * Convenience methods for Knora Admin routes.
-  */
+ * Convenience methods for Knora Admin routes.
+ */
 object RouteUtilADM {
 
     /**
-      * Sends a message to a responder and completes the HTTP request by returning the response as JSON.
-      *
-      * @param requestMessageF  a future containing a [[KnoraRequestADM]] message that should be sent to the responder manager.
-      * @param requestContext   the akka-http [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[Future]] containing a [[RouteResult]].
-      */
+     * Sends a message to a responder and completes the HTTP request by returning the response as JSON.
+     *
+     * @param requestMessageF  a future containing a [[KnoraRequestADM]] message that should be sent to the responder manager.
+     * @param requestContext   the akka-http [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[Future]] containing a [[RouteResult]].
+     */
     def runJsonRoute(requestMessageF: Future[KnoraRequestADM],
                      requestContext: RequestContext,
                      settings: SettingsImpl,

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV1.scala
@@ -38,22 +38,22 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
 /**
-  * Convenience methods for Knora routes.
-  */
+ * Convenience methods for Knora routes.
+ */
 object RouteUtilV1 {
 
     /**
-      * Sends a message to a responder and completes the HTTP request by returning the response as JSON.
-      *
-      * @param requestMessage   a [[KnoraRequestV1]] message that should be sent to the responder manager.
-      * @param requestContext   the akka-http [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[Future]] containing a [[RouteResult]].
-      */
+     * Sends a message to a responder and completes the HTTP request by returning the response as JSON.
+     *
+     * @param requestMessage   a [[KnoraRequestV1]] message that should be sent to the responder manager.
+     * @param requestContext   the akka-http [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[Future]] containing a [[RouteResult]].
+     */
     def runJsonRoute(requestMessage: KnoraRequestV1,
                      requestContext: RequestContext,
                      settings: SettingsImpl,
@@ -96,17 +96,17 @@ object RouteUtilV1 {
     }
 
     /**
-      * Sends a message (resulting from a [[Future]]) to a responder and completes the HTTP request by returning the response as JSON.
-      *
-      * @param requestMessageF  a [[Future]] containing a [[KnoraRequestV1]] message that should be sent to the responder manager.
-      * @param requestContext   the akka-http [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[Future]] containing a [[RouteResult]].
-      */
+     * Sends a message (resulting from a [[Future]]) to a responder and completes the HTTP request by returning the response as JSON.
+     *
+     * @param requestMessageF  a [[Future]] containing a [[KnoraRequestV1]] message that should be sent to the responder manager.
+     * @param requestContext   the akka-http [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[Future]] containing a [[RouteResult]].
+     */
     def runJsonRouteWithFuture[RequestMessageT <: KnoraRequestV1](requestMessageF: Future[RequestMessageT],
                                                                   requestContext: RequestContext,
                                                                   settings: SettingsImpl,
@@ -126,19 +126,19 @@ object RouteUtilV1 {
     }
 
     /**
-      * Sends a message to a responder and completes the HTTP request by returning the response as HTML.
-      *
-      * @tparam RequestMessageT the type of request message to be sent to the responder.
-      * @tparam ReplyMessageT   the type of reply message expected from the responder.
-      * @param requestMessageF  a [[Future]] containing the message that should be sent to the responder manager.
-      * @param viewHandler      a function that can generate HTML from the responder's reply message.
-      * @param requestContext   the [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      */
+     * Sends a message to a responder and completes the HTTP request by returning the response as HTML.
+     *
+     * @tparam RequestMessageT the type of request message to be sent to the responder.
+     * @tparam ReplyMessageT   the type of reply message expected from the responder.
+     * @param requestMessageF  a [[Future]] containing the message that should be sent to the responder manager.
+     * @param viewHandler      a function that can generate HTML from the responder's reply message.
+     * @param requestContext   the [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     */
     def runHtmlRoute[RequestMessageT <: KnoraRequestV1, ReplyMessageT <: KnoraResponseV1 : ClassTag](requestMessageF: Future[RequestMessageT],
                                                                                                      viewHandler: (ReplyMessageT, ActorRef) => String,
                                                                                                      requestContext: RequestContext,
@@ -184,22 +184,22 @@ object RouteUtilV1 {
     }
 
     /**
-      *
-      * Converts XML to a [[TextWithStandoffTagsV2]], representing the text and its standoff markup.
-      *
-      * @param xml                            the given XML to be converted to standoff.
-      * @param mappingIri                     the mapping to be used to convert the XML to standoff.
-      * @param acceptStandoffLinksToClientIDs if `true`, allow standoff link tags to use the client's IDs for target
-      *                                       resources. In a bulk import, this allows standoff links to resources
-      *                                       that are to be created by the import.
-      * @param userProfile                    the user making the request.
-      * @param settings                       the application's settings.
-      * @param responderManager               a reference to the responder manager.
-      * @param log                            a logging adapter.
-      * @param timeout                        a timeout for `ask` messages.
-      * @param executionContext               an execution context for futures.
-      * @return a [[TextWithStandoffTagsV2]].
-      */
+     *
+     * Converts XML to a [[TextWithStandoffTagsV2]], representing the text and its standoff markup.
+     *
+     * @param xml                            the given XML to be converted to standoff.
+     * @param mappingIri                     the mapping to be used to convert the XML to standoff.
+     * @param acceptStandoffLinksToClientIDs if `true`, allow standoff link tags to use the client's IDs for target
+     *                                       resources. In a bulk import, this allows standoff links to resources
+     *                                       that are to be created by the import.
+     * @param userProfile                    the user making the request.
+     * @param settings                       the application's settings.
+     * @param responderManager               a reference to the responder manager.
+     * @param log                            a logging adapter.
+     * @param timeout                        a timeout for `ask` messages.
+     * @param executionContext               an execution context for futures.
+     * @return a [[TextWithStandoffTagsV2]].
+     */
     def convertXMLtoStandoffTagV1(xml: String,
                                   mappingIri: IRI,
                                   acceptStandoffLinksToClientIDs: Boolean,

--- a/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/RouteUtilV2.scala
@@ -33,73 +33,73 @@ import org.eclipse.rdf4j.rio.rdfxml.util.RDFXMLPrettyWriter
 import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.resourcemessages.ResourceTEIGetResponseV2
 import org.knora.webapi.messages.v2.responder.{KnoraRequestV2, KnoraResponseV2}
-import org.knora.webapi.util.{SmartIri, StringFormatter}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.jsonld.JsonLDDocument
+import org.knora.webapi.util.{SmartIri, StringFormatter}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.Exception.catching
 
 /**
-  * Handles message formatting, content negotiation, and simple interactions with responders, on behalf of Knora routes.
-  */
+ * Handles message formatting, content negotiation, and simple interactions with responders, on behalf of Knora routes.
+ */
 object RouteUtilV2 {
     /**
-      * The name of the HTTP header in which an ontology schema can be requested.
-      */
+     * The name of the HTTP header in which an ontology schema can be requested.
+     */
     val SCHEMA_HEADER: String = "x-knora-accept-schema"
 
     /**
-      * The name of the URL parameter in which an ontology schema can be requested.
-      */
+     * The name of the URL parameter in which an ontology schema can be requested.
+     */
     val SCHEMA_PARAM: String = "schema"
 
     /**
-      * The name of the complex schema.
-      */
+     * The name of the complex schema.
+     */
     val SIMPLE_SCHEMA_NAME: String = "simple"
 
     /**
-      * The name of the simple schema.
-      */
+     * The name of the simple schema.
+     */
     val COMPLEX_SCHEMA_NAME: String = "complex"
 
     /**
-      * The name of the HTTP header in which results from a project can be requested.
-      */
+     * The name of the HTTP header in which results from a project can be requested.
+     */
     val PROJECT_HEADER: String = "x-knora-accept-project"
 
     /**
-      * The name of the URL parameter that can be used to specify how markup should be returned
-      * with text values.
-      */
+     * The name of the URL parameter that can be used to specify how markup should be returned
+     * with text values.
+     */
     val MARKUP_PARAM: String = "markup"
 
     /**
-      * The name of the HTTP header that can be used to specify how markup should be returned with
-      * text values.
-      */
+     * The name of the HTTP header that can be used to specify how markup should be returned with
+     * text values.
+     */
     val MARKUP_HEADER: String = "x-knora-accept-markup"
 
     /**
-      * Indicates that standoff markup should be returned as XML with text values.
-      */
+     * Indicates that standoff markup should be returned as XML with text values.
+     */
     val MARKUP_XML: String = "xml"
 
     /**
-      * Indicates that markup should not be returned with text values, because it will be requested
-      * separately as standoff.
-      */
+     * Indicates that markup should not be returned with text values, because it will be requested
+     * separately as standoff.
+     */
     val MARKUP_STANDOFF: String = "standoff"
 
     /**
-      * Gets the ontology schema that is specified in an HTTP request. The schema can be specified
-      * either in the HTTP header [[SCHEMA_HEADER]] or in the URL parameter [[SCHEMA_PARAM]].
-      * If no schema is specified in the request, the default of [[ApiV2Complex]] is returned.
-      *
-      * @param requestContext the akka-http [[RequestContext]].
-      * @return the specified schema, or [[ApiV2Complex]] if no schema was specified in the request.
-      */
+     * Gets the ontology schema that is specified in an HTTP request. The schema can be specified
+     * either in the HTTP header [[SCHEMA_HEADER]] or in the URL parameter [[SCHEMA_PARAM]].
+     * If no schema is specified in the request, the default of [[ApiV2Complex]] is returned.
+     *
+     * @param requestContext the akka-http [[RequestContext]].
+     * @return the specified schema, or [[ApiV2Complex]] if no schema was specified in the request.
+     */
     def getOntologySchema(requestContext: RequestContext): ApiV2Schema = {
         def nameToSchema(schemaName: String): ApiV2Schema = {
             schemaName match {
@@ -123,15 +123,15 @@ object RouteUtilV2 {
     }
 
     /**
-      * Gets the type of standoff rendering that should be used when returning text with standoff.
-      * The name of the standoff rendering can be specified either in the HTTP header [[MARKUP_HEADER]]
-      * or in the URL parameter [[MARKUP_PARAM]]. If no rendering is specified in the request, the
-      * default of [[MarkupAsXml]] is returned.
-      *
-      * @param requestContext the akka-http [[RequestContext]].
-      * @return the specified standoff rendering, or [[MarkupAsXml]] if no rendering was specified
-      *         in the request.
-      */
+     * Gets the type of standoff rendering that should be used when returning text with standoff.
+     * The name of the standoff rendering can be specified either in the HTTP header [[MARKUP_HEADER]]
+     * or in the URL parameter [[MARKUP_PARAM]]. If no rendering is specified in the request, the
+     * default of [[MarkupAsXml]] is returned.
+     *
+     * @param requestContext the akka-http [[RequestContext]].
+     * @return the specified standoff rendering, or [[MarkupAsXml]] if no rendering was specified
+     *         in the request.
+     */
     private def getStandoffRendering(requestContext: RequestContext): Option[MarkupRendering] = {
         def nameToStandoffRendering(standoffRenderingName: String): MarkupRendering = {
             standoffRenderingName match {
@@ -154,21 +154,21 @@ object RouteUtilV2 {
     }
 
     /**
-      * Gets the schema options submitted in the request.
-      *
-      * @param requestContext the request context.
-      * @return the set of schema options submitted in the request, including default options.
-      */
+     * Gets the schema options submitted in the request.
+     *
+     * @param requestContext the request context.
+     * @return the set of schema options submitted in the request, including default options.
+     */
     def getSchemaOptions(requestContext: RequestContext): Set[SchemaOption] = {
         getStandoffRendering(requestContext).toSet
     }
 
     /**
-      * Gets the project IRI specified in a Knora-specific HTTP header.
-      *
-      * @param requestContext the akka-http [[RequestContext]].
-      * @return the specified project IRI, or [[None]] if no project header was included in the request.
-      */
+     * Gets the project IRI specified in a Knora-specific HTTP header.
+     *
+     * @param requestContext the akka-http [[RequestContext]].
+     * @return the specified project IRI, or [[None]] if no project header was included in the request.
+     */
     def getProject(requestContext: RequestContext)(implicit stringFormatter: StringFormatter): Option[SmartIri] = {
         requestContext.request.headers.find(_.lowercaseName == PROJECT_HEADER).map {
             header =>
@@ -178,18 +178,18 @@ object RouteUtilV2 {
     }
 
     /**
-      * Sends a message to a responder and completes the HTTP request by returning the response as RDF using content negotation.
-      *
-      * @param requestMessage   a future containing a [[KnoraRequestV2]] message that should be sent to the responder manager.
-      * @param requestContext   the akka-http [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param targetSchema   the API schema that should be used in the response.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[Future]] containing a [[RouteResult]].
-      */
+     * Sends a message to a responder and completes the HTTP request by returning the response as RDF using content negotation.
+     *
+     * @param requestMessage   a future containing a [[KnoraRequestV2]] message that should be sent to the responder manager.
+     * @param requestContext   the akka-http [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param targetSchema     the API schema that should be used in the response.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[Future]] containing a [[RouteResult]].
+     */
     private def runRdfRoute(requestMessage: KnoraRequestV2,
                             requestContext: RequestContext,
                             settings: SettingsImpl,
@@ -238,18 +238,18 @@ object RouteUtilV2 {
     }
 
     /**
-      * Sends a message to a responder and completes the HTTP request by returning the response as TEI/XML.
-      *
-      * @param requestMessageF  a future containing a [[KnoraRequestV2]] message that should be sent to the responder manager.
-      * @param requestContext   the akka-http [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param targetSchema   the API schema that should be used in the response.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[Future]] containing a [[RouteResult]].
-      */
+     * Sends a message to a responder and completes the HTTP request by returning the response as TEI/XML.
+     *
+     * @param requestMessageF  a future containing a [[KnoraRequestV2]] message that should be sent to the responder manager.
+     * @param requestContext   the akka-http [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param targetSchema     the API schema that should be used in the response.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[Future]] containing a [[RouteResult]].
+     */
     def runTEIXMLRoute(requestMessageF: Future[KnoraRequestV2],
                        requestContext: RequestContext,
                        settings: SettingsImpl,
@@ -286,19 +286,19 @@ object RouteUtilV2 {
     }
 
     /**
-      * Sends a message (resulting from a [[Future]]) to a responder and completes the HTTP request by returning the response as RDF.
-      *
-      * @param requestMessageF  a [[Future]] containing a [[KnoraRequestV2]] message that should be sent to the responder manager.
-      * @param requestContext   the akka-http [[RequestContext]].
-      * @param settings         the application's settings.
-      * @param responderManager a reference to the responder manager.
-      * @param log              a logging adapter.
-      * @param targetSchema   the API schema that should be used in the response.
-      * @param schemaOptions    the schema options that should be used when processing the request.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[Future]] containing a [[RouteResult]].
-      */
+     * Sends a message (resulting from a [[Future]]) to a responder and completes the HTTP request by returning the response as RDF.
+     *
+     * @param requestMessageF  a [[Future]] containing a [[KnoraRequestV2]] message that should be sent to the responder manager.
+     * @param requestContext   the akka-http [[RequestContext]].
+     * @param settings         the application's settings.
+     * @param responderManager a reference to the responder manager.
+     * @param log              a logging adapter.
+     * @param targetSchema     the API schema that should be used in the response.
+     * @param schemaOptions    the schema options that should be used when processing the request.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[Future]] containing a [[RouteResult]].
+     */
     def runRdfRouteWithFuture(requestMessageF: Future[KnoraRequestV2],
                               requestContext: RequestContext,
                               settings: SettingsImpl,
@@ -323,11 +323,11 @@ object RouteUtilV2 {
     }
 
     /**
-      * Chooses an RDF media type for the response, using content negotiation as per [[https://tools.ietf.org/html/rfc7231#section-5.3.2]].
-      *
-      * @param requestContext the request context.
-      * @return an RDF media type.
-      */
+     * Chooses an RDF media type for the response, using content negotiation as per [[https://tools.ietf.org/html/rfc7231#section-5.3.2]].
+     *
+     * @param requestContext the request context.
+     * @return an RDF media type.
+     */
     private def chooseRdfMediaTypeForResponse(requestContext: RequestContext): MediaType.NonBinary = {
         // Get the client's HTTP Accept header, if provided.
         val maybeAcceptHeader: Option[HttpHeader] = requestContext.request.headers.find(_.lowercaseName == "accept")
@@ -374,15 +374,15 @@ object RouteUtilV2 {
     }
 
     /**
-      * Constructs an HTTP response containing a Knora response message formatted in the requested media type.
-      *
-      * @param knoraResponse     the response message.
-      * @param responseMediaType the media type selected for the response (must be one of the types in [[RdfMediaTypes]]).
-      * @param targetSchema    the response schema.
-      * @param schemaOptions     the schema options.
-      * @param settings          the application settings.
-      * @return an HTTP response.
-      */
+     * Constructs an HTTP response containing a Knora response message formatted in the requested media type.
+     *
+     * @param knoraResponse     the response message.
+     * @param responseMediaType the media type selected for the response (must be one of the types in [[RdfMediaTypes]]).
+     * @param targetSchema      the response schema.
+     * @param schemaOptions     the schema options.
+     * @param settings          the application settings.
+     * @return an HTTP response.
+     */
     private def formatResponse(knoraResponse: KnoraResponseV2,
                                responseMediaType: MediaType.NonBinary,
                                targetSchema: ApiV2Schema,

--- a/webapi/src/main/scala/org/knora/webapi/routing/SwaggerApiDocsRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/SwaggerApiDocsRoute.scala
@@ -27,8 +27,8 @@ import io.swagger.models.{ExternalDocs, Scheme}
 import org.knora.webapi.routing.admin._
 
 /**
-  * Provides the '/api-docs' endpoint serving the 'swagger.json' OpenAPI specification
-  */
+ * Provides the '/api-docs' endpoint serving the 'swagger.json' OpenAPI specification
+ */
 class SwaggerApiDocsRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) with SwaggerHttpService {
 
     // List all routes here
@@ -53,13 +53,16 @@ class SwaggerApiDocsRoute(routeData: KnoraRouteData) extends KnoraRoute(routeDat
     // swagger will publish at: http://locahost:3333/api-docs/swagger.json
 
     override val host: String = settings.externalKnoraApiHostPort // the url of your api, not swagger's json endpoint
-    override val basePath = "/"    //the basePath for the API you are exposing
+    override val basePath = "/" //the basePath for the API you are exposing
     override val apiDocsPath = "api-docs" //where you want the swagger-json endpoint exposed
     override val info = Info(version = "1.8.0") //provides license and other description details
     override val externalDocs = Some(new ExternalDocs("Knora Docs", "http://docs.knora.org"))
     override val securitySchemeDefinitions = Map("basicAuth" -> new BasicAuthDefinition())
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
         routes
     }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/VersionRoute.scala
@@ -23,11 +23,10 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives.{get, path}
 import akka.http.scaladsl.server.Route
 import akka.util.Timeout
+import org.knora.webapi.BuildInfo
 import spray.json.{JsObject, JsString}
 
 import scala.concurrent.duration._
-
-import org.knora.webapi.BuildInfo
 
 
 case class VersionCheckResult(name: String,
@@ -40,8 +39,8 @@ case class VersionCheckResult(name: String,
                               gdbFree: String)
 
 /**
-  * Provides version check logic
-  */
+ * Provides version check logic
+ */
 trait VersionCheck {
     this: VersionRoute =>
 
@@ -51,7 +50,6 @@ trait VersionCheck {
         val result = getVersion()
         createResponse(result)
     }
-
 
 
     protected def createResponse(result: VersionCheckResult): HttpResponse = {
@@ -76,15 +74,15 @@ trait VersionCheck {
     private def getVersion() = {
         var sipiVersion = BuildInfo.sipi
         val sipiIndex = sipiVersion.indexOf(':')
-        sipiVersion = if (sipiIndex > 0) sipiVersion.substring(sipiIndex+1) else sipiVersion
+        sipiVersion = if (sipiIndex > 0) sipiVersion.substring(sipiIndex + 1) else sipiVersion
 
         var gdbSEVersion = BuildInfo.gdbSE
         val gdbSEIndex = gdbSEVersion.indexOf(':')
-        gdbSEVersion = if (gdbSEIndex > 0) gdbSEVersion.substring(gdbSEIndex+1) else gdbSEVersion
+        gdbSEVersion = if (gdbSEIndex > 0) gdbSEVersion.substring(gdbSEIndex + 1) else gdbSEVersion
 
         var gdbFreeVersion = BuildInfo.gdbFree
         val gdbFreeIndex = gdbFreeVersion.indexOf(':')
-        gdbFreeVersion = if (gdbFreeIndex > 0) gdbFreeVersion.substring(gdbFreeIndex+1) else gdbFreeVersion
+        gdbFreeVersion = if (gdbFreeIndex > 0) gdbFreeVersion.substring(gdbFreeIndex + 1) else gdbFreeVersion
 
         VersionCheckResult(
             name = "version",
@@ -100,10 +98,13 @@ trait VersionCheck {
 }
 
 /**
-  * Provides the '/version' endpoint serving the components versions.
-  */
+ * Provides the '/version' endpoint serving the components versions.
+ */
 class VersionRoute(routeData: KnoraRouteData) extends KnoraRoute(routeData) with VersionCheck {
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route = {
         path("version") {
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/AdminClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/AdminClientApi.scala
@@ -33,8 +33,8 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
     implicit private val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * The serialisation format used by this [[ClientApi]].
-      */
+     * The serialisation format used by this [[ClientApi]].
+     */
     override val serialisationFormat: ApiSerialisationFormat = Json
 
     /**
@@ -68,8 +68,8 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
     override val description: String = "A client API for administering Knora."
 
     /**
-      * A map of class IRIs to their read-only properties.
-      */
+     * A map of class IRIs to their read-only properties.
+     */
     override val classesWithReadOnlyProperties: Map[SmartIri, Set[SmartIri]] = Map(
         OntologyConstants.KnoraAdminV2.UserClass -> Set(
             OntologyConstants.KnoraAdminV2.Token,
@@ -78,10 +78,10 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
             OntologyConstants.KnoraAdminV2.Projects,
             OntologyConstants.KnoraAdminV2.Permissions
         ),
-        OntologyConstants.KnoraAdminV2.GroupClass ->  Set(
+        OntologyConstants.KnoraAdminV2.GroupClass -> Set(
             OntologyConstants.KnoraAdminV2.ProjectProperty
         ),
-        OntologyConstants.KnoraAdminV2.ProjectClass ->  Set(
+        OntologyConstants.KnoraAdminV2.ProjectClass -> Set(
             OntologyConstants.KnoraAdminV2.Ontologies
         )
     ).map {
@@ -90,9 +90,9 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
     }
 
     /**
-      * A map of class IRIs to IRIs of optional set properties. Such properties have cardinality 0-n, and should
-      * be made optional in generated code.
-      */
+     * A map of class IRIs to IRIs of optional set properties. Such properties have cardinality 0-n, and should
+     * be made optional in generated code.
+     */
     override val classesWithOptionalSetProperties: Map[SmartIri, Set[SmartIri]] = Map(
         OntologyConstants.KnoraAdminV2.UpdateProjectRequest -> Set(
             OntologyConstants.KnoraAdminV2.KeywordsProperty,
@@ -104,8 +104,8 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
     }
 
     /**
-      * A set of IRIs of classes that represent API responses.
-      */
+     * A set of IRIs of classes that represent API responses.
+     */
     override val responseClasses: Set[SmartIri] = Set(
         OntologyConstants.KnoraAdminV2.UserResponse,
         OntologyConstants.KnoraAdminV2.UsersResponse,
@@ -129,10 +129,10 @@ class AdminClientApi(routeData: KnoraRouteData) extends ClientApi {
     ).map(_.toSmartIri)
 
     /**
-      * A map of class IRIs to maps of property IRIs to non-standard names that those properties must have
-      * in those classes. Needed only for JSON, and only if two different properties should have the same name in
-      * different classes. `JsonInstanceInspector` also needs to know about these.
-      */
+     * A map of class IRIs to maps of property IRIs to non-standard names that those properties must have
+     * in those classes. Needed only for JSON, and only if two different properties should have the same name in
+     * different classes. `JsonInstanceInspector` also needs to know about these.
+     */
     override lazy val propertyNames: Map[SmartIri, Map[SmartIri, String]] = AdminClientApi.propertyNames
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
@@ -247,10 +247,10 @@ class GroupsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
     }
 
     private val updateGroupFunction: ClientFunction =
-        "updateGroup" description "Updates a group." params (
+        "updateGroup" description "Updates a group." params(
             "iri" description "The IRI of the group to be updated." paramType UriDatatype,
             "groupInfo" description "The group information to be updated." paramType UpdateGroupRequest
-            ) doThis {
+        ) doThis {
             httpPut(
                 path = arg("iri"),
                 body = Some(arg("groupInfo"))
@@ -309,10 +309,10 @@ class GroupsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
     }
 
     private val changeGroupStatusFunction: ClientFunction =
-        "updateGroupStatus" description "Updates the status of a group." params (
+        "updateGroupStatus" description "Updates the status of a group." params(
             "iri" description "The IRI of the group to be updated." paramType UriDatatype,
             "status" description "The new status of the group." paramType BooleanDatatype
-            ) doThis {
+        ) doThis {
             httpPut(
                 path = arg("iri") / str("status"),
                 body = Some(json(
@@ -408,7 +408,7 @@ class GroupsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
     }
 
     /**
-     * All defined routes need to be combined here.
+     * Returns the route.
      */
     override def knoraApiPath: Route = getGroups ~ createGroup ~ getGroupByIri ~
         updateGroup ~ changeGroupStatus ~ deleteGroup ~ getGroupMembers

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
@@ -39,11 +39,11 @@ import scala.concurrent.Future
 @Path("/admin/lists")
 class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ListADMJsonProtocol {
 
+    /* return all lists optionally filtered by project */
     @ApiOperation(value = "Get lists", nickname = "getlists", httpMethod = "GET", response = classOf[ListsGetResponseADM])
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
-    /* return all lists optionally filtered by project */
     def getLists: Route = path("admin" / "lists") {
         get {
             /* return all lists */
@@ -66,6 +66,7 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         }
     }
 
+    /* create a new list (root node) */
     @ApiOperation(value = "Add new list", nickname = "addList", httpMethod = "POST", response = classOf[ListGetResponseADM])
     @ApiImplicitParams(Array(
         new ApiImplicitParam(name = "body", value = "\"list\" to create", required = true,
@@ -74,7 +75,6 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
-    /* create a new list (root node) */
     def postList: Route = path("admin" / "lists") {
         post {
             /* create a list */
@@ -99,12 +99,12 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         }
     }
 
+    /* get a list */
     @Path("/{IRI}")
     @ApiOperation(value = "Get a list", nickname = "getlist", httpMethod = "GET", response = classOf[ListGetResponseADM])
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
-    /* get a list */
     def getList: Route = path("admin" / "lists" / Segment) { iri =>
         get {
             /* return a list (a graph with all list nodes) */
@@ -125,6 +125,9 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         }
     }
 
+    /**
+     * update list
+     */
     @Path("/{IRI}")
     @ApiOperation(value = "Update basic list information", nickname = "putList", httpMethod = "PUT", response = classOf[ListInfoGetResponseADM])
     @ApiImplicitParams(Array(
@@ -134,10 +137,6 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
-
-    /**
-     * update list
-     */
     def putList: Route = path("admin" / "lists" / Segment) { iri =>
         put {
             /* update existing list node (either root or child) */
@@ -165,6 +164,9 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         }
     }
 
+    /**
+     * create a new child node
+     */
     @Path("/{IRI}")
     @ApiOperation(value = "Add new child node", nickname = "addListChildNode", httpMethod = "POST", response = classOf[ListNodeInfoGetResponseADM])
     @ApiImplicitParams(Array(
@@ -174,10 +176,6 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
-
-    /**
-     * create a new child node
-     */
     def postListChildNode: Route = path("admin" / "lists" / Segment) { iri =>
         post {
             /* add node to existing list node. the existing list node can be either the root or a child */

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ListsRouteADM.scala
@@ -134,6 +134,7 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
+
     /**
      * update list
      */
@@ -173,6 +174,7 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     @ApiResponses(Array(
         new ApiResponse(code = 500, message = "Internal server error")
     ))
+
     /**
      * create a new child node
      */
@@ -212,6 +214,9 @@ class ListsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         }
     }
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route = getLists ~ postList ~ getList ~ putList ~ postListChildNode ~ deleteListNode ~ {
 
         path("admin" / "lists" / "infos" / Segment) { iri =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -22,20 +22,18 @@ package org.knora.webapi.routing.admin
 import java.net.URLEncoder
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.client.RequestBuilding.{Get, addCredentials}
-import akka.http.scaladsl.model.headers.BasicHttpCredentials
+import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{PathMatcher, Route}
-import akka.http.scaladsl.util.FastFuture
 import akka.stream.ActorMaterializer
 import io.swagger.annotations.Api
 import javax.ws.rs.Path
-import org.knora.webapi.{OntologyConstants, SharedTestDataADM}
 import org.knora.webapi.messages.admin.responder.permissionsmessages.{AdministrativePermissionForProjectGroupGetRequestADM, PermissionType}
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilADM}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.clientapi.EndpointFunctionDSL._
 import org.knora.webapi.util.clientapi._
+import org.knora.webapi.{OntologyConstants, SharedTestDataADM}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -77,6 +75,9 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
     private val projectIri: String = URLEncoder.encode(SharedTestDataADM.imagesProject.id, "utf-8")
     private val groupIri: String = URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route = getAdministrativePermission
 
     private def getAdministrativePermission: Route = path(PermissionsBasePath / Segment / Segment) { (projectIri, groupIri) =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
@@ -93,6 +93,9 @@ class ProjectsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     private val imagesProjectIriEnc = URLEncoder.encode(SharedTestDataADM.imagesProject.id, "utf-8")
     private val incunabulaIriEnc = URLEncoder.encode(SharedTestDataADM.incunabulaProject.id, "utf-8")
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route =
         getProjects ~
             addProject ~
@@ -397,10 +400,10 @@ class ProjectsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     }
 
     private val updateProjectFunction: ClientFunction =
-        "updateProject" description "Updates a project." params (
+        "updateProject" description "Updates a project." params(
             "iri" description "The IRI of the project to be updated." paramType UriDatatype,
             "projectInfo" description "The project info to be updated." paramType UpdateProjectRequest
-            ) doThis {
+        ) doThis {
             httpPut(
                 path = str("iri") / arg("iri"),
                 body = Some(arg("projectInfo"))

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/SipiRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/SipiRouteADM.scala
@@ -33,7 +33,10 @@ class SipiRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) with
     /**
      * A routing function for the API that Sipi connects to.
      */
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("admin" / "files" / Segments(2)) { projectIDAndFile: Seq[String] =>
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/StoreRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/StoreRouteADM.scala
@@ -38,6 +38,9 @@ import scala.concurrent.duration._
 @Path("/admin/store")
 class StoreRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with StoresADMJsonProtocol {
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath = Route {
         path("admin" / "store") {
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -91,7 +91,9 @@ class UsersRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     private val anythingUser1IriEnc = URLEncoder.encode(SharedTestDataADM.anythingUser1.id, "UTF-8")
     private val multiUserIriEnc = URLEncoder.encode(SharedTestDataADM.multiuserUser.id, "UTF-8")
 
-    /* concatenate paths in the CORRECT order and return */
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route =
         getUsers ~
             addUser ~ getUserByIri ~ getUserByEmail ~ getUserByUsername ~
@@ -332,10 +334,10 @@ class UsersRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     private val updateUserBasicInformationFunction: ClientFunction =
-        "updateUserBasicInformation" description "Updates an existing user's basic information." params (
+        "updateUserBasicInformation" description "Updates an existing user's basic information." params(
             "iri" description "The IRI of the user to be updated." paramType UriDatatype,
             "userInfo" description "The user information to be updated." paramType UpdateUserRequest
-            ) doThis {
+        ) doThis {
             httpPut(
                 path = str("iri") / arg("iri") / str("BasicUserInformation"),
                 body = Some(arg("userInfo"))
@@ -452,10 +454,10 @@ class UsersRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     private val updateUserStatusFunction: ClientFunction =
-        "updateUserStatus" description "Updates a user's status." params (
+        "updateUserStatus" description "Updates a user's status." params(
             "iri" description "The user's IRI." paramType UriDatatype,
             "status" description "The user's new status." paramType BooleanDatatype
-            ) doThis {
+        ) doThis {
             httpPut(
                 path = str("iri") / arg("iri") / str("Status"),
                 body = Some(json("status" -> arg("status")))

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/AssetsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/AssetsRouteV1.scala
@@ -30,10 +30,13 @@ import javax.imageio.ImageIO
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData}
 
 /**
-  * A route used for faking the image server.
-  */
+ * A route used for faking the image server.
+ */
 class AssetsRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route = {
 
         path("v1" / "assets" / Remaining) { assetId =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/AuthenticationRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/AuthenticationRouteV1.scala
@@ -24,11 +24,14 @@ import akka.http.scaladsl.server.Route
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData}
 
 /**
-  * A route providing authentication support. It allows the creation of "sessions", which is used in the SALSAH app.
-  */
+ * A route providing authentication support. It allows the creation of "sessions", which is used in the SALSAH app.
+ */
 class AuthenticationRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "authenticate") {
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/CkanRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/CkanRouteV1.scala
@@ -25,11 +25,14 @@ import org.knora.webapi.messages.v1.responder.ckanmessages.CkanRequestV1
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV1}
 
 /**
-  * A route used to serve data to CKAN. It is used be the Ckan instance running under http://data.humanities.ch.
-  */
+ * A route used to serve data to CKAN. It is used be the Ckan instance running under http://data.humanities.ch.
+ */
 class CkanRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "ckan") {
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ListsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ListsRouteV1.scala
@@ -27,11 +27,14 @@ import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, Rout
 import org.knora.webapi.util.StringFormatter
 
 /**
-  * Provides API routes that deal with lists.
-  */
+ * Provides API routes that deal with lists.
+ */
 class ListsRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         val stringFormatter = StringFormatter.getGeneralInstance
 
@@ -40,15 +43,15 @@ class ListsRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with
                 requestContext =>
 
                     val requestMessageFuture = for {
-                            userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
-                            listIri = stringFormatter.validateAndEscapeIri(iri, throw BadRequestException(s"Invalid param list IRI: $iri"))
+                        userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
+                        listIri = stringFormatter.validateAndEscapeIri(iri, throw BadRequestException(s"Invalid param list IRI: $iri"))
 
-                            requestMessage = requestContext.request.uri.query().get("reqtype") match {
-                              case Some("node") => NodePathGetRequestV1(listIri, userProfile)
-                              case Some(reqtype) => throw BadRequestException(s"Invalid reqtype: $reqtype")
-                              case None => HListGetRequestV1(listIri, userProfile)
-                          }
-                        } yield requestMessage
+                        requestMessage = requestContext.request.uri.query().get("reqtype") match {
+                            case Some("node") => NodePathGetRequestV1(listIri, userProfile)
+                            case Some(reqtype) => throw BadRequestException(s"Invalid reqtype: $reqtype")
+                            case None => HListGetRequestV1(listIri, userProfile)
+                        }
+                    } yield requestMessage
 
 
                     RouteUtilV1.runJsonRouteWithFuture(
@@ -60,28 +63,28 @@ class ListsRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with
                     )
             }
         } ~
-        path("v1" / "selections" / Segment) { iri =>
-            get {
-                requestContext =>
-                    val requestMessageFuture = for {
+            path("v1" / "selections" / Segment) { iri =>
+                get {
+                    requestContext =>
+                        val requestMessageFuture = for {
                             userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
                             selIri = stringFormatter.validateAndEscapeIri(iri, throw BadRequestException(s"Invalid param list IRI: $iri"))
 
                             requestMessage = requestContext.request.uri.query().get("reqtype") match {
-                            case Some("node") => NodePathGetRequestV1(selIri, userProfile)
-                            case Some(reqtype) => throw BadRequestException(s"Invalid reqtype: $reqtype")
-                            case None => SelectionGetRequestV1(selIri, userProfile)
-                        }
-                    } yield requestMessage
+                                case Some("node") => NodePathGetRequestV1(selIri, userProfile)
+                                case Some(reqtype) => throw BadRequestException(s"Invalid reqtype: $reqtype")
+                                case None => SelectionGetRequestV1(selIri, userProfile)
+                            }
+                        } yield requestMessage
 
-                    RouteUtilV1.runJsonRouteWithFuture(
-                        requestMessageFuture,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
+                        RouteUtilV1.runJsonRouteWithFuture(
+                            requestMessageFuture,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
             }
-        }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ProjectsRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ProjectsRouteV1.scala
@@ -32,7 +32,10 @@ class ProjectsRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) w
     private val schemes = Array("http", "https")
     private val urlValidator = new UrlValidator(schemes)
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "projects") {
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourceTypesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourceTypesRouteV1.scala
@@ -26,17 +26,20 @@ import org.knora.webapi.messages.v1.responder.ontologymessages._
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV1}
 
 /**
-  * Provides a spray-routing function for API routes that deal with resource types.
-  */
+ * Provides a spray-routing function for API routes that deal with resource types.
+ */
 class ResourceTypesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "resourcetypes" / Segment) { iri =>
             get {
                 requestContext =>
 
-                    val requestMessage =  for {
+                    val requestMessage = for {
                         userProfile <- getUserADM(requestContext)
 
                         // TODO: Check that this is the IRI of a resource type and not just any IRI

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourcesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ResourcesRouteV1.scala
@@ -34,7 +34,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.FileInfo
 import akka.http.scaladsl.util.FastFuture
 import akka.pattern._
-import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.FileIO
 import javax.xml.XMLConstants
 import javax.xml.transform.stream.StreamSource
@@ -64,13 +63,16 @@ import scala.util.{Failure, Success, Try}
 import scala.xml._
 
 /**
-  * Provides API routes that deal with resources.
-  */
+ * Provides API routes that deal with resources.
+ */
 class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
     // A scala.xml.PrettyPrinter for formatting generated XML import schemas.
     private val xmlPrettyPrinter = new scala.xml.PrettyPrinter(width = 160, step = 4)
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         def makeResourceRequestMessage(resIri: String,
                                        resinfo: Boolean,
@@ -354,29 +356,29 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
 
         /**
-          * Given the IRI the main internal ontology to be used in an XML import, recursively gets instances of
-          * [[NamedGraphEntityInfoV1]] for that ontology, for `knora-base`, and for any other ontologies containing
-          * classes used in object class constraints in the main ontology.
-          *
-          * @param mainOntologyIri the IRI of the main ontology used in the XML import.
-          * @param userProfile     the profile of the user making the request.
-          * @return a map of internal ontology IRIs to [[NamedGraphEntityInfoV1]] objects.
-          */
+         * Given the IRI the main internal ontology to be used in an XML import, recursively gets instances of
+         * [[NamedGraphEntityInfoV1]] for that ontology, for `knora-base`, and for any other ontologies containing
+         * classes used in object class constraints in the main ontology.
+         *
+         * @param mainOntologyIri the IRI of the main ontology used in the XML import.
+         * @param userProfile     the profile of the user making the request.
+         * @return a map of internal ontology IRIs to [[NamedGraphEntityInfoV1]] objects.
+         */
         def getNamedGraphInfos(mainOntologyIri: IRI, userProfile: UserADM): Future[Map[IRI, NamedGraphEntityInfoV1]] = {
             /**
-              * Does the actual recursion for `getNamedGraphInfos`, loading only information about project-specific
-              * ontologies (i.e. ontologies other than `knora-base`).
-              *
-              * @param initialOntologyIri  the IRI of the internal project-specific ontology to start with.
-              * @param intermediateResults the intermediate results collected so far (a map of internal ontology IRIs to
-              *                            [[NamedGraphEntityInfoV1]] objects). When this method is first called, this
-              *                            collection must already contain a [[NamedGraphEntityInfoV1]] for
-              *                            the `knora-base` ontology. This is an optimisation to avoid getting
-              *                            information about `knora-base` repeatedly, since every project-specific
-              *                            ontology depends on `knora-base`.
-              * @param userProfile         the profile of the user making the request.
-              * @return a map of internal ontology IRIs to [[NamedGraphEntityInfoV1]] objects.
-              */
+             * Does the actual recursion for `getNamedGraphInfos`, loading only information about project-specific
+             * ontologies (i.e. ontologies other than `knora-base`).
+             *
+             * @param initialOntologyIri  the IRI of the internal project-specific ontology to start with.
+             * @param intermediateResults the intermediate results collected so far (a map of internal ontology IRIs to
+             *                            [[NamedGraphEntityInfoV1]] objects). When this method is first called, this
+             *                            collection must already contain a [[NamedGraphEntityInfoV1]] for
+             *                            the `knora-base` ontology. This is an optimisation to avoid getting
+             *                            information about `knora-base` repeatedly, since every project-specific
+             *                            ontology depends on `knora-base`.
+             * @param userProfile         the profile of the user making the request.
+             * @return a map of internal ontology IRIs to [[NamedGraphEntityInfoV1]] objects.
+             */
             def getNamedGraphInfosRec(initialOntologyIri: IRI, intermediateResults: Map[IRI, NamedGraphEntityInfoV1], userProfile: UserADM): Future[Map[IRI, NamedGraphEntityInfoV1]] = {
                 assert(intermediateResults.contains(OntologyConstants.KnoraBase.KnoraBaseOntologyIri))
 
@@ -464,22 +466,22 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
 
         /**
-          * Given the IRI of an internal project-specific ontology, generates an [[XmlImportSchemaBundleV1]] for validating
-          * XML imports for that ontology and any other ontologies it depends on.
-          *
-          * @param internalOntologyIri the IRI of the main internal project-specific ontology to be used in the XML import.
-          * @param userProfile         the profile of the user making the request.
-          * @return an [[XmlImportSchemaBundleV1]] for validating the import.
-          */
+         * Given the IRI of an internal project-specific ontology, generates an [[XmlImportSchemaBundleV1]] for validating
+         * XML imports for that ontology and any other ontologies it depends on.
+         *
+         * @param internalOntologyIri the IRI of the main internal project-specific ontology to be used in the XML import.
+         * @param userProfile         the profile of the user making the request.
+         * @return an [[XmlImportSchemaBundleV1]] for validating the import.
+         */
         def generateSchemasFromOntologies(internalOntologyIri: IRI, userProfile: UserADM): Future[XmlImportSchemaBundleV1] = {
             /**
-              * Called by the schema generation template to get the prefix label for an internal ontology
-              * entity IRI. The schema generation template gets these IRIs from resource cardinalities
-              * and property object class constraints, which we get from the ontology responder.
-              *
-              * @param internalEntityIri an internal ontology entity IRI.
-              * @return the prefix label that Knora uses to refer to the ontology.
-              */
+             * Called by the schema generation template to get the prefix label for an internal ontology
+             * entity IRI. The schema generation template gets these IRIs from resource cardinalities
+             * and property object class constraints, which we get from the ontology responder.
+             *
+             * @param internalEntityIri an internal ontology entity IRI.
+             * @return the prefix label that Knora uses to refer to the ontology.
+             */
             def getNamespacePrefixLabel(internalEntityIri: IRI): String = {
                 val prefixLabel = internalEntityIri.toSmartIri.getLongPrefixLabel
 
@@ -493,13 +495,13 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
             }
 
             /**
-              * Called by the schema generation template to get the entity name (i.e. the local name part) of an
-              * internal ontology entity IRI. The schema generation template gets these IRIs from resource cardinalities
-              * and property object class constraints, which we get from the ontology responder.
-              *
-              * @param internalEntityIri an internal ontology entity IRI.
-              * @return the local name of the entity.
-              */
+             * Called by the schema generation template to get the entity name (i.e. the local name part) of an
+             * internal ontology entity IRI. The schema generation template gets these IRIs from resource cardinalities
+             * and property object class constraints, which we get from the ontology responder.
+             *
+             * @param internalEntityIri an internal ontology entity IRI.
+             * @return the local name of the entity.
+             */
             def getEntityName(internalEntityIri: IRI): String = {
                 internalEntityIri.toSmartIri.getEntityName
             }
@@ -600,12 +602,12 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
 
         /**
-          * Generates a byte array representing a Zip file containing XML schemas for validating XML import data.
-          *
-          * @param internalOntologyIri the IRI of the main internal ontology for which data will be imported.
-          * @param userProfile         the profile of the user making the request.
-          * @return a byte array representing a Zip file containing XML schemas.
-          */
+         * Generates a byte array representing a Zip file containing XML schemas for validating XML import data.
+         *
+         * @param internalOntologyIri the IRI of the main internal ontology for which data will be imported.
+         * @param userProfile         the profile of the user making the request.
+         * @return a byte array representing a Zip file containing XML schemas.
+         */
         def generateSchemaZipFile(internalOntologyIri: IRI, userProfile: UserADM): Future[Array[Byte]] = {
             for {
                 // Generate a bundle of XML schemas.
@@ -625,14 +627,14 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
 
         /**
-          * Validates bulk import XML using project-specific XML schemas and the Knora XML import schema v1.
-          *
-          * @param xml              the XML to be validated.
-          * @param defaultNamespace the default namespace of the submitted XML. This should be the Knora XML import
-          *                         namespace corresponding to the main internal ontology used in the import.
-          * @param userADM          the profile of the user making the request.
-          * @return a `Future` containing `()` if successful, otherwise a failed future.
-          */
+         * Validates bulk import XML using project-specific XML schemas and the Knora XML import schema v1.
+         *
+         * @param xml              the XML to be validated.
+         * @param defaultNamespace the default namespace of the submitted XML. This should be the Knora XML import
+         *                         namespace corresponding to the main internal ontology used in the import.
+         * @param userADM          the profile of the user making the request.
+         * @return a `Future` containing `()` if successful, otherwise a failed future.
+         */
         def validateImportXml(xml: String, defaultNamespace: IRI, userADM: UserADM): Future[Unit] = {
             // Convert the default namespace of the submitted XML to an internal ontology IRI. This should be the
             // IRI of the main ontology used in the import.
@@ -670,12 +672,12 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
 
         /**
-          * Converts parsed import XML into a sequence of [[CreateResourceFromXmlImportRequestV1]] for each resource
-          * described in the XML.
-          *
-          * @param rootElement the root element of an XML document describing multiple resources to be created.
-          * @return Seq[CreateResourceFromXmlImportRequestV1] a collection of resource creation requests.
-          */
+         * Converts parsed import XML into a sequence of [[CreateResourceFromXmlImportRequestV1]] for each resource
+         * described in the XML.
+         *
+         * @param rootElement the root element of an XML document describing multiple resources to be created.
+         * @return Seq[CreateResourceFromXmlImportRequestV1] a collection of resource creation requests.
+         */
         def importXmlToCreateResourceRequests(rootElement: Elem): Seq[CreateResourceFromXmlImportRequestV1] = {
             rootElement.head.child
                 .filter(node => node.label != "#PCDATA")
@@ -791,12 +793,12 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
 
         /**
-          * Given an XML element representing a property value in an XML import, returns a [[CreateResourceValueV1]]
-          * describing the value to be created.
-          *
-          * @param node the XML element.
-          * @return a [[CreateResourceValueV1]] requesting the creation of the value described by the element.
-          */
+         * Given an XML element representing a property value in an XML import, returns a [[CreateResourceValueV1]]
+         * describing the value to be created.
+         *
+         * @param node the XML element.
+         * @return a [[CreateResourceValueV1]] requesting the creation of the value described by the element.
+         */
         def knoraDataTypeXml(node: Node): CreateResourceValueV1 = {
             val knoraType: Seq[Node] = node.attribute("knoraType").getOrElse(throw BadRequestException(s"Attribute 'knoraType' missing in element '${node.label}'"))
             val elementValue = node.text
@@ -1278,27 +1280,27 @@ class ResourcesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     }
 
     /**
-      * Represents an XML import schema corresponding to an ontology.
-      *
-      * @param namespaceInfo information about the schema's namespace.
-      * @param schemaXml     the XML text of the schema.
-      */
+     * Represents an XML import schema corresponding to an ontology.
+     *
+     * @param namespaceInfo information about the schema's namespace.
+     * @param schemaXml     the XML text of the schema.
+     */
     case class XmlImportSchemaV1(namespaceInfo: XmlImportNamespaceInfoV1, schemaXml: String)
 
     /**
-      * Represents a bundle of XML import schemas corresponding to ontologies.
-      *
-      * @param mainNamespace the XML namespace corresponding to the main ontology to be used in the XML import.
-      * @param schemas       a map of XML namespaces to schemas.
-      */
+     * Represents a bundle of XML import schemas corresponding to ontologies.
+     *
+     * @param mainNamespace the XML namespace corresponding to the main ontology to be used in the XML import.
+     * @param schemas       a map of XML namespaces to schemas.
+     */
     case class XmlImportSchemaBundleV1(mainNamespace: IRI, schemas: Map[IRI, XmlImportSchemaV1])
 
     /**
-      * An implementation of [[LSResourceResolver]] that resolves resources from a [[XmlImportSchemaBundleV1]].
-      * This is used to allow the XML schema validator to load additional schemas during XML import data validation.
-      *
-      * @param schemaBundle an [[XmlImportSchemaBundleV1]].
-      */
+     * An implementation of [[LSResourceResolver]] that resolves resources from a [[XmlImportSchemaBundleV1]].
+     * This is used to allow the XML schema validator to load additional schemas during XML import data validation.
+     *
+     * @param schemaBundle an [[XmlImportSchemaBundleV1]].
+     */
     class SchemaBundleResolver(schemaBundle: XmlImportSchemaBundleV1) extends LSResourceResolver {
         private val contents: Map[IRI, Array[Byte]] = schemaBundle.schemas.map {
             case (namespace, schema) => namespace -> schema.schemaXml.getBytes(StandardCharsets.UTF_8)

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/SearchRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/SearchRouteV1.scala
@@ -32,13 +32,13 @@ import scala.language.postfixOps
 // slash after path without following segment
 
 /**
-  * Provides a spray-routing function for API routes that deal with search.
-  */
+ * Provides a spray-routing function for API routes that deal with search.
+ */
 class SearchRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
     /**
-      * The default number of rows to show in search results.
-      */
+     * The default number of rows to show in search results.
+     */
     private val defaultShowNRows = 25
 
     def makeExtendedSearchRequestMessage(userADM: UserADM, reverseParams: Map[String, Seq[String]]): ExtendedSearchGetRequestV1 = {
@@ -180,7 +180,10 @@ class SearchRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         )
     }
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "search" /) {
             // in the original API, there is a slash after "search": "http://www.salsah.org/api/search/?searchtype=extended"
@@ -201,23 +204,23 @@ class SearchRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
                 }
             }
         } ~
-        path("v1" / "search" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
-            get {
-                requestContext => {
-                    val requestMessage = for {
-                        userADM <- getUserADM(requestContext)
-                        params: Map[String, String] = requestContext.request.uri.query().toMap
-                    } yield makeFulltextSearchRequestMessage(userADM, searchval, params)
+            path("v1" / "search" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
+                get {
+                    requestContext => {
+                        val requestMessage = for {
+                            userADM <- getUserADM(requestContext)
+                            params: Map[String, String] = requestContext.request.uri.query().toMap
+                        } yield makeFulltextSearchRequestMessage(userADM, searchval, params)
 
-                    RouteUtilV1.runJsonRouteWithFuture(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
+                        RouteUtilV1.runJsonRouteWithFuture(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                    }
                 }
             }
-        }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/StandoffRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/StandoffRouteV1.scala
@@ -25,7 +25,6 @@ import akka.http.scaladsl.model.Multipart
 import akka.http.scaladsl.model.Multipart.BodyPart
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
 import org.knora.webapi.BadRequestException
 import org.knora.webapi.messages.v1.responder.standoffmessages.RepresentationV1JsonProtocol.createMappingApiRequestV1Format
 import org.knora.webapi.messages.v1.responder.standoffmessages._
@@ -37,11 +36,14 @@ import scala.concurrent.duration._
 
 
 /**
-  * A route used to convert XML to standoff.
-  */
+ * A route used to convert XML to standoff.
+ */
 class StandoffRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "mapping") {
             post {
@@ -95,7 +97,7 @@ class StandoffRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) w
                             }
 
                             xml: String = allParts.getOrElse(XML_PART, throw BadRequestException(s"MultiPart POST request was sent without required '$XML_PART' part!")).toString
-                            
+
                         } yield CreateMappingRequestV1(
                             projectIri = stringFormatter.validateAndEscapeIri(standoffApiJSONRequest.project_id, throw BadRequestException("invalid project IRI")),
                             xml = xml,

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/UsersRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/UsersRouteV1.scala
@@ -29,14 +29,17 @@ import org.knora.webapi.messages.v1.responder.usermessages._
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV1}
 
 /**
-  * Provides a spray-routing function for API routes that deal with lists.
-  */
+ * Provides a spray-routing function for API routes that deal with lists.
+ */
 class UsersRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
     private val schemes = Array("http", "https")
     private val urlValidator = new UrlValidator(schemes)
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v1" / "users") {
             get {
@@ -55,11 +58,11 @@ class UsersRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with
                     )
             }
         } ~
-        path("v1" / "users" / Segment) { value =>
-            get {
-                /* return a single user identified by iri or email */
-                parameters("identifier" ? "iri") { (identifier: String) =>
-                    requestContext =>
+            path("v1" / "users" / Segment) { value =>
+                get {
+                    /* return a single user identified by iri or email */
+                    parameters("identifier" ? "iri") { (identifier: String) =>
+                        requestContext =>
 
                             /* check if email or iri was supplied */
                             val requestMessage = if (identifier == "email") {
@@ -80,77 +83,77 @@ class UsersRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with
                                 responderManager,
                                 log
                             )
+                    }
+                }
+            } ~
+            path("v1" / "users" / "projects" / Segment) { userIri =>
+                get {
+                    /* get user's project memberships */
+                    requestContext =>
+
+                        val requestMessage = for {
+                            userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
+                            checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                        } yield UserProjectMembershipsGetRequestV1(
+                            userIri = checkedUserIri,
+                            userProfileV1 = userProfile,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilV1.runJsonRouteWithFuture(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
+            } ~
+            path("v1" / "users" / "projects-admin" / Segment) { userIri =>
+                get {
+                    /* get user's project admin memberships */
+                    requestContext =>
+
+                        val requestMessage = for {
+                            userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
+                            checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                        } yield UserProjectAdminMembershipsGetRequestV1(
+                            userIri = checkedUserIri,
+                            userProfileV1 = userProfile,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilV1.runJsonRouteWithFuture(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
+            } ~
+            path("v1" / "users" / "groups" / Segment) { userIri =>
+                get {
+                    /* get user's group memberships */
+                    requestContext =>
+
+                        val requestMessage = for {
+                            userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
+                            checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
+                        } yield UserGroupMembershipsGetRequestV1(
+                            userIri = checkedUserIri,
+                            userProfileV1 = userProfile,
+                            apiRequestID = UUID.randomUUID()
+                        )
+
+                        RouteUtilV1.runJsonRouteWithFuture(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
                 }
             }
-        } ~
-        path("v1" / "users" / "projects" / Segment) { userIri =>
-            get {
-                /* get user's project memberships */
-                requestContext =>
-
-                    val requestMessage = for {
-                        userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
-                        checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    } yield UserProjectMembershipsGetRequestV1(
-                        userIri = checkedUserIri,
-                        userProfileV1 = userProfile,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilV1.runJsonRouteWithFuture(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("v1" / "users" / "projects-admin" / Segment) { userIri =>
-            get {
-                /* get user's project admin memberships */
-                requestContext =>
-
-                    val requestMessage = for {
-                        userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
-                        checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    } yield UserProjectAdminMembershipsGetRequestV1(
-                        userIri = checkedUserIri,
-                        userProfileV1 = userProfile,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilV1.runJsonRouteWithFuture(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        } ~
-        path("v1" / "users" / "groups" / Segment) { userIri =>
-            get {
-                /* get user's group memberships */
-                requestContext =>
-
-                    val requestMessage = for {
-                        userProfile <- getUserADM(requestContext).map(_.asUserProfileV1)
-                        checkedUserIri = stringFormatter.validateAndEscapeIri(userIri, throw BadRequestException(s"Invalid user IRI $userIri"))
-                    } yield UserGroupMembershipsGetRequestV1(
-                        userIri = checkedUserIri,
-                        userProfileV1 = userProfile,
-                        apiRequestID = UUID.randomUUID()
-                    )
-
-                    RouteUtilV1.runJsonRouteWithFuture(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
-        }
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v1/ValuesRouteV1.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v1/ValuesRouteV1.scala
@@ -22,14 +22,13 @@ package org.knora.webapi.routing.v1
 import java.io.File
 import java.util.UUID
 
-import akka.pattern._
 import akka.http.scaladsl.model.Multipart
 import akka.http.scaladsl.model.Multipart.BodyPart
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.FileInfo
 import akka.http.scaladsl.util.FastFuture
-import akka.stream.ActorMaterializer
+import akka.pattern._
 import akka.stream.scaladsl.FileIO
 import org.knora.webapi._
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
@@ -44,11 +43,14 @@ import org.knora.webapi.util.{DateUtilV1, FileUtil}
 import scala.concurrent.{Future, Promise}
 
 /**
-  * Provides a spray-routing function for API routes that deal with values.
-  */
+ * Provides a spray-routing function for API routes that deal with values.
+ */
 class ValuesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         def makeVersionHistoryRequestMessage(iris: Seq[IRI], userADM: UserADM): ValueVersionHistoryGetRequestV1 = {
             if (iris.length != 3) throw BadRequestException("Version history request requires resource IRI, property IRI, and current value IRI")
@@ -501,7 +503,6 @@ class ValuesRouteV1(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
                     requestContext =>
 
                         log.debug("/v1/filevalue - PUT - Multipart.FormData - Route")
-
 
 
                         val FILE_PART = "file"

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ListsRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ListsRouteV2.scala
@@ -45,7 +45,10 @@ class ListsRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with
     override val description: String = "An endpoint for working with Knora lists."
     override val functions: Seq[ClientFunction] = Seq.empty
 
-    def knoraApiPath: Route = getList ~ getNode
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = getList ~ getNode
 
     private def getList: Route = path("v2" / "lists" / Segment) { lIri: String =>
         get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ListsRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ListsRouteV2.scala
@@ -19,64 +19,114 @@
 
 package org.knora.webapi.routing.v2
 
-import akka.http.scaladsl.server.Directives.{get, path, _}
+import java.net.URLEncoder
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.stream.ActorMaterializer
 import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.listsmessages.{ListGetRequestV2, NodeGetRequestV2}
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV2}
+import org.knora.webapi.util.clientapi.{ClientEndpoint, ClientFunction, SourceCodeFileContent, SourceCodeFilePath}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * Provides a function for API routes that deal with lists and nodes.
-  */
-class ListsRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
+ * Provides a function for API routes that deal with lists and nodes.
+ */
+class ListsRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ClientEndpoint {
 
-    def knoraApiPath: Route = {
+    // Definitions for ClientEndpoint
+    override val name: String = "ListsEndpoint"
+    override val directoryName: String = "lists"
+    override val urlPath: String = "lists"
+    override val description: String = "An endpoint for working with Knora lists."
+    override val functions: Seq[ClientFunction] = Seq.empty
 
-        path("v2" / "lists" / Segment) { lIri: String =>
-            get {
+    def knoraApiPath: Route = getList ~ getNode
 
-                /* return a list (a graph with all list nodes) */
-                requestContext =>
-                    val requestMessage: Future[ListGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                        listIri: IRI = stringFormatter.validateAndEscapeIri(lIri, throw BadRequestException(s"Invalid list IRI: '$lIri'"))
-                    } yield ListGetRequestV2(listIri, requestingUser)
+    private def getList: Route = path("v2" / "lists" / Segment) { lIri: String =>
+        get {
+            /* return a list (a graph with all list nodes) */
+            requestContext =>
+                val requestMessage: Future[ListGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                    listIri: IRI = stringFormatter.validateAndEscapeIri(lIri, throw BadRequestException(s"Invalid list IRI: '$lIri'"))
+                } yield ListGetRequestV2(listIri, requestingUser)
 
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessage,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+        }
+    }
 
-            }
-        } ~
-        path("v2" / "node" / Segment) { nIri: String =>
-            get {
+    // Lists to return in test data.
+    private val testLists: Map[String, IRI] = Map(
+        "treelist" -> SharedTestDataADM.treeList,
+        "othertreelist" -> SharedTestDataADM.otherTreeList
+    )
 
-                /* return a list (a graph with all list nodes) */
-                requestContext =>
-                    val requestMessage: Future[NodeGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                        nodeIri: IRI = stringFormatter.validateAndEscapeIri(nIri, throw BadRequestException(s"Invalid list IRI: '$nIri'"))
-                    } yield NodeGetRequestV2(nodeIri, requestingUser)
+    private def getListTestResponses: Future[Set[SourceCodeFileContent]] = {
+        val responseFutures: Iterable[Future[SourceCodeFileContent]] = testLists.map {
+            case (filename, listIri) =>
+                val encodedListIri = URLEncoder.encode(listIri, "UTF-8")
 
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessage,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-            }
+                for {
+                    responseStr <- doTestDataRequest(Get(s"$baseApiUrl/v2/lists/$encodedListIri"))
+                } yield SourceCodeFileContent(
+                    filePath = SourceCodeFilePath.makeJsonPath(filename),
+                    text = responseStr
+                )
         }
 
+        Future.sequence(responseFutures).map(_.toSet)
+    }
+
+    private def getNode: Route = path("v2" / "node" / Segment) { nIri: String =>
+        get {
+            /* return a list node */
+            requestContext =>
+                val requestMessage: Future[NodeGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                    nodeIri: IRI = stringFormatter.validateAndEscapeIri(nIri, throw BadRequestException(s"Invalid list IRI: '$nIri'"))
+                } yield NodeGetRequestV2(nodeIri, requestingUser)
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+        }
+    }
+
+    private def getNodeTestResponse: Future[SourceCodeFileContent] = {
+        for {
+            responseStr <- doTestDataRequest(Get(s"$baseApiUrl/v2/node/${URLEncoder.encode(SharedTestDataADM.treeListNode, "UTF-8")}"))
+        } yield SourceCodeFileContent(
+            filePath = SourceCodeFilePath.makeJsonPath("listnode"),
+            text = responseStr
+        )
+    }
+
+
+    override def getTestData(implicit executionContext: ExecutionContext,
+                             actorSystem: ActorSystem,
+                             materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]] = {
+        for {
+            testLists <- getListTestResponses
+            testNode <- getNodeTestResponse
+        } yield testLists + testNode
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -19,605 +19,152 @@
 
 package org.knora.webapi.routing.v2
 
+import java.net.URLEncoder
 import java.util.UUID
 
+import akka.actor.ActorSystem
+import akka.http.scaladsl.client.RequestBuilding.Get
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{PathMatcher, Route}
+import akka.stream.ActorMaterializer
 import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.ontologymessages._
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV2}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.SmartIri
+import org.knora.webapi.util.clientapi.{ClientEndpoint, ClientFunction, SourceCodeFileContent, SourceCodeFilePath}
 import org.knora.webapi.util.jsonld.{JsonLDDocument, JsonLDUtil}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
+
+object OntologiesRouteV2 {
+    val OntologiesBasePath: PathMatcher[Unit] = PathMatcher("v2" / "ontologies")
+    val OntologiesBasePathString = "/v2/ontologies"
+}
 
 /**
-  * Provides a routing function for API v2 routes that deal with ontologies.
-  */
-class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
+ * Provides a routing function for API v2 routes that deal with ontologies.
+ */
+class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ClientEndpoint {
+
+    import OntologiesRouteV2._
+
+    // Definitions for ClientEndpoint
+    override val name: String = "OntologiesEndpoint"
+    override val directoryName: String = "ontologies"
+    override val urlPath: String = "ontologies"
+    override val description: String = "An endpoint for working with Knora ontologies."
+    override val functions: Seq[ClientFunction] = Seq.empty
+
     private val ALL_LANGUAGES = "allLanguages"
     private val LAST_MODIFICATION_DATE = "lastModificationDate"
 
-    def knoraApiPath: Route = {
+    def knoraApiPath: Route = dereferenceOntologyIri ~ getOntologyMetadata ~ updateOntologyMetadata ~ getOntologyMetadataForProjects ~
+        getOntology ~ createClass ~ updateClass ~ addCardinalities ~ replaceCardinalities ~ getClasses ~
+        deleteClass ~ createProperty ~ updateProperty ~ getProperties ~ deleteProperty ~ createOntology ~
+        deleteOntology
 
-        path("ontology" / Segments) { _: List[String] =>
-            get {
-                requestContext => {
-                    // This is the route used to dereference an actual ontology IRI. If the URL path looks like it
-                    // belongs to a built-in API ontology (which has to contain "knora-api"), prefix it with
-                    // http://api.knora.org to get the ontology IRI. Otherwise, if it looks like it belongs to a
-                    // project-specific API ontology, prefix it with settings.externalOntologyIriHostAndPort to get the
-                    // ontology IRI.
+    private def dereferenceOntologyIri: Route = path("ontology" / Segments) { _: List[String] =>
+        get {
+            requestContext => {
+                // This is the route used to dereference an actual ontology IRI. If the URL path looks like it
+                // belongs to a built-in API ontology (which has to contain "knora-api"), prefix it with
+                // http://api.knora.org to get the ontology IRI. Otherwise, if it looks like it belongs to a
+                // project-specific API ontology, prefix it with settings.externalOntologyIriHostAndPort to get the
+                // ontology IRI.
 
-                    val urlPath = requestContext.request.uri.path.toString
+                val urlPath = requestContext.request.uri.path.toString
 
-                    val requestedOntologyStr: IRI = if (stringFormatter.isBuiltInApiV2OntologyUrlPath(urlPath)) {
-                        OntologyConstants.KnoraApi.ApiOntologyHostname + urlPath
-                    } else if (stringFormatter.isProjectSpecificApiV2OntologyUrlPath(urlPath)) {
-                        "http://" + settings.externalOntologyIriHostAndPort + urlPath
-                    } else {
-                        throw BadRequestException(s"Invalid or unknown URL path for external ontology: $urlPath")
-                    }
-
-                    val requestedOntology = requestedOntologyStr.toSmartIriWithErr(throw BadRequestException(s"Invalid ontology IRI: $requestedOntologyStr"))
-
-                    val targetSchema = requestedOntology.getOntologySchema match {
-                        case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
-                        case _ => throw BadRequestException(s"Invalid ontology IRI: $requestedOntologyStr")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-                    val allLanguagesStr = params.get(ALL_LANGUAGES)
-                    val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
-
-                    val requestMessageFuture: Future[OntologyEntitiesGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield OntologyEntitiesGetRequestV2(
-                        ontologyIri = requestedOntology,
-                        allLanguages = allLanguages,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = targetSchema,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
+                val requestedOntologyStr: IRI = if (stringFormatter.isBuiltInApiV2OntologyUrlPath(urlPath)) {
+                    OntologyConstants.KnoraApi.ApiOntologyHostname + urlPath
+                } else if (stringFormatter.isProjectSpecificApiV2OntologyUrlPath(urlPath)) {
+                    "http://" + settings.externalOntologyIriHostAndPort + urlPath
+                } else {
+                    throw BadRequestException(s"Invalid or unknown URL path for external ontology: $urlPath")
                 }
+
+                val requestedOntology = requestedOntologyStr.toSmartIriWithErr(throw BadRequestException(s"Invalid ontology IRI: $requestedOntologyStr"))
+
+                val targetSchema = requestedOntology.getOntologySchema match {
+                    case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
+                    case _ => throw BadRequestException(s"Invalid ontology IRI: $requestedOntologyStr")
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+                val allLanguagesStr = params.get(ALL_LANGUAGES)
+                val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
+
+                val requestMessageFuture: Future[OntologyEntitiesGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield OntologyEntitiesGetRequestV2(
+                    ontologyIri = requestedOntology,
+                    allLanguages = allLanguages,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
             }
-        } ~ path("v2" / "ontologies" / "metadata") {
-            get {
+        }
+    }
+
+    private def getOntologyMetadata: Route = path(OntologiesBasePath / "metadata") {
+        get {
+            requestContext => {
+                val maybeProjectIri: Option[SmartIri] = RouteUtilV2.getProject(requestContext)
+
+                val requestMessageFuture: Future[OntologyMetadataGetByProjectRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield OntologyMetadataGetByProjectRequestV2(projectIris = maybeProjectIri.toSet, requestingUser = requestingUser)
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def getOntologyMetadataTestResponse: Future[SourceCodeFileContent] = {
+        for {
+            responseStr <- doTestDataRequest(Get(s"$baseApiUrl$OntologiesBasePathString/metadata"))
+        } yield SourceCodeFileContent(
+            filePath = SourceCodeFilePath.makeJsonPath("all-ontology-metadata"),
+            text = responseStr
+        )
+    }
+
+    private def updateOntologyMetadata: Route = path(OntologiesBasePath / "metadata") {
+        put {
+            entity(as[String]) { jsonRequest =>
                 requestContext => {
-                    val maybeProjectIri: Option[SmartIri] = RouteUtilV2.getProject(requestContext)
 
-                    val requestMessageFuture: Future[OntologyMetadataGetByProjectRequestV2] = for {
+                    val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+
+                    val requestMessageFuture: Future[ChangeOntologyMetadataRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
-                    } yield OntologyMetadataGetByProjectRequestV2(projectIris = maybeProjectIri.toSet, requestingUser = requestingUser)
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            } ~ put {
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-
-                        val requestMessageFuture: Future[ChangeOntologyMetadataRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestMessage: ChangeOntologyMetadataRequestV2 <- ChangeOntologyMetadataRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
+                        requestMessage: ChangeOntologyMetadataRequestV2 <- ChangeOntologyMetadataRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
                             responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            }
-        } ~ path("v2" / "ontologies" / "metadata" / Segments) { projectIris: List[IRI] =>
-            get {
-                requestContext => {
-
-                    val requestMessageFuture: Future[OntologyMetadataGetByProjectRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                        validatedProjectIris = projectIris.map(iri => iri.toSmartIriWithErr(throw BadRequestException(s"Invalid project IRI: $iri"))).toSet
-                    } yield OntologyMetadataGetByProjectRequestV2(projectIris = validatedProjectIris, requestingUser = requestingUser)
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "ontologies" / "allentities" / Segment) { externalOntologyIriStr: IRI =>
-            get {
-                requestContext => {
-                    val requestedOntologyIri = externalOntologyIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid ontology IRI: $externalOntologyIriStr"))
-
-                    val targetSchema = requestedOntologyIri.getOntologySchema match {
-                        case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
-                        case _ => throw BadRequestException(s"Invalid ontology IRI: $externalOntologyIriStr")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-                    val allLanguagesStr = params.get(ALL_LANGUAGES)
-                    val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
-
-                    val requestMessageFuture: Future[OntologyEntitiesGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield OntologyEntitiesGetRequestV2(
-                        ontologyIri = requestedOntologyIri,
-                        allLanguages = allLanguages,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = targetSchema,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "ontologies" / "classes") {
-            post {
-                // Create a new class.
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[CreateClassRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage: CreateClassRequestV2 <- CreateClassRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
+                            storeManager = storeManager,
                             settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                            log = log
                         )
-                    }
-                }
-            } ~ put {
-                // Change the labels or comments of a class.
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[ChangeClassLabelsOrCommentsRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage <- ChangeClassLabelsOrCommentsRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            }
-        } ~ path("v2" / "ontologies" / "cardinalities") {
-            post {
-                // Add cardinalities to a class.
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[AddCardinalitiesToClassRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage: AddCardinalitiesToClassRequestV2 <- AddCardinalitiesToClassRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            } ~ put {
-                // Change a class's cardinalities.
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[ChangeCardinalitiesRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage: ChangeCardinalitiesRequestV2 <- ChangeCardinalitiesRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            }
-        } ~ path("v2" / "ontologies" / "classes" / Segments) { externalResourceClassIris: List[IRI] =>
-            get {
-                requestContext => {
-
-                    val classesAndSchemas: Set[(SmartIri, ApiV2Schema)] = externalResourceClassIris.map {
-                        classIriStr: IRI =>
-                            val requestedClassIri: SmartIri = classIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid class IRI: $classIriStr"))
-
-                            if (!requestedClassIri.isKnoraApiV2EntityIri) {
-                                throw BadRequestException(s"Invalid class IRI: $classIriStr")
-                            }
-
-                            val schema = requestedClassIri.getOntologySchema match {
-                                case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
-                                case _ => throw BadRequestException(s"Invalid class IRI: $classIriStr")
-                            }
-
-                            (requestedClassIri, schema)
-                    }.toSet
-
-                    val (classesForResponder: Set[SmartIri], schemas: Set[ApiV2Schema]) = classesAndSchemas.unzip
-
-                    if (classesForResponder.map(_.getOntologyFromEntity).size != 1) {
-                        throw BadRequestException(s"Only one ontology may be queried per request")
-                    }
-
-                    // Decide which API schema to use for the response.
-                    val targetSchema = if (schemas.size == 1) {
-                        schemas.head
-                    } else {
-                        // The client requested different schemas.
-                        throw BadRequestException("The request refers to multiple API schemas")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-                    val allLanguagesStr = params.get(ALL_LANGUAGES)
-                    val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
-
-                    val requestMessageFuture: Future[ClassesGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield ClassesGetRequestV2(
-                        classIris = classesForResponder,
-                        allLanguages = allLanguages,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = targetSchema,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            } ~ delete {
-                requestContext => {
-
-                    val classIriStr = externalResourceClassIris match {
-                        case List(str) => str
-                        case _ => throw BadRequestException(s"Only one class can be deleted at a time")
-                    }
-
-                    val classIri = classIriStr.toSmartIri
-
-                    if (!classIri.getOntologySchema.contains(ApiV2Complex)) {
-                        throw BadRequestException(s"Invalid class IRI for request: $classIriStr")
-                    }
-
-                    val lastModificationDateStr = requestContext.request.uri.query().toMap.getOrElse(LAST_MODIFICATION_DATE, throw BadRequestException(s"Missing parameter: $LAST_MODIFICATION_DATE"))
-                    val lastModificationDate = stringFormatter.xsdDateTimeStampToInstant(lastModificationDateStr, throw BadRequestException(s"Invalid timestamp: $lastModificationDateStr"))
-
-                    val requestMessageFuture: Future[DeleteClassRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield DeleteClassRequestV2(
-                        classIri = classIri,
-                        lastModificationDate = lastModificationDate,
-                        apiRequestID = UUID.randomUUID,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "ontologies" / "properties") {
-            post {
-                // Create a new property.
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[CreatePropertyRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage: CreatePropertyRequestV2 <- CreatePropertyRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            } ~ put {
-                // Change the labels or comments of a property.
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[ChangePropertyLabelsOrCommentsRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage: ChangePropertyLabelsOrCommentsRequestV2 <- ChangePropertyLabelsOrCommentsRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            }
-        } ~ path("v2" / "ontologies" / "properties" / Segments) { externalPropertyIris: List[IRI] =>
-            get {
-                requestContext => {
-
-                    val propsAndSchemas: Set[(SmartIri, ApiV2Schema)] = externalPropertyIris.map {
-                        (propIriStr: IRI) =>
-                            val requestedPropIri: SmartIri = propIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid property IRI: $propIriStr"))
-
-                            if (!requestedPropIri.isKnoraApiV2EntityIri) {
-                                throw BadRequestException(s"Invalid property IRI: $propIriStr")
-                            }
-
-                            val schema = requestedPropIri.getOntologySchema match {
-                                case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
-                                case _ => throw BadRequestException(s"Invalid property IRI: $propIriStr")
-                            }
-
-                            (requestedPropIri, schema)
-                    }.toSet
-
-                    val (propsForResponder: Set[SmartIri], schemas: Set[ApiV2Schema]) = propsAndSchemas.unzip
-
-                    if (propsForResponder.map(_.getOntologyFromEntity).size != 1) {
-                        throw BadRequestException(s"Only one ontology may be queried per request")
-                    }
-
-                    // Decide which API schema to use for the response.
-                    val targetSchema = if (schemas.size == 1) {
-                        schemas.head
-                    } else {
-                        // The client requested different schemas.
-                        throw BadRequestException("The request refers to multiple API schemas")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-                    val allLanguagesStr = params.get(ALL_LANGUAGES)
-                    val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
-
-                    val requestMessageFuture: Future[PropertiesGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield PropertiesGetRequestV2(
-                        propertyIris = propsForResponder,
-                        allLanguages = allLanguages,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = targetSchema,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            } ~ delete {
-                requestContext => {
-
-                    val propertyIriStr = externalPropertyIris match {
-                        case List(str) => str
-                        case _ => throw BadRequestException(s"Only one property can be deleted at a time")
-                    }
-
-                    val propertyIri = propertyIriStr.toSmartIri
-
-                    if (!propertyIri.getOntologySchema.contains(ApiV2Complex)) {
-                        throw BadRequestException(s"Invalid property IRI for request: $propertyIri")
-                    }
-
-                    val lastModificationDateStr = requestContext.request.uri.query().toMap.getOrElse(LAST_MODIFICATION_DATE, throw BadRequestException(s"Missing parameter: $LAST_MODIFICATION_DATE"))
-                    val lastModificationDate = stringFormatter.xsdDateTimeStampToInstant(lastModificationDateStr, throw BadRequestException(s"Invalid timestamp: $lastModificationDateStr"))
-
-                    val requestMessageFuture: Future[DeletePropertyRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield DeletePropertyRequestV2(
-                        propertyIri = propertyIri,
-                        lastModificationDate = lastModificationDate,
-                        apiRequestID = UUID.randomUUID,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "ontologies") {
-            // Create a new, empty ontology.
-            post {
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-
-                        val requestMessageFuture: Future[CreateOntologyRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-                            requestMessage: CreateOntologyRequestV2 <- CreateOntologyRequestV2.fromJsonLD(
-                                jsonLDDocument = requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            }
-        } ~ path ("v2" / "ontologies" / Segment) { ontologyIriStr =>
-            delete {
-                requestContext => {
-
-                    val ontologyIri = ontologyIriStr.toSmartIri
-
-                    if (!ontologyIri.isKnoraOntologyIri || ontologyIri.isKnoraBuiltInDefinitionIri || !ontologyIri.getOntologySchema.contains(ApiV2Complex)) {
-                        throw BadRequestException(s"Invalid ontology IRI for request: $ontologyIri")
-                    }
-
-                    val lastModificationDateStr = requestContext.request.uri.query().toMap.getOrElse(LAST_MODIFICATION_DATE, throw BadRequestException(s"Missing parameter: $LAST_MODIFICATION_DATE"))
-                    val lastModificationDate = stringFormatter.xsdDateTimeStampToInstant(lastModificationDateStr, throw BadRequestException(s"Invalid timestamp: $lastModificationDateStr"))
-
-                    val requestMessageFuture: Future[DeleteOntologyRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield DeleteOntologyRequestV2(
-                        ontologyIri = ontologyIri,
-                        lastModificationDate = lastModificationDate,
-                        apiRequestID = UUID.randomUUID,
-                        requestingUser = requestingUser
-                    )
+                    } yield requestMessage
 
                     RouteUtilV2.runRdfRouteWithFuture(
                         requestMessageF = requestMessageFuture,
@@ -631,5 +178,569 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
                 }
             }
         }
+    }
+
+    private def getOntologyMetadataForProjects: Route = path(OntologiesBasePath / "metadata" / Segments) { projectIris: List[IRI] =>
+        get {
+            requestContext => {
+
+                val requestMessageFuture: Future[OntologyMetadataGetByProjectRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                    validatedProjectIris = projectIris.map(iri => iri.toSmartIriWithErr(throw BadRequestException(s"Invalid project IRI: $iri"))).toSet
+                } yield OntologyMetadataGetByProjectRequestV2(projectIris = validatedProjectIris, requestingUser = requestingUser)
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def getOntology: Route = path(OntologiesBasePath / "allentities" / Segment) { externalOntologyIriStr: IRI =>
+        get {
+            requestContext => {
+                val requestedOntologyIri = externalOntologyIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid ontology IRI: $externalOntologyIriStr"))
+
+                val targetSchema = requestedOntologyIri.getOntologySchema match {
+                    case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
+                    case _ => throw BadRequestException(s"Invalid ontology IRI: $externalOntologyIriStr")
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+                val allLanguagesStr = params.get(ALL_LANGUAGES)
+                val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
+
+                val requestMessageFuture: Future[OntologyEntitiesGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield OntologyEntitiesGetRequestV2(
+                    ontologyIri = requestedOntologyIri,
+                    allLanguages = allLanguages,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    // Ontologies to return in test data.
+    private val testOntologies: Map[String, IRI] = Map(
+        "knora-api-ontology" -> OntologyConstants.KnoraApiV2Complex.KnoraApiOntologyIri,
+        "anything-ontology" -> "http://0.0.0.0:3333/ontology/0001/anything/v2",
+        "minimal-ontology" -> "http://0.0.0.0:3333/ontology/0001/minimal/v2",
+        "incunabula-ontology" -> "http://0.0.0.0:3333/ontology/0803/incunabula/v2"
+    )
+
+    /**
+     * Provides JSON-LD responses to requests for values, for use in tests of generated client code.
+     */
+    private def getOntologyTestResponses: Future[Set[SourceCodeFileContent]] = {
+        val responseFutures: Iterable[Future[SourceCodeFileContent]] = testOntologies.map {
+            case (filename, ontologyIri) =>
+                val encodedOntologyIri = URLEncoder.encode(ontologyIri, "UTF-8")
+
+                for {
+                    responseStr <- doTestDataRequest(Get(s"$baseApiUrl$OntologiesBasePathString/allentities/$encodedOntologyIri"))
+                } yield SourceCodeFileContent(
+                    filePath = SourceCodeFilePath.makeJsonPath(filename),
+                    text = responseStr
+                )
+        }
+
+        Future.sequence(responseFutures).map(_.toSet)
+    }
+
+    private def createClass: Route = path(OntologiesBasePath / "classes") {
+        post {
+            // Create a new class.
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[CreateClassRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage: CreateClassRequestV2 <- CreateClassRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def updateClass: Route = path(OntologiesBasePath / "classes") {
+        put {
+            // Change the labels or comments of a class.
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[ChangeClassLabelsOrCommentsRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage <- ChangeClassLabelsOrCommentsRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def addCardinalities: Route = path(OntologiesBasePath / "cardinalities") {
+        post {
+            // Add cardinalities to a class.
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[AddCardinalitiesToClassRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage: AddCardinalitiesToClassRequestV2 <- AddCardinalitiesToClassRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def replaceCardinalities: Route = path(OntologiesBasePath / "cardinalities") {
+        put {
+            // Change a class's cardinalities.
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[ChangeCardinalitiesRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage: ChangeCardinalitiesRequestV2 <- ChangeCardinalitiesRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def getClasses: Route = path(OntologiesBasePath / "classes" / Segments) { externalResourceClassIris: List[IRI] =>
+        get {
+            requestContext => {
+
+                val classesAndSchemas: Set[(SmartIri, ApiV2Schema)] = externalResourceClassIris.map {
+                    classIriStr: IRI =>
+                        val requestedClassIri: SmartIri = classIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid class IRI: $classIriStr"))
+
+                        if (!requestedClassIri.isKnoraApiV2EntityIri) {
+                            throw BadRequestException(s"Invalid class IRI: $classIriStr")
+                        }
+
+                        val schema = requestedClassIri.getOntologySchema match {
+                            case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
+                            case _ => throw BadRequestException(s"Invalid class IRI: $classIriStr")
+                        }
+
+                        (requestedClassIri, schema)
+                }.toSet
+
+                val (classesForResponder: Set[SmartIri], schemas: Set[ApiV2Schema]) = classesAndSchemas.unzip
+
+                if (classesForResponder.map(_.getOntologyFromEntity).size != 1) {
+                    throw BadRequestException(s"Only one ontology may be queried per request")
+                }
+
+                // Decide which API schema to use for the response.
+                val targetSchema = if (schemas.size == 1) {
+                    schemas.head
+                } else {
+                    // The client requested different schemas.
+                    throw BadRequestException("The request refers to multiple API schemas")
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+                val allLanguagesStr = params.get(ALL_LANGUAGES)
+                val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
+
+                val requestMessageFuture: Future[ClassesGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield ClassesGetRequestV2(
+                    classIris = classesForResponder,
+                    allLanguages = allLanguages,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def deleteClass: Route = path(OntologiesBasePath / "classes" / Segments) { externalResourceClassIris: List[IRI] =>
+        delete {
+            requestContext => {
+
+                val classIriStr = externalResourceClassIris match {
+                    case List(str) => str
+                    case _ => throw BadRequestException(s"Only one class can be deleted at a time")
+                }
+
+                val classIri = classIriStr.toSmartIri
+
+                if (!classIri.getOntologySchema.contains(ApiV2Complex)) {
+                    throw BadRequestException(s"Invalid class IRI for request: $classIriStr")
+                }
+
+                val lastModificationDateStr = requestContext.request.uri.query().toMap.getOrElse(LAST_MODIFICATION_DATE, throw BadRequestException(s"Missing parameter: $LAST_MODIFICATION_DATE"))
+                val lastModificationDate = stringFormatter.xsdDateTimeStampToInstant(lastModificationDateStr, throw BadRequestException(s"Invalid timestamp: $lastModificationDateStr"))
+
+                val requestMessageFuture: Future[DeleteClassRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield DeleteClassRequestV2(
+                    classIri = classIri,
+                    lastModificationDate = lastModificationDate,
+                    apiRequestID = UUID.randomUUID,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def createProperty: Route = path(OntologiesBasePath / "properties") {
+        post {
+            // Create a new property.
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[CreatePropertyRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage: CreatePropertyRequestV2 <- CreatePropertyRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def updateProperty: Route = path(OntologiesBasePath / "properties") {
+        put {
+            // Change the labels or comments of a property.
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[ChangePropertyLabelsOrCommentsRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage: ChangePropertyLabelsOrCommentsRequestV2 <- ChangePropertyLabelsOrCommentsRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def getProperties: Route = path(OntologiesBasePath / "properties" / Segments) { externalPropertyIris: List[IRI] =>
+        get {
+            requestContext => {
+
+                val propsAndSchemas: Set[(SmartIri, ApiV2Schema)] = externalPropertyIris.map {
+                    propIriStr: IRI =>
+                        val requestedPropIri: SmartIri = propIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid property IRI: $propIriStr"))
+
+                        if (!requestedPropIri.isKnoraApiV2EntityIri) {
+                            throw BadRequestException(s"Invalid property IRI: $propIriStr")
+                        }
+
+                        val schema = requestedPropIri.getOntologySchema match {
+                            case Some(apiV2Schema: ApiV2Schema) => apiV2Schema
+                            case _ => throw BadRequestException(s"Invalid property IRI: $propIriStr")
+                        }
+
+                        (requestedPropIri, schema)
+                }.toSet
+
+                val (propsForResponder: Set[SmartIri], schemas: Set[ApiV2Schema]) = propsAndSchemas.unzip
+
+                if (propsForResponder.map(_.getOntologyFromEntity).size != 1) {
+                    throw BadRequestException(s"Only one ontology may be queried per request")
+                }
+
+                // Decide which API schema to use for the response.
+                val targetSchema = if (schemas.size == 1) {
+                    schemas.head
+                } else {
+                    // The client requested different schemas.
+                    throw BadRequestException("The request refers to multiple API schemas")
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+                val allLanguagesStr = params.get(ALL_LANGUAGES)
+                val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
+
+                val requestMessageFuture: Future[PropertiesGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield PropertiesGetRequestV2(
+                    propertyIris = propsForResponder,
+                    allLanguages = allLanguages,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def deleteProperty: Route = path(OntologiesBasePath / "properties" / Segments) { externalPropertyIris: List[IRI] =>
+        delete {
+            requestContext => {
+
+                val propertyIriStr = externalPropertyIris match {
+                    case List(str) => str
+                    case _ => throw BadRequestException(s"Only one property can be deleted at a time")
+                }
+
+                val propertyIri = propertyIriStr.toSmartIri
+
+                if (!propertyIri.getOntologySchema.contains(ApiV2Complex)) {
+                    throw BadRequestException(s"Invalid property IRI for request: $propertyIri")
+                }
+
+                val lastModificationDateStr = requestContext.request.uri.query().toMap.getOrElse(LAST_MODIFICATION_DATE, throw BadRequestException(s"Missing parameter: $LAST_MODIFICATION_DATE"))
+                val lastModificationDate = stringFormatter.xsdDateTimeStampToInstant(lastModificationDateStr, throw BadRequestException(s"Invalid timestamp: $lastModificationDateStr"))
+
+                val requestMessageFuture: Future[DeletePropertyRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield DeletePropertyRequestV2(
+                    propertyIri = propertyIri,
+                    lastModificationDate = lastModificationDate,
+                    apiRequestID = UUID.randomUUID,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def createOntology: Route = path(OntologiesBasePath) {
+        // Create a new, empty ontology.
+        post {
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+
+                    val requestMessageFuture: Future[CreateOntologyRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+                        requestMessage: CreateOntologyRequestV2 <- CreateOntologyRequestV2.fromJsonLD(
+                            jsonLDDocument = requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def deleteOntology: Route = path(OntologiesBasePath / Segment) { ontologyIriStr =>
+        delete {
+            requestContext => {
+
+                val ontologyIri = ontologyIriStr.toSmartIri
+
+                if (!ontologyIri.isKnoraOntologyIri || ontologyIri.isKnoraBuiltInDefinitionIri || !ontologyIri.getOntologySchema.contains(ApiV2Complex)) {
+                    throw BadRequestException(s"Invalid ontology IRI for request: $ontologyIri")
+                }
+
+                val lastModificationDateStr = requestContext.request.uri.query().toMap.getOrElse(LAST_MODIFICATION_DATE, throw BadRequestException(s"Missing parameter: $LAST_MODIFICATION_DATE"))
+                val lastModificationDate = stringFormatter.xsdDateTimeStampToInstant(lastModificationDateStr, throw BadRequestException(s"Invalid timestamp: $lastModificationDateStr"))
+
+                val requestMessageFuture: Future[DeleteOntologyRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield DeleteOntologyRequestV2(
+                    ontologyIri = ontologyIri,
+                    lastModificationDate = lastModificationDate,
+                    apiRequestID = UUID.randomUUID,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    override def getTestData(implicit executionContext: ExecutionContext,
+                             actorSystem: ActorSystem,
+                             materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]] = {
+        for {
+            ontologyResponses: Set[SourceCodeFileContent] <- getOntologyTestResponses
+            ontologyMetadataResponses: SourceCodeFileContent <- getOntologyMetadataTestResponse
+        } yield ontologyResponses + ontologyMetadataResponses
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -59,7 +59,10 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
     private val ALL_LANGUAGES = "allLanguages"
     private val LAST_MODIFICATION_DATE = "lastModificationDate"
 
-    def knoraApiPath: Route = dereferenceOntologyIri ~ getOntologyMetadata ~ updateOntologyMetadata ~ getOntologyMetadataForProjects ~
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = dereferenceOntologyIri ~ getOntologyMetadata ~ updateOntologyMetadata ~ getOntologyMetadataForProjects ~
         getOntology ~ createClass ~ updateClass ~ addCardinalities ~ replaceCardinalities ~ getClasses ~
         deleteClass ~ createProperty ~ updateProperty ~ getProperties ~ deleteProperty ~ createOntology ~
         deleteOntology

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -166,7 +166,7 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         val resourceIri = "http://rdfh.ch/0001/a-thing"
         val newLabel = "test thing with modified label"
         val newPermissions = "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:ProjectMember"
-        val newModificationDate = Instant.now.plus(java.time.Duration.ofDays(1))
+        val newModificationDate = Instant.parse("2019-12-12T10:23:25.836924Z")
 
         FastFuture.successful(
             Set(
@@ -534,7 +534,7 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
 
     private def deleteResourceTestRequestAndResponse: Future[Set[SourceCodeFileContent]] = {
         val resourceIri = "http://rdfh.ch/0001/a-thing"
-        val lastModificationDate = Instant.now
+        val lastModificationDate = Instant.parse("2019-12-12T10:23:25.836924Z")
 
         FastFuture.successful(
             Set(

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -22,22 +22,40 @@ package org.knora.webapi.routing.v2
 import java.time.Instant
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{PathMatcher, Route}
+import akka.stream.ActorMaterializer
 import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.resourcemessages._
 import org.knora.webapi.messages.v2.responder.searchmessages.SearchResourcesByProjectAndClassRequestV2
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV2}
 import org.knora.webapi.util.IriConversions._
+import org.knora.webapi.util.clientapi.{ClientEndpoint, ClientFunction, SourceCodeFileContent}
 import org.knora.webapi.util.jsonld.{JsonLDDocument, JsonLDUtil}
 import org.knora.webapi.util.{SmartIri, StringFormatter}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
+
+object ResourcesRouteV2 {
+    val ResourcesBasePath: PathMatcher[Unit] = PathMatcher("v2" / "resources")
+    val ResourcesBasePathString = "/v2/resources"
+}
 
 /**
-  * Provides a routing function for API v2 routes that deal with resources.
-  */
-class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
+ * Provides a routing function for API v2 routes that deal with resources.
+ */
+class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ClientEndpoint {
+
+    import ResourcesRouteV2._
+
+    // Definitions for ClientEndpoint
+    override val name: String = "ResourcesEndpoint"
+    override val directoryName: String = "resources"
+    override val urlPath: String = "resources"
+    override val description: String = "An endpoint for working with Knora resources."
+    override val functions: Seq[ClientFunction] = Seq.empty
+
     private val Text_Property = "textProperty"
     private val Mapping_Iri = "mappingIri"
     private val GravsearchTemplate_Iri = "gravsearchTemplateIri"
@@ -50,11 +68,11 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     private val Both = "both"
 
     /**
-      * Gets the Iri of the property that represents the text of the resource.
-      *
-      * @param params the GET parameters.
-      * @return the internal resource class, if any.
-      */
+     * Gets the Iri of the property that represents the text of the resource.
+     *
+     * @param params the GET parameters.
+     * @return the internal resource class, if any.
+     */
     private def getTextPropertyFromParams(params: Map[String, String]): SmartIri = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val textProperty = params.get(Text_Property)
@@ -74,11 +92,11 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     }
 
     /**
-      * Gets the Iri of the mapping to be used to convert standoff to XML.
-      *
-      * @param params the GET parameters.
-      * @return the internal resource class, if any.
-      */
+     * Gets the Iri of the mapping to be used to convert standoff to XML.
+     *
+     * @param params the GET parameters.
+     * @return the internal resource class, if any.
+     */
     private def getMappingIriFromParams(params: Map[String, String]): Option[IRI] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val mappingIriStr = params.get(Mapping_Iri)
@@ -92,11 +110,11 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     }
 
     /**
-      * Gets the Iri of Gravsearch template to be used to query for the resource's metadata.
-      *
-      * @param params the GET parameters.
-      * @return the internal resource class, if any.
-      */
+     * Gets the Iri of Gravsearch template to be used to query for the resource's metadata.
+     *
+     * @param params the GET parameters.
+     * @return the internal resource class, if any.
+     */
     private def getGravsearchTemplateIriFromParams(params: Map[String, String]): Option[IRI] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val gravsearchTemplateIriStr = params.get(GravsearchTemplate_Iri)
@@ -110,11 +128,11 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     }
 
     /**
-      * Gets the Iri of the XSL transformation to be used to convert the TEI header's metadata.
-      *
-      * @param params the GET parameters.
-      * @return the internal resource class, if any.
-      */
+     * Gets the Iri of the XSL transformation to be used to convert the TEI header's metadata.
+     *
+     * @param params the GET parameters.
+     * @return the internal resource class, if any.
+     */
     private def getHeaderXSLTIriFromParams(params: Map[String, String]): Option[IRI] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val headerXSLTIriStr = params.get(TEIHeader_XSLT_IRI)
@@ -127,138 +145,28 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
     }
 
+    def knoraApiPath: Route = createResource ~ updateResourceMetadata ~ getResourcesInProject ~
+        getResourceHistory ~ getResources ~ getResourcesPreview ~ getResourcesTei ~
+        getResourcesGraph ~ deleteResource ~ eraseResource
 
-    def knoraApiPath: Route = {
-
-        path("v2" / "resources") {
-            post {
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-                        val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-
-                        val requestMessageFuture: Future[CreateResourceRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestMessage: CreateResourceRequestV2 <- CreateResourceRequestV2.fromJsonLD(
-                                requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            } ~ put {
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-                        val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-
-                        val requestMessageFuture: Future[UpdateResourceMetadataRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestMessage: UpdateResourceMetadataRequestV2 <- UpdateResourceMetadataRequestV2.fromJsonLD(
-                                requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            } ~ get {
+    private def createResource: Route = path(ResourcesBasePath) {
+        post {
+            entity(as[String]) { jsonRequest =>
                 requestContext => {
-                    val projectIri: SmartIri = RouteUtilV2.getProject(requestContext).getOrElse(throw BadRequestException(s"This route requires the request header ${RouteUtilV2.PROJECT_HEADER}"))
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
+                    val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
 
-                    val resourceClassStr: String = params.getOrElse("resourceClass", throw BadRequestException(s"This route requires the parameter 'resourceClass'"))
-                    val resourceClass: SmartIri = resourceClassStr.toSmartIriWithErr(throw BadRequestException(s"Invalid resource class IRI: $resourceClassStr"))
-
-                    if (!(resourceClass.isKnoraApiV2EntityIri && resourceClass.getOntologySchema.contains(ApiV2Complex))) {
-                        throw BadRequestException(s"Invalid resource class IRI: $resourceClassStr")
-                    }
-
-                    val maybeOrderByPropertyStr: Option[String] = params.get("orderByProperty")
-                    val maybeOrderByProperty: Option[SmartIri] = maybeOrderByPropertyStr.map {
-                        orderByPropertyStr =>
-                            val orderByProperty = orderByPropertyStr.toSmartIriWithErr(throw BadRequestException(s"Invalid property IRI: $orderByPropertyStr"))
-
-                            if (!(orderByProperty.isKnoraApiV2EntityIri && orderByProperty.getOntologySchema.contains(ApiV2Complex))) {
-                                throw BadRequestException(s"Invalid property IRI: $orderByPropertyStr")
-                            }
-
-                            orderByProperty.toOntologySchema(ApiV2Complex)
-                    }
-
-                    val pageStr: String = params.getOrElse("page", throw BadRequestException(s"This route requires the parameter 'page'"))
-                    val page: Int = stringFormatter.validateInt(pageStr, throw BadRequestException(s"Invalid page number: $pageStr"))
-
-                    val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
-
-                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
-
-                    val requestMessageFuture: Future[SearchResourcesByProjectAndClassRequestV2] = for {
+                    val requestMessageFuture: Future[CreateResourceRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
-                    } yield SearchResourcesByProjectAndClassRequestV2(
-                        projectIri = projectIri,
-                        resourceClass = resourceClass.toOntologySchema(ApiV2Complex),
-                        orderByProperty = maybeOrderByProperty,
-                        page = page,
-                        targetSchema = targetSchema,
-                        schemaOptions = schemaOptions,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageFuture,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log,
-                        targetSchema = ApiV2Complex,
-                        schemaOptions = schemaOptions
-                    )
-                }
-            }
-        } ~ path("v2" / "resources" / "history" / Segment) { resourceIriStr: IRI =>
-            get {
-                requestContext => {
-                    val resourceIri = stringFormatter.validateAndEscapeIri(resourceIriStr, throw BadRequestException(s"Invalid resource IRI: $resourceIriStr"))
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-                    val startDate: Option[Instant] = params.get("startDate").map(dateStr => stringFormatter.xsdDateTimeStampToInstant(dateStr, throw BadRequestException(s"Invalid start date: $dateStr")))
-                    val endDate = params.get("endDate").map(dateStr => stringFormatter.xsdDateTimeStampToInstant(dateStr, throw BadRequestException(s"Invalid end date: $dateStr")))
-
-                    val requestMessageFuture: Future[ResourceVersionHistoryGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield ResourceVersionHistoryGetRequestV2(
-                        resourceIri = resourceIri,
-                        startDate = startDate,
-                        endDate = endDate,
-                        requestingUser = requestingUser
-                    )
+                        requestMessage: CreateResourceRequestV2 <- CreateResourceRequestV2.fromJsonLD(
+                            requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
 
                     RouteUtilV2.runRdfRouteWithFuture(
                         requestMessageF = requestMessageFuture,
@@ -269,235 +177,373 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
                         targetSchema = ApiV2Complex,
                         schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
                     )
-                }
-            }
-        } ~ path("v2" / "resources" / Segments) { resIris: Seq[String] =>
-            get {
-                requestContext => {
-
-                    if (resIris.size > settings.v2ResultsPerPage) throw BadRequestException(s"List of provided resource Iris exceeds limit of ${settings.v2ResultsPerPage}")
-
-                    val resourceIris: Seq[IRI] = resIris.map {
-                        resIri: String =>
-                            stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-
-                    // Was a version date provided?
-                    val versionDate: Option[Instant] = params.get("version").map {
-                        versionStr =>
-                            def errorFun: Nothing = throw BadRequestException(s"Invalid version date: $versionStr")
-
-                            // Yes. Try to parse it as an xsd:dateTimeStamp.
-                            try {
-                                stringFormatter.xsdDateTimeStampToInstant(versionStr, errorFun)
-                            } catch {
-                                // If that doesn't work, try to parse it as a Knora ARK timestamp.
-                                case _: Exception => stringFormatter.arkTimestampToInstant(versionStr, errorFun)
-                            }
-                    }
-
-                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
-                    val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
-
-                    val requestMessageFuture: Future[ResourcesGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield ResourcesGetRequestV2(
-                        resourceIris = resourceIris,
-                        versionDate = versionDate,
-                        targetSchema = targetSchema,
-                        schemaOptions = schemaOptions,
-                        requestingUser = requestingUser
-                    )
-
-                    // #use-requested-schema
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = targetSchema,
-                        schemaOptions = schemaOptions
-                    )
-                    // #use-requested-schema
-                }
-            }
-        } ~ path("v2" / "resourcespreview" / Segments) { resIris: Seq[String] =>
-            get {
-                requestContext => {
-                    if (resIris.size > settings.v2ResultsPerPage) throw BadRequestException(s"List of provided resource Iris exceeds limit of ${settings.v2ResultsPerPage}")
-
-                    val resourceIris: Seq[IRI] = resIris.map {
-                        resIri: String =>
-                            stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
-                    }
-
-                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
-
-                    val requestMessageFuture: Future[ResourcesPreviewGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield ResourcesPreviewGetRequestV2(resourceIris = resourceIris, targetSchema = targetSchema, requestingUser = requestingUser)
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = RouteUtilV2.getOntologySchema(requestContext),
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "tei" / Segment) { resIri: String =>
-            get {
-                requestContext => {
-
-                    val resourceIri: IRI = stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-
-                    // the the property that represents the text
-                    val textProperty: SmartIri = getTextPropertyFromParams(params)
-
-                    val mappingIri: Option[IRI] = getMappingIriFromParams(params)
-
-                    val gravsearchTemplateIri: Option[IRI] = getGravsearchTemplateIriFromParams(params)
-
-                    val headerXSLTIri = getHeaderXSLTIriFromParams(params)
-
-                    val requestMessageFuture: Future[ResourceTEIGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield ResourceTEIGetRequestV2(
-                        resourceIri = resourceIri,
-                        textProperty = textProperty,
-                        mappingIri = mappingIri,
-                        gravsearchTemplateIri = gravsearchTemplateIri,
-                        headerXSLTIri = headerXSLTIri,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runTEIXMLRoute(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = RouteUtilV2.getOntologySchema(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "graph" / Segment) { resIriStr: String =>
-            get {
-                requestContext => {
-                    val resourceIri: IRI = stringFormatter.validateAndEscapeIri(resIriStr, throw BadRequestException(s"Invalid resource IRI: <$resIriStr>"))
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-                    val depth: Int = params.get(Depth).map(_.toInt).getOrElse(settings.defaultGraphDepth)
-
-                    if (depth < 1) {
-                        throw BadRequestException(s"$Depth must be at least 1")
-                    }
-
-                    if (depth > settings.maxGraphDepth) {
-                        throw BadRequestException(s"$Depth cannot be greater than ${settings.maxGraphDepth}")
-                    }
-
-                    val direction: String = params.getOrElse(Direction, Outbound)
-                    val excludeProperty: Option[SmartIri] = params.get(ExcludeProperty).map(propIriStr => propIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid property IRI: <$propIriStr>")))
-
-                    val (inbound: Boolean, outbound: Boolean) = direction match {
-                        case Inbound => (true, false)
-                        case Outbound => (false, true)
-                        case Both => (true, true)
-                        case other => throw BadRequestException(s"Invalid direction: $other")
-                    }
-
-                    val requestMessageFuture: Future[GraphDataGetRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield GraphDataGetRequestV2(
-                        resourceIri = resourceIri,
-                        depth = depth,
-                        inbound = inbound,
-                        outbound = outbound,
-                        excludeProperty = excludeProperty,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessageFuture,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = RouteUtilV2.getOntologySchema(requestContext),
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path ("v2" / "resources" / "delete") {
-            post {
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-                        val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-
-                        val requestMessageFuture: Future[DeleteOrEraseResourceRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestMessage: DeleteOrEraseResourceRequestV2 <- DeleteOrEraseResourceRequestV2.fromJsonLD(
-                                requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
-                }
-            }
-        } ~ path ("v2" / "resources" / "erase") {
-            post {
-                entity(as[String]) { jsonRequest =>
-                    requestContext => {
-                        val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
-
-                        val requestMessageFuture: Future[DeleteOrEraseResourceRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                            requestMessage: DeleteOrEraseResourceRequestV2 <- DeleteOrEraseResourceRequestV2.fromJsonLD(
-                                requestDoc,
-                                apiRequestID = UUID.randomUUID,
-                                requestingUser = requestingUser,
-                                responderManager = responderManager,
-                                storeManager = storeManager,
-                                settings = settings,
-                                log = log
-                            )
-                        } yield requestMessage.copy(erase = true)
-
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessageFuture,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = ApiV2Complex,
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
                 }
             }
         }
+    }
+
+    private def updateResourceMetadata: Route = path(ResourcesBasePath) {
+        put {
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+                    val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+
+                    val requestMessageFuture: Future[UpdateResourceMetadataRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestMessage: UpdateResourceMetadataRequestV2 <- UpdateResourceMetadataRequestV2.fromJsonLD(
+                            requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def getResourcesInProject: Route = path(ResourcesBasePath) {
+        get {
+            requestContext => {
+                val projectIri: SmartIri = RouteUtilV2.getProject(requestContext).getOrElse(throw BadRequestException(s"This route requires the request header ${RouteUtilV2.PROJECT_HEADER}"))
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                val resourceClassStr: String = params.getOrElse("resourceClass", throw BadRequestException(s"This route requires the parameter 'resourceClass'"))
+                val resourceClass: SmartIri = resourceClassStr.toSmartIriWithErr(throw BadRequestException(s"Invalid resource class IRI: $resourceClassStr"))
+
+                if (!(resourceClass.isKnoraApiV2EntityIri && resourceClass.getOntologySchema.contains(ApiV2Complex))) {
+                    throw BadRequestException(s"Invalid resource class IRI: $resourceClassStr")
+                }
+
+                val maybeOrderByPropertyStr: Option[String] = params.get("orderByProperty")
+                val maybeOrderByProperty: Option[SmartIri] = maybeOrderByPropertyStr.map {
+                    orderByPropertyStr =>
+                        val orderByProperty = orderByPropertyStr.toSmartIriWithErr(throw BadRequestException(s"Invalid property IRI: $orderByPropertyStr"))
+
+                        if (!(orderByProperty.isKnoraApiV2EntityIri && orderByProperty.getOntologySchema.contains(ApiV2Complex))) {
+                            throw BadRequestException(s"Invalid property IRI: $orderByPropertyStr")
+                        }
+
+                        orderByProperty.toOntologySchema(ApiV2Complex)
+                }
+
+                val pageStr: String = params.getOrElse("page", throw BadRequestException(s"This route requires the parameter 'page'"))
+                val page: Int = stringFormatter.validateInt(pageStr, throw BadRequestException(s"Invalid page number: $pageStr"))
+
+                val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
+
+                val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
+                val requestMessageFuture: Future[SearchResourcesByProjectAndClassRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield SearchResourcesByProjectAndClassRequestV2(
+                    projectIri = projectIri,
+                    resourceClass = resourceClass.toOntologySchema(ApiV2Complex),
+                    orderByProperty = maybeOrderByProperty,
+                    page = page,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageFuture,
+                    requestContext,
+                    settings,
+                    responderManager,
+                    log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = schemaOptions
+                )
+            }
+        }
+    }
+
+    private def getResourceHistory: Route = path(ResourcesBasePath / "history" / Segment) { resourceIriStr: IRI =>
+        get {
+            requestContext => {
+                val resourceIri = stringFormatter.validateAndEscapeIri(resourceIriStr, throw BadRequestException(s"Invalid resource IRI: $resourceIriStr"))
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+                val startDate: Option[Instant] = params.get("startDate").map(dateStr => stringFormatter.xsdDateTimeStampToInstant(dateStr, throw BadRequestException(s"Invalid start date: $dateStr")))
+                val endDate = params.get("endDate").map(dateStr => stringFormatter.xsdDateTimeStampToInstant(dateStr, throw BadRequestException(s"Invalid end date: $dateStr")))
+
+                val requestMessageFuture: Future[ResourceVersionHistoryGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield ResourceVersionHistoryGetRequestV2(
+                    resourceIri = resourceIri,
+                    startDate = startDate,
+                    endDate = endDate,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = ApiV2Complex,
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def getResources: Route = path(ResourcesBasePath / Segments) { resIris: Seq[String] =>
+        get {
+            requestContext => {
+
+                if (resIris.size > settings.v2ResultsPerPage) throw BadRequestException(s"List of provided resource Iris exceeds limit of ${settings.v2ResultsPerPage}")
+
+                val resourceIris: Seq[IRI] = resIris.map {
+                    resIri: String =>
+                        stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                // Was a version date provided?
+                val versionDate: Option[Instant] = params.get("version").map {
+                    versionStr =>
+                        def errorFun: Nothing = throw BadRequestException(s"Invalid version date: $versionStr")
+
+                        // Yes. Try to parse it as an xsd:dateTimeStamp.
+                        try {
+                            stringFormatter.xsdDateTimeStampToInstant(versionStr, errorFun)
+                        } catch {
+                            // If that doesn't work, try to parse it as a Knora ARK timestamp.
+                            case _: Exception => stringFormatter.arkTimestampToInstant(versionStr, errorFun)
+                        }
+                }
+
+                val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+                val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
+
+                val requestMessageFuture: Future[ResourcesGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield ResourcesGetRequestV2(
+                    resourceIris = resourceIris,
+                    versionDate = versionDate,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions,
+                    requestingUser = requestingUser
+                )
+
+                // #use-requested-schema
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions
+                )
+                // #use-requested-schema
+            }
+        }
+    }
+
+    private def getResourcesPreview: Route = path("v2" / "resourcespreview" / Segments) { resIris: Seq[String] =>
+        get {
+            requestContext => {
+                if (resIris.size > settings.v2ResultsPerPage) throw BadRequestException(s"List of provided resource Iris exceeds limit of ${settings.v2ResultsPerPage}")
+
+                val resourceIris: Seq[IRI] = resIris.map {
+                    resIri: String =>
+                        stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
+                }
+
+                val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
+                val requestMessageFuture: Future[ResourcesPreviewGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield ResourcesPreviewGetRequestV2(resourceIris = resourceIris, targetSchema = targetSchema, requestingUser = requestingUser)
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext),
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def getResourcesTei: Route = path("v2" / "tei" / Segment) { resIri: String =>
+        get {
+            requestContext => {
+
+                val resourceIri: IRI = stringFormatter.validateAndEscapeIri(resIri, throw BadRequestException(s"Invalid resource IRI: <$resIri>"))
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                // the the property that represents the text
+                val textProperty: SmartIri = getTextPropertyFromParams(params)
+
+                val mappingIri: Option[IRI] = getMappingIriFromParams(params)
+
+                val gravsearchTemplateIri: Option[IRI] = getGravsearchTemplateIriFromParams(params)
+
+                val headerXSLTIri = getHeaderXSLTIriFromParams(params)
+
+                val requestMessageFuture: Future[ResourceTEIGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield ResourceTEIGetRequestV2(
+                    resourceIri = resourceIri,
+                    textProperty = textProperty,
+                    mappingIri = mappingIri,
+                    gravsearchTemplateIri = gravsearchTemplateIri,
+                    headerXSLTIri = headerXSLTIri,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runTEIXMLRoute(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext)
+                )
+            }
+        }
+    }
+
+    private def getResourcesGraph: Route = path("v2" / "graph" / Segment) { resIriStr: String =>
+        get {
+            requestContext => {
+                val resourceIri: IRI = stringFormatter.validateAndEscapeIri(resIriStr, throw BadRequestException(s"Invalid resource IRI: <$resIriStr>"))
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+                val depth: Int = params.get(Depth).map(_.toInt).getOrElse(settings.defaultGraphDepth)
+
+                if (depth < 1) {
+                    throw BadRequestException(s"$Depth must be at least 1")
+                }
+
+                if (depth > settings.maxGraphDepth) {
+                    throw BadRequestException(s"$Depth cannot be greater than ${settings.maxGraphDepth}")
+                }
+
+                val direction: String = params.getOrElse(Direction, Outbound)
+                val excludeProperty: Option[SmartIri] = params.get(ExcludeProperty).map(propIriStr => propIriStr.toSmartIriWithErr(throw BadRequestException(s"Invalid property IRI: <$propIriStr>")))
+
+                val (inbound: Boolean, outbound: Boolean) = direction match {
+                    case Inbound => (true, false)
+                    case Outbound => (false, true)
+                    case Both => (true, true)
+                    case other => throw BadRequestException(s"Invalid direction: $other")
+                }
+
+                val requestMessageFuture: Future[GraphDataGetRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield GraphDataGetRequestV2(
+                    resourceIri = resourceIri,
+                    depth = depth,
+                    inbound = inbound,
+                    outbound = outbound,
+                    excludeProperty = excludeProperty,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessageFuture,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext),
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def deleteResource: Route = path(ResourcesBasePath / "delete") {
+        post {
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+                    val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+
+                    val requestMessageFuture: Future[DeleteOrEraseResourceRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestMessage: DeleteOrEraseResourceRequestV2 <- DeleteOrEraseResourceRequestV2.fromJsonLD(
+                            requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    private def eraseResource: Route = path(ResourcesBasePath / "erase") {
+        post {
+            entity(as[String]) { jsonRequest =>
+                requestContext => {
+                    val requestDoc: JsonLDDocument = JsonLDUtil.parseJsonLD(jsonRequest)
+
+                    val requestMessageFuture: Future[DeleteOrEraseResourceRequestV2] = for {
+                        requestingUser <- getUserADM(requestContext)
+                        requestMessage: DeleteOrEraseResourceRequestV2 <- DeleteOrEraseResourceRequestV2.fromJsonLD(
+                            requestDoc,
+                            apiRequestID = UUID.randomUUID,
+                            requestingUser = requestingUser,
+                            responderManager = responderManager,
+                            storeManager = storeManager,
+                            settings = settings,
+                            log = log
+                        )
+                    } yield requestMessage.copy(erase = true)
+
+                    RouteUtilV2.runRdfRouteWithFuture(
+                        requestMessageF = requestMessageFuture,
+                        requestContext = requestContext,
+                        settings = settings,
+                        responderManager = responderManager,
+                        log = log,
+                        targetSchema = ApiV2Complex,
+                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                    )
+                }
+            }
+        }
+    }
+
+    override def getTestData(implicit executionContext: ExecutionContext, actorSystem: ActorSystem, materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]] = {
+        for {
+            foo <- Future.successful(???)
+        } yield foo
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -147,7 +147,10 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
     }
 
-    def knoraApiPath: Route = createResource ~ updateResourceMetadata ~ getResourcesInProject ~
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = createResource ~ updateResourceMetadata ~ getResourcesInProject ~
         getResourceHistory ~ getResources ~ getResourcesPreview ~ getResourcesTei ~
         getResourcesGraph ~ deleteResource ~ eraseResource
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -374,6 +374,15 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         }
     }
 
+    private def getResourcesPreviewTestResponse: Future[SourceCodeFileContent] = {
+        for {
+            responseStr <- doTestDataRequest(Get(s"${baseApiUrl}resourcespreview/${SharedTestDataADM.AThing.iriEncoded}"))
+        } yield SourceCodeFileContent(
+            filePath = SourceCodeFilePath.makeJsonPath("resource-preview"),
+            text = responseStr
+        )
+    }
+
     private def getResourcesTei: Route = path("v2" / "tei" / Segment) { resIri: String =>
         get {
             requestContext => {
@@ -575,11 +584,13 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
         for {
             getResponses <- getResourceTestResponses
             createRequests <- createResourceTestRequests
+            previewResponse <- getResourcesPreviewTestResponse
             graphResponse <- getResourceGraphTestResponse
             metadataRequest <- updateResourceMetadataTestRequest
             deleteRequest <- deleteResourceTestRequest
             eraseRequest <- eraseResourceTestRequest
-        } yield getResponses ++ createRequests + graphResponse + metadataRequest + deleteRequest + eraseRequest
+        } yield getResponses ++ createRequests + previewResponse + graphResponse + metadataRequest +
+            deleteRequest + eraseRequest
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ResourcesRouteV2.scala
@@ -376,7 +376,7 @@ class ResourcesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
 
     private def getResourcesPreviewTestResponse: Future[SourceCodeFileContent] = {
         for {
-            responseStr <- doTestDataRequest(Get(s"${baseApiUrl}resourcespreview/${SharedTestDataADM.AThing.iriEncoded}"))
+            responseStr <- doTestDataRequest(Get(s"$baseApiUrl/resourcespreview/${SharedTestDataADM.AThing.iriEncoded}"))
         } yield SourceCodeFileContent(
             filePath = SourceCodeFilePath.makeJsonPath("resource-preview"),
             text = responseStr

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -40,6 +40,7 @@ import scala.concurrent.{ExecutionContext, Future}
  * Provides a function for API routes that deal with search.
  */
 class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ClientEndpoint {
+
     // Definitions for ClientEndpoint
     override val name: String = "SearchEndpoint"
     override val directoryName: String = "search"

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -53,7 +53,10 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     private val OFFSET = "offset"
     private val LIMIT_TO_STANDOFF_CLASS = "limitToStandoffClass"
 
-    def knoraApiPath: Route = fullTextSearchCount ~ fullTextSearch ~ gravsearchCountGet ~ gravsearchCountPost ~
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = fullTextSearchCount ~ fullTextSearch ~ gravsearchCountGet ~ gravsearchCountPost ~
         gravsearchGet ~ gravsearchPost ~ searchByLabelCount ~ searchByLabel
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/SearchRouteV2.scala
@@ -19,32 +19,48 @@
 
 package org.knora.webapi.routing.v2
 
+import akka.actor.ActorSystem
+import akka.http.scaladsl.client.RequestBuilding._
+import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.stream.ActorMaterializer
 import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.searchmessages._
+import org.knora.webapi.responders.v2.search.SparqlQueryConstants
 import org.knora.webapi.responders.v2.search.gravsearch.GravsearchParser
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV2}
 import org.knora.webapi.util.IriConversions._
+import org.knora.webapi.util.clientapi.{ClientEndpoint, ClientFunction, SourceCodeFileContent, SourceCodeFilePath}
 import org.knora.webapi.util.{SmartIri, StringFormatter}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * Provides a function for API routes that deal with search.
-  */
-class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
+ * Provides a function for API routes that deal with search.
+ */
+class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ClientEndpoint {
+    // Definitions for ClientEndpoint
+    override val name: String = "SearchEndpoint"
+    override val directoryName: String = "search"
+    override val urlPath: String = "search"
+    override val description: String = "An endpoint for searching data in Knora."
+    override val functions: Seq[ClientFunction] = Seq.empty
+
     private val LIMIT_TO_PROJECT = "limitToProject"
     private val LIMIT_TO_RESOURCE_CLASS = "limitToResourceClass"
     private val OFFSET = "offset"
     private val LIMIT_TO_STANDOFF_CLASS = "limitToStandoffClass"
 
+    def knoraApiPath: Route = fullTextSearchCount ~ fullTextSearch ~ gravsearchCountGet ~ gravsearchCountPost ~
+        gravsearchGet ~ gravsearchPost ~ searchByLabelCount ~ searchByLabel
+
     /**
-      * Gets the requested offset. Returns zero if no offset is indicated.
-      *
-      * @param params the GET parameters.
-      * @return the offset to be used for paging.
-      */
+     * Gets the requested offset. Returns zero if no offset is indicated.
+     *
+     * @param params the GET parameters.
+     * @return the offset to be used for paging.
+     */
     private def getOffsetFromParams(params: Map[String, String]): Int = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val offsetStr = params.get(OFFSET)
@@ -64,11 +80,11 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     /**
-      * Gets the the project the search should be restricted to, if any.
-      *
-      * @param params the GET parameters.
-      * @return the project Iri, if any.
-      */
+     * Gets the the project the search should be restricted to, if any.
+     *
+     * @param params the GET parameters.
+     * @return the project Iri, if any.
+     */
     private def getProjectFromParams(params: Map[String, String]): Option[IRI] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val limitToProjectIriStr = params.get(LIMIT_TO_PROJECT)
@@ -89,11 +105,11 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     /**
-      * Gets the resource class the search should be restricted to, if any.
-      *
-      * @param params the GET parameters.
-      * @return the internal resource class, if any.
-      */
+     * Gets the resource class the search should be restricted to, if any.
+     *
+     * @param params the GET parameters.
+     * @return the internal resource class, if any.
+     */
     private def getResourceClassFromParams(params: Map[String, String]): Option[SmartIri] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val limitToResourceClassIriStr = params.get(LIMIT_TO_RESOURCE_CLASS)
@@ -113,11 +129,11 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     /**
-      * Gets the standoff class the search should be restricted to.
-      *
-      * @param params the GET parameters.
-      * @return the internal standoff class, if any.
-      */
+     * Gets the standoff class the search should be restricted to.
+     *
+     * @param params the GET parameters.
+     * @return the internal standoff class, if any.
+     */
     private def getStandoffClass(params: Map[String, String]): Option[SmartIri] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
         val limitToStandoffClassIriStr: Option[String] = params.get(LIMIT_TO_STANDOFF_CLASS)
@@ -136,120 +152,120 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
         }
     }
 
-    def knoraApiPath: Route = {
+    private def fullTextSearchCount: Route = path("v2" / "search" / "count" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
+        get {
+            requestContext =>
+                val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
 
-        path("v2" / "search" / "count" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
-            get {
-                requestContext =>
-
-                    val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
-
-                    if (searchString.length < settings.searchValueMinLength) {
-                        throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-
-                    val limitToProject: Option[IRI] = getProjectFromParams(params)
-
-                    val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
-
-                    val limitToStandoffClass: Option[SmartIri] = getStandoffClass(params)
-
-                    val requestMessage: Future[FullTextSearchCountRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield FullTextSearchCountRequestV2(
-                        searchValue = searchString,
-                        limitToProject = limitToProject,
-                        limitToResourceClass = limitToResourceClass,
-                        limitToStandoffClass = limitToStandoffClass,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessage,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = RouteUtilV2.getOntologySchema(requestContext),
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-            }
-        } ~ path("v2" / "search" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
-            get {
-                requestContext => {
-
-                    val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
-
-                    if (searchString.length < settings.searchValueMinLength) {
-                        throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-
-                    val offset = getOffsetFromParams(params)
-
-                    val limitToProject: Option[IRI] = getProjectFromParams(params)
-
-                    val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
-
-                    val limitToStandoffClass: Option[SmartIri] = getStandoffClass(params)
-
-                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
-                    val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
-
-                    val requestMessage: Future[FulltextSearchRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield FulltextSearchRequestV2(
-                        searchValue = searchString,
-                        offset = offset,
-                        limitToProject = limitToProject,
-                        limitToResourceClass = limitToResourceClass,
-                        limitToStandoffClass,
-                        requestingUser = requestingUser,
-                        targetSchema = targetSchema,
-                        schemaOptions = schemaOptions
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessage,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = targetSchema,
-                        schemaOptions = schemaOptions
-                    )
+                if (searchString.length < settings.searchValueMinLength) {
+                    throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
                 }
-            }
-        } ~ path("v2" / "searchextended" / "count") {
-            post {
-                entity(as[String]) { gravsearchQuery =>
-                    requestContext => {
-                        val constructQuery = GravsearchParser.parseQuery(gravsearchQuery)
-                        val requestMessage: Future[GravsearchCountRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                        } yield GravsearchCountRequestV2(constructQuery = constructQuery, requestingUser = requestingUser)
 
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessage,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = RouteUtilV2.getOntologySchema(requestContext),
-                            schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                        )
-                    }
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                val limitToProject: Option[IRI] = getProjectFromParams(params)
+
+                val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
+
+                val limitToStandoffClass: Option[SmartIri] = getStandoffClass(params)
+
+                val requestMessage: Future[FullTextSearchCountRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield FullTextSearchCountRequestV2(
+                    searchValue = searchString,
+                    limitToProject = limitToProject,
+                    limitToResourceClass = limitToResourceClass,
+                    limitToStandoffClass = limitToStandoffClass,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext),
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+        }
+    }
+
+    private def fullTextSearch: Route = path("v2" / "search" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
+        get {
+            requestContext => {
+                val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
+
+                if (searchString.length < settings.searchValueMinLength) {
+                    throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
                 }
-            }
-        } ~ path("v2" / "searchextended" / "count" / Segment) { gravsearchQuery => // Segment is a URL encoded string representing a Gravsearch query
-            get {
 
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                val offset = getOffsetFromParams(params)
+
+                val limitToProject: Option[IRI] = getProjectFromParams(params)
+
+                val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
+
+                val limitToStandoffClass: Option[SmartIri] = getStandoffClass(params)
+
+                val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+                val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
+
+                val requestMessage: Future[FulltextSearchRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield FulltextSearchRequestV2(
+                    searchValue = searchString,
+                    offset = offset,
+                    limitToProject = limitToProject,
+                    limitToResourceClass = limitToResourceClass,
+                    limitToStandoffClass,
+                    requestingUser = requestingUser,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions
+                )
+            }
+        }
+    }
+
+    private def gravsearchCountGet: Route = path("v2" / "searchextended" / "count" / Segment) { gravsearchQuery => // Segment is a URL encoded string representing a Gravsearch query
+        get {
+            requestContext => {
+                val constructQuery = GravsearchParser.parseQuery(gravsearchQuery)
+
+                val requestMessage: Future[GravsearchCountRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield GravsearchCountRequestV2(constructQuery = constructQuery, requestingUser = requestingUser)
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext),
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def gravsearchCountPost: Route = path("v2" / "searchextended" / "count") {
+        post {
+            entity(as[String]) { gravsearchQuery =>
                 requestContext => {
                     val constructQuery = GravsearchParser.parseQuery(gravsearchQuery)
-
                     val requestMessage: Future[GravsearchCountRequestV2] = for {
                         requestingUser <- getUserADM(requestContext)
                     } yield GravsearchCountRequestV2(constructQuery = constructQuery, requestingUser = requestingUser)
@@ -265,40 +281,43 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
                     )
                 }
             }
-        } ~ path("v2" / "searchextended") {
-            post {
-                entity(as[String]) { gravsearchQuery =>
-                    requestContext => {
-                        val constructQuery = GravsearchParser.parseQuery(gravsearchQuery)
-                        val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
-                        val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
+        }
+    }
 
-                        val requestMessage: Future[GravsearchRequestV2] = for {
-                            requestingUser <- getUserADM(requestContext)
-                        } yield GravsearchRequestV2(
-                            constructQuery = constructQuery,
-                            targetSchema = targetSchema,
-                            schemaOptions = schemaOptions,
-                            requestingUser = requestingUser
-                        )
+    private def gravsearchGet: Route = path("v2" / "searchextended" / Segment) { sparql => // Segment is a URL encoded string representing a Gravsearch query
+        get {
+            requestContext => {
+                val constructQuery = GravsearchParser.parseQuery(sparql)
+                val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+                val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
 
-                        RouteUtilV2.runRdfRouteWithFuture(
-                            requestMessageF = requestMessage,
-                            requestContext = requestContext,
-                            settings = settings,
-                            responderManager = responderManager,
-                            log = log,
-                            targetSchema = targetSchema,
-                            schemaOptions = schemaOptions
-                        )
-                    }
-                }
+                val requestMessage: Future[GravsearchRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield GravsearchRequestV2(
+                    constructQuery = constructQuery,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = targetSchema,
+                    schemaOptions = schemaOptions
+                )
             }
-        } ~ path("v2" / "searchextended" / Segment) { sparql => // Segment is a URL encoded string representing a Gravsearch query
-            get {
+        }
+    }
 
+    private def gravsearchPost: Route = path("v2" / "searchextended") {
+        post {
+            entity(as[String]) { gravsearchQuery =>
                 requestContext => {
-                    val constructQuery = GravsearchParser.parseQuery(sparql)
+                    val constructQuery = GravsearchParser.parseQuery(gravsearchQuery)
                     val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
                     val schemaOptions: Set[SchemaOption] = RouteUtilV2.getSchemaOptions(requestContext)
 
@@ -321,91 +340,114 @@ class SearchRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
                         schemaOptions = schemaOptions
                     )
                 }
-
             }
-
-
-        } ~ path("v2" / "searchbylabel" / "count" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
-            get {
-                requestContext => {
-
-                    val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
-
-                    if (searchString.length < settings.searchValueMinLength) {
-                        throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-
-                    val limitToProject: Option[IRI] = getProjectFromParams(params)
-
-                    val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
-
-                    val requestMessage: Future[SearchResourceByLabelCountRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield SearchResourceByLabelCountRequestV2(
-                        searchValue = searchString,
-                        limitToProject = limitToProject,
-                        limitToResourceClass = limitToResourceClass,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessage,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = RouteUtilV2.getOntologySchema(requestContext),
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-        } ~ path("v2" / "searchbylabel" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
-            get {
-                requestContext => {
-
-                    val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
-
-                    if (searchString.length < settings.searchValueMinLength) {
-                        throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
-                    }
-
-                    val params: Map[String, String] = requestContext.request.uri.query().toMap
-
-                    val offset = getOffsetFromParams(params)
-
-                    val limitToProject: Option[IRI] = getProjectFromParams(params)
-
-                    val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
-
-                    val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
-
-                    val requestMessage: Future[SearchResourceByLabelRequestV2] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield SearchResourceByLabelRequestV2(
-                        searchValue = searchString,
-                        offset = offset,
-                        limitToProject = limitToProject,
-                        limitToResourceClass = limitToResourceClass,
-                        targetSchema = targetSchema,
-                        requestingUser = requestingUser
-                    )
-
-                    RouteUtilV2.runRdfRouteWithFuture(
-                        requestMessageF = requestMessage,
-                        requestContext = requestContext,
-                        settings = settings,
-                        responderManager = responderManager,
-                        log = log,
-                        targetSchema = RouteUtilV2.getOntologySchema(requestContext),
-                        schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
-                    )
-                }
-            }
-
         }
     }
 
+    // Search results to return in test data.
+    private val testSearches: Map[String, IRI] = Map(
+        "things" -> SharedTestDataADM.gravsearchComplexThingSmallerThanDecimal,
+        "regions" -> SharedTestDataADM.gravsearchComplexRegionsForPage
+    )
 
+    private def getSearchTestResponses: Future[Set[SourceCodeFileContent]] = {
+        val responseFutures: Iterable[Future[SourceCodeFileContent]] = testSearches.map {
+            case (filename, search) =>
+                for {
+                    responseStr <- doTestDataRequest(Post(s"$baseApiUrl/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, search)))
+                } yield SourceCodeFileContent(
+                    filePath = SourceCodeFilePath.makeJsonPath(filename),
+                    text = responseStr
+                )
+        }
+
+        Future.sequence(responseFutures).map(_.toSet)
+    }
+
+    private def searchByLabelCount: Route = path("v2" / "searchbylabel" / "count" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
+        get {
+            requestContext => {
+
+                val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
+
+                if (searchString.length < settings.searchValueMinLength) {
+                    throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                val limitToProject: Option[IRI] = getProjectFromParams(params)
+
+                val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
+
+                val requestMessage: Future[SearchResourceByLabelCountRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield SearchResourceByLabelCountRequestV2(
+                    searchValue = searchString,
+                    limitToProject = limitToProject,
+                    limitToResourceClass = limitToResourceClass,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext),
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    private def searchByLabel: Route = path("v2" / "searchbylabel" / Segment) { searchval => // TODO: if a space is encoded as a "+", this is not converted back to a space
+        get {
+            requestContext => {
+                val searchString = stringFormatter.toSparqlEncodedString(searchval, throw BadRequestException(s"Invalid search string: '$searchval'"))
+
+                if (searchString.length < settings.searchValueMinLength) {
+                    throw BadRequestException(s"A search value is expected to have at least length of ${settings.searchValueMinLength}, but '$searchString' given of length ${searchString.length}.")
+                }
+
+                val params: Map[String, String] = requestContext.request.uri.query().toMap
+
+                val offset = getOffsetFromParams(params)
+
+                val limitToProject: Option[IRI] = getProjectFromParams(params)
+
+                val limitToResourceClass: Option[SmartIri] = getResourceClassFromParams(params)
+
+                val targetSchema: ApiV2Schema = RouteUtilV2.getOntologySchema(requestContext)
+
+                val requestMessage: Future[SearchResourceByLabelRequestV2] = for {
+                    requestingUser <- getUserADM(requestContext)
+                } yield SearchResourceByLabelRequestV2(
+                    searchValue = searchString,
+                    offset = offset,
+                    limitToProject = limitToProject,
+                    limitToResourceClass = limitToResourceClass,
+                    targetSchema = targetSchema,
+                    requestingUser = requestingUser
+                )
+
+                RouteUtilV2.runRdfRouteWithFuture(
+                    requestMessageF = requestMessage,
+                    requestContext = requestContext,
+                    settings = settings,
+                    responderManager = responderManager,
+                    log = log,
+                    targetSchema = RouteUtilV2.getOntologySchema(requestContext),
+                    schemaOptions = RouteUtilV2.getSchemaOptions(requestContext)
+                )
+            }
+        }
+    }
+
+    override def getTestData(implicit executionContext: ExecutionContext,
+                             actorSystem: ActorSystem,
+                             materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]] = {
+        getSearchTestResponses
+    }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/StandoffRouteV2.scala
@@ -25,23 +25,25 @@ import akka.http.scaladsl.model.Multipart
 import akka.http.scaladsl.model.Multipart.BodyPart
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
-import akka.stream.ActorMaterializer
+import org.knora.webapi._
 import org.knora.webapi.messages.v2.responder.standoffmessages.{CreateMappingRequestMetadataV2, CreateMappingRequestV2, CreateMappingRequestXMLV2, GetStandoffPageRequestV2}
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilV2}
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.SmartIri
 import org.knora.webapi.util.jsonld.JsonLDUtil
-import org.knora.webapi._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
 /**
-  * Provides a function for API routes that deal with search.
-  */
+ * Provides a function for API routes that deal with search.
+ */
 class StandoffRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator {
 
-    def knoraApiPath: Route = {
+    /**
+     * Returns the route.
+     */
+    override def knoraApiPath: Route = {
 
         path("v2" / "standoff" / Segment / Segment / Segment) { (resourceIriStr: String, valueIriStr: String, offsetStr: String) =>
             get {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
@@ -45,6 +45,8 @@ class V2ClientApi (routeData: KnoraRouteData) extends ClientApi {
       * The endpoints in this [[ClientApi]].
       */
     override val endpoints: Seq[ClientEndpoint] = Seq(
+        new OntologiesRouteV2(routeData),
+        new ResourcesRouteV2(routeData),
         new ValuesRouteV2(routeData)
     )
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
@@ -23,27 +23,27 @@ import org.knora.webapi.routing.KnoraRouteData
 import org.knora.webapi.util.clientapi.{ApiSerialisationFormat, ClientApi, ClientEndpoint, JsonLD}
 import org.knora.webapi.util.{SmartIri, StringFormatter}
 
-class V2ClientApi (routeData: KnoraRouteData) extends ClientApi {
+class V2ClientApi(routeData: KnoraRouteData) extends ClientApi {
     implicit private val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * The serialisation format used by this [[ClientApi]].
-      */
+     * The serialisation format used by this [[ClientApi]].
+     */
     override val serialisationFormat: ApiSerialisationFormat = JsonLD
 
     /**
-      * Don't generate endpoints for this API.
-      */
+     * Don't generate endpoints for this API.
+     */
     override val generateEndpoints: Boolean = false
 
     /**
-      * Don't generate classes for this API.
-      */
+     * Don't generate classes for this API.
+     */
     override val generateClasses: Boolean = false
 
     /**
-      * The endpoints in this [[ClientApi]].
-      */
+     * The endpoints in this [[ClientApi]].
+     */
     override val endpoints: Seq[ClientEndpoint] = Seq(
         new OntologiesRouteV2(routeData),
         new ResourcesRouteV2(routeData),
@@ -53,49 +53,49 @@ class V2ClientApi (routeData: KnoraRouteData) extends ClientApi {
     )
 
     /**
-      * The name of this [[ClientApi]].
-      */
+     * The name of this [[ClientApi]].
+     */
     override val name: String = "V2Endpoint"
 
     /**
-      * The directory name to be used for this API's code.
-      */
+     * The directory name to be used for this API's code.
+     */
     override val directoryName: String = "v2"
 
     /**
-      * The URL path of this [[ClientApi]].
-      */
+     * The URL path of this [[ClientApi]].
+     */
     override val urlPath: String = "/v2"
 
     /**
-      * A description of this [[ClientApi]].
-      */
+     * A description of this [[ClientApi]].
+     */
     override val description: String = "The Knora API v2."
 
     /**
-      * A map of class IRIs to their read-only properties.
-      */
+     * A map of class IRIs to their read-only properties.
+     */
     override val classesWithReadOnlyProperties: Map[SmartIri, Set[SmartIri]] = Map.empty
 
     /**
-      * A set of IRIs of classes that represent API responses.
-      */
+     * A set of IRIs of classes that represent API responses.
+     */
     override val responseClasses: Set[SmartIri] = Set.empty
 
     /**
-      * A set of property IRIs that are used for the unique IDs of objects.
-      */
+     * A set of property IRIs that are used for the unique IDs of objects.
+     */
     override val idProperties: Set[SmartIri] = Set.empty
 
     /**
-      * A map of class IRIs to maps of property IRIs to non-standard names that those properties must have
-      * in those classes. Needed only for JSON, and only if two different properties should have the same name in
-      * different classes. `JsonInstanceInspector` also needs to know about these.
-      */
+     * A map of class IRIs to maps of property IRIs to non-standard names that those properties must have
+     * in those classes. Needed only for JSON, and only if two different properties should have the same name in
+     * different classes. `JsonInstanceInspector` also needs to know about these.
+     */
     override val propertyNames: Map[SmartIri, Map[SmartIri, String]] = Map.empty
     /**
-      * A map of class IRIs to IRIs of optional set properties. Such properties have cardinality 0-n, and should
-      * be made optional in generated code.
-      */
+     * A map of class IRIs to IRIs of optional set properties. Such properties have cardinality 0-n, and should
+     * be made optional in generated code.
+     */
     override val classesWithOptionalSetProperties: Map[SmartIri, Set[SmartIri]] = Map.empty
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
@@ -48,7 +48,8 @@ class V2ClientApi (routeData: KnoraRouteData) extends ClientApi {
         new OntologiesRouteV2(routeData),
         new ResourcesRouteV2(routeData),
         new ValuesRouteV2(routeData),
-        new SearchRouteV2(routeData)
+        new SearchRouteV2(routeData),
+        new ListsRouteV2(routeData)
     )
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/V2ClientApi.scala
@@ -47,7 +47,8 @@ class V2ClientApi (routeData: KnoraRouteData) extends ClientApi {
     override val endpoints: Seq[ClientEndpoint] = Seq(
         new OntologiesRouteV2(routeData),
         new ResourcesRouteV2(routeData),
-        new ValuesRouteV2(routeData)
+        new ValuesRouteV2(routeData),
+        new SearchRouteV2(routeData)
     )
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
@@ -46,8 +46,8 @@ object ValuesRouteV2 {
 }
 
 /**
-  * Provides a routing function for API v2 routes that deal with values.
-  */
+ * Provides a routing function for API v2 routes that deal with values.
+ */
 class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with ClientEndpoint {
 
     import ValuesRouteV2._
@@ -59,6 +59,9 @@ class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     override val description: String = "An endpoint for working with Knora values."
     override val functions: Seq[ClientFunction] = Seq.empty
 
+    /**
+     * Returns the route.
+     */
     override def knoraApiPath: Route = getValue ~ createValue ~ updateValue ~ deleteValue
 
     private def getValue: Route = path(ValuesBasePath / Segment / Segment) { (resourceIriStr: IRI, valueUuidStr: String) =>
@@ -132,8 +135,8 @@ class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     )
 
     /**
-      * Provides JSON-LD responses to requests for values, for use in tests of generated client code.
-      */
+     * Provides JSON-LD responses to requests for values, for use in tests of generated client code.
+     */
     private def getValueTestResponses: Future[Set[SourceCodeFileContent]] = {
         val responseFutures: Iterable[Future[SourceCodeFileContent]] = testDingValues.map {
             case (valueTypeName, valueUuid) =>
@@ -197,8 +200,8 @@ class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     /**
-      * Returns JSON-LD requests for creating values in tests of generated client code.
-      */
+     * Returns JSON-LD requests for creating values in tests of generated client code.
+     */
     private def createValueTestRequests: Future[Set[SourceCodeFileContent]] = {
         FastFuture.successful(
             Set(
@@ -381,8 +384,8 @@ class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     /**
-      * Returns JSON-LD requests for updating values in tests of generated client code.
-      */
+     * Returns JSON-LD requests for updating values in tests of generated client code.
+     */
     private def updateValueTestRequests: Future[Set[SourceCodeFileContent]] = {
         FastFuture.successful(
             Set(
@@ -598,8 +601,8 @@ class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     }
 
     /**
-      * Returns JSON-LD requests for deleting values in tests of generated client code.
-      */
+     * Returns JSON-LD requests for deleting values in tests of generated client code.
+     */
     private def deleteValueTestRequests: Future[Set[SourceCodeFileContent]] = {
         FastFuture.successful(
             Set(

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
@@ -41,7 +41,7 @@ import org.knora.webapi.util.jsonld.{JsonLDDocument, JsonLDUtil}
 import scala.concurrent.{ExecutionContext, Future}
 
 object ValuesRouteV2 {
-    val ValuesBasePath = PathMatcher("v2" / "values")
+    val ValuesBasePath: PathMatcher[Unit] = PathMatcher("v2" / "values")
     val ValuesBasePathString = "/v2/values"
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/ValuesRouteV2.scala
@@ -624,10 +624,10 @@ class ValuesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
 
     override def getTestData(implicit executionContext: ExecutionContext, actorSystem: ActorSystem, materializer: ActorMaterializer): Future[Set[SourceCodeFileContent]] = {
         for {
-            getRequests: Set[SourceCodeFileContent] <- getValueTestResponses
+            getResponses: Set[SourceCodeFileContent] <- getValueTestResponses
             createRequests: Set[SourceCodeFileContent] <- createValueTestRequests
             updateRequests: Set[SourceCodeFileContent] <- updateValueTestRequests
             deleteRequests: Set[SourceCodeFileContent] <- deleteValueTestRequests
-        } yield getRequests ++ createRequests ++ updateRequests ++ deleteRequests
+        } yield getResponses ++ createRequests ++ updateRequests ++ deleteRequests
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
@@ -50,7 +50,8 @@ class ClientApiRouteE2ESpec extends E2ESpec(ClientApiRouteE2ESpec.config) {
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
 
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
-        RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything")
+        RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything"),
+        RdfDataObject(path = "_test_data/ontologies/minimal-onto.ttl", name = "http://www.knora.org/ontology/0001/minimal")
     )
 
     "The client API route" should {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
@@ -50,6 +50,7 @@ class ClientApiRouteE2ESpec extends E2ESpec(ClientApiRouteE2ESpec.config) {
     implicit def default(implicit system: ActorSystem): RouteTestTimeout = RouteTestTimeout(settings.defaultTimeout)
 
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
+        RdfDataObject(path = "_test_data/all_data/incunabula-data.ttl", name = "http://www.knora.org/data/0803/incunabula"),
         RdfDataObject(path = "_test_data/all_data/anything-data.ttl", name = "http://www.knora.org/data/0001/anything"),
         RdfDataObject(path = "_test_data/ontologies/minimal-onto.ttl", name = "http://www.knora.org/ontology/0001/minimal")
     )

--- a/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/ClientApiRouteE2ESpec.scala
@@ -58,7 +58,7 @@ class ClientApiRouteE2ESpec extends E2ESpec(ClientApiRouteE2ESpec.config) {
     "The client API route" should {
         "generate a Zip file of TypeScript code that compiles" in {
             val request = Get(baseApiUrl + s"/clientapi/typescript?mock=true")
-            val response: HttpResponse = singleAwaitingRequest(request = request, duration = 20480.millis)
+            val response: HttpResponse = singleAwaitingRequest(request = request, duration = 40960.millis)
             val responseBytes: Array[Byte] = getResponseEntityBytes(response)
             val filenames: Set[String] = getZipContents(responseBytes)
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ListsRouteV2R2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ListsRouteV2R2Spec.scala
@@ -82,7 +82,7 @@ class ListsRouteV2R2Spec extends R2RSpec {
 
         "perform a request for the anything treelist list in JSON-LD" in {
 
-            Get(s"/v2/lists/${URLEncoder.encode("http://rdfh.ch/lists/0001/treeList", "UTF-8")}") ~> listsPath ~> check {
+            Get(s"/v2/lists/${URLEncoder.encode(SharedTestDataADM.treeList, "UTF-8")}") ~> listsPath ~> check {
 
                 assert(status == StatusCodes.OK, response.toString)
 
@@ -96,7 +96,7 @@ class ListsRouteV2R2Spec extends R2RSpec {
 
         "perform a request for the anything othertreelist list in JSON-LD" in {
 
-            Get(s"/v2/lists/${URLEncoder.encode("http://rdfh.ch/lists/0001/otherTreeList", "UTF-8")}") ~> listsPath ~> check {
+            Get(s"/v2/lists/${URLEncoder.encode(SharedTestDataADM.otherTreeList, "UTF-8")}") ~> listsPath ~> check {
 
                 assert(status == StatusCodes.OK, response.toString)
 
@@ -152,7 +152,7 @@ class ListsRouteV2R2Spec extends R2RSpec {
 
         "perform a request for a treelist node in JSON-LD" in {
 
-            Get(s"/v2/node/${URLEncoder.encode("http://rdfh.ch/lists/0001/treeList01", "UTF-8")}") ~> listsPath ~> check {
+            Get(s"/v2/node/${URLEncoder.encode(SharedTestDataADM.treeListNode, "UTF-8")}") ~> listsPath ~> check {
 
                 assert(status == StatusCodes.OK, response.toString)
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -629,6 +629,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
             val jsonLDEntity = SharedTestDataADM.updateResourceMetadata(
                 resourceIri = resourceIri,
+                lastModificationDate = None,
                 newLabel = newLabel,
                 newPermissions = newPermissions,
                 newModificationDate = newModificationDate
@@ -636,8 +637,9 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
             val updateRequest = Put(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val updateResponse: HttpResponse = singleAwaitingRequest(updateRequest)
-            val updateResponseAsString = responseToString(updateResponse)
+            val updateResponseAsString: String = responseToString(updateResponse)
             assert(updateResponse.status == StatusCodes.OK, updateResponseAsString)
+            assert(updateResponseAsString == SharedTestDataADM.successResponse("Resource metadata updated"))
 
             val previewRequest = Get(s"$baseApiUrl/v2/resourcespreview/${URLEncoder.encode(resourceIri, "UTF-8")}") ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val previewResponse: HttpResponse = singleAwaitingRequest(previewRequest)
@@ -670,8 +672,9 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
             val updateRequest = Post(s"$baseApiUrl/v2/resources/delete", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val updateResponse: HttpResponse = singleAwaitingRequest(updateRequest)
-            val updateResponseAsString = responseToString(updateResponse)
+            val updateResponseAsString: String = responseToString(updateResponse)
             assert(updateResponse.status == StatusCodes.OK, updateResponseAsString)
+            assert(updateResponseAsString == SharedTestDataADM.successResponse("Resource marked as deleted"))
 
             val previewRequest = Get(s"$baseApiUrl/v2/resourcespreview/${URLEncoder.encode(resourceIri, "UTF-8")}") ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val previewResponse: HttpResponse = singleAwaitingRequest(previewRequest)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/ResourcesRouteV2E2ESpec.scala
@@ -505,104 +505,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
         }
 
         "create a resource with values" in {
-            val jsonLDEntity =
-                """{
-                  |  "@type" : "anything:Thing",
-                  |  "anything:hasBoolean" : {
-                  |    "@type" : "knora-api:BooleanValue",
-                  |    "knora-api:booleanValueAsBoolean" : true
-                  |  },
-                  |  "anything:hasColor" : {
-                  |    "@type" : "knora-api:ColorValue",
-                  |    "knora-api:colorValueAsColor" : "#ff3333"
-                  |  },
-                  |  "anything:hasDate" : {
-                  |    "@type" : "knora-api:DateValue",
-                  |    "knora-api:dateValueHasCalendar" : "GREGORIAN",
-                  |    "knora-api:dateValueHasEndEra" : "CE",
-                  |    "knora-api:dateValueHasEndYear" : 1489,
-                  |    "knora-api:dateValueHasStartEra" : "CE",
-                  |    "knora-api:dateValueHasStartYear" : 1489
-                  |  },
-                  |  "anything:hasDecimal" : {
-                  |    "@type" : "knora-api:DecimalValue",
-                  |    "knora-api:decimalValueAsDecimal" : {
-                  |      "@type" : "xsd:decimal",
-                  |      "@value" : "100000000000000.000000000000001"
-                  |    }
-                  |  },
-                  |  "anything:hasGeometry" : {
-                  |    "@type" : "knora-api:GeomValue",
-                  |    "knora-api:geometryValueAsGeometry" : "{\"status\":\"active\",\"lineColor\":\"#ff3333\",\"lineWidth\":2,\"points\":[{\"x\":0.08098591549295775,\"y\":0.16741071428571427},{\"x\":0.7394366197183099,\"y\":0.7299107142857143}],\"type\":\"rectangle\",\"original_index\":0}"
-                  |  },
-                  |  "anything:hasGeoname" : {
-                  |    "@type" : "knora-api:GeonameValue",
-                  |    "knora-api:geonameValueAsGeonameCode" : "2661604"
-                  |  },
-                  |  "anything:hasInteger" : [ {
-                  |    "@type" : "knora-api:IntValue",
-                  |    "knora-api:hasPermissions" : "CR knora-admin:Creator|V http://rdfh.ch/groups/0001/thing-searcher",
-                  |    "knora-api:intValueAsInt" : 5,
-                  |    "knora-api:valueHasComment" : "this is the number five"
-                  |  }, {
-                  |    "@type" : "knora-api:IntValue",
-                  |    "knora-api:intValueAsInt" : 6
-                  |  } ],
-                  |  "anything:hasInterval" : {
-                  |    "@type" : "knora-api:IntervalValue",
-                  |    "knora-api:intervalValueHasEnd" : {
-                  |      "@type" : "xsd:decimal",
-                  |      "@value" : "3.4"
-                  |    },
-                  |    "knora-api:intervalValueHasStart" : {
-                  |      "@type" : "xsd:decimal",
-                  |      "@value" : "1.2"
-                  |    }
-                  |  },
-                  |  "anything:hasListItem" : {
-                  |    "@type" : "knora-api:ListValue",
-                  |    "knora-api:listValueAsListNode" : {
-                  |      "@id" : "http://rdfh.ch/lists/0001/treeList03"
-                  |    }
-                  |  },
-                  |  "anything:hasOtherThingValue" : {
-                  |    "@type" : "knora-api:LinkValue",
-                  |    "knora-api:linkValueHasTargetIri" : {
-                  |      "@id" : "http://rdfh.ch/0001/a-thing"
-                  |    }
-                  |  },
-                  |  "anything:hasRichtext" : {
-                  |    "@type" : "knora-api:TextValue",
-                  |    "knora-api:textValueAsXml" : "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<text><p><strong>this is</strong> text</p> with standoff</text>",
-                  |    "knora-api:textValueHasMapping" : {
-                  |      "@id" : "http://rdfh.ch/standoff/mappings/StandardMapping"
-                  |    }
-                  |  },
-                  |  "anything:hasText" : {
-                  |    "@type" : "knora-api:TextValue",
-                  |    "knora-api:valueAsString" : "this is text without standoff"
-                  |  },
-                  |  "anything:hasUri" : {
-                  |    "@type" : "knora-api:UriValue",
-                  |    "knora-api:uriValueAsUri" : {
-                  |      "@type" : "xsd:anyURI",
-                  |      "@value" : "https://www.knora.org"
-                  |    }
-                  |  },
-                  |  "knora-api:attachedToProject" : {
-                  |    "@id" : "http://rdfh.ch/projects/0001"
-                  |  },
-                  |  "rdfs:label" : "test thing",
-                  |  "@context" : {
-                  |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                  |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-                  |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-                  |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-                  |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-                  |  }
-                  |}""".stripMargin
-
-            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
+            val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, SharedTestDataADM.createResourceWithValues)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK, response.toString)
             val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
@@ -649,31 +552,7 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
 
         "create a resource with a custom creation date" in {
             val creationDate: Instant = Instant.parse("2019-01-09T15:45:54.502951Z")
-
-            val jsonLDEntity =
-                s"""{
-                   |  "@type" : "anything:Thing",
-                   |  "knora-api:attachedToProject" : {
-                   |    "@id" : "http://rdfh.ch/projects/0001"
-                   |  },
-                   |  "anything:hasBoolean" : {
-                   |    "@type" : "knora-api:BooleanValue",
-                   |    "knora-api:booleanValueAsBoolean" : true
-                   |  },
-                   |  "rdfs:label" : "test thing",
-                   |  "knora-api:creationDate" : {
-                   |    "@type" : "xsd:dateTimeStamp",
-                   |    "@value" : "$creationDate"
-                   |  },
-                   |  "@context" : {
-                   |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                   |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-                   |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-                   |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-                   |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-                   |  }
-                   |}""".stripMargin
-
+            val jsonLDEntity = SharedTestDataADM.createResourceWithCustomCreationDate(creationDate)
             val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK, response.toString)
@@ -691,36 +570,13 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
         }
 
         "create a resource as another user" in {
-            val jsonLDEntity =
-                s"""{
-                   |  "@type" : "anything:Thing",
-                   |  "knora-api:attachedToProject" : {
-                   |    "@id" : "http://rdfh.ch/projects/0001"
-                   |  },
-                   |  "anything:hasBoolean" : {
-                   |    "@type" : "knora-api:BooleanValue",
-                   |    "knora-api:booleanValueAsBoolean" : true
-                   |  },
-                   |  "rdfs:label" : "test thing",
-                   |  "knora-api:attachedToUser" : {
-                   |    "@id" : "${SharedTestDataADM.anythingUser1.id}"
-                   |  },
-                   |  "@context" : {
-                   |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                   |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-                   |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-                   |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-                   |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-                   |  }
-                   |}""".stripMargin
-
+            val jsonLDEntity = SharedTestDataADM.createResourceAsUser(SharedTestDataADM.anythingUser1)
             val request = Post(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(SharedTestDataADM.anythingAdminUser.email, password))
             val response: HttpResponse = singleAwaitingRequest(request)
             assert(response.status == StatusCodes.OK, response.toString)
             val responseJsonDoc: JsonLDDocument = responseToJsonLDDocument(response)
             val resourceIri: IRI = responseJsonDoc.body.requireStringWithValidation(JsonLDConstants.ID, stringFormatter.validateAndEscapeIri)
             assert(resourceIri.toSmartIri.isKnoraDataIri)
-
             val savedAttachedToUser: IRI = responseJsonDoc.body.requireIriInObject(OntologyConstants.KnoraApiV2Complex.AttachedToUser, stringFormatter.validateAndEscapeIri)
             assert(savedAttachedToUser == SharedTestDataADM.anythingUser1.id)
         }
@@ -771,24 +627,12 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             val newPermissions = "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:ProjectMember"
             val newModificationDate = Instant.now.plus(java.time.Duration.ofDays(1))
 
-            val jsonLDEntity =
-                s"""|{
-                    |  "@id" : "$resourceIri",
-                    |  "@type" : "anything:Thing",
-                    |  "rdfs:label" : "$newLabel",
-                    |  "knora-api:hasPermissions" : "$newPermissions",
-                    |  "knora-api:newModificationDate" : {
-                    |    "@type" : "xsd:dateTimeStamp",
-                    |    "@value" : "$newModificationDate"
-                    |  },
-                    |  "@context" : {
-                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-                    |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-                    |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-                    |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-                    |  }
-                    |}""".stripMargin
+            val jsonLDEntity = SharedTestDataADM.updateResourceMetadata(
+                resourceIri = resourceIri,
+                newLabel = newLabel,
+                newPermissions = newPermissions,
+                newModificationDate = newModificationDate
+            )
 
             val updateRequest = Put(s"$baseApiUrl/v2/resources", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val updateResponse: HttpResponse = singleAwaitingRequest(updateRequest)
@@ -819,23 +663,10 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
         "mark a resource as deleted" in {
             val resourceIri = "http://rdfh.ch/0001/a-thing"
 
-            val jsonLDEntity =
-                s"""|{
-                    |  "@id" : "$resourceIri",
-                    |  "@type" : "anything:Thing",
-                    |  "knora-api:lastModificationDate" : {
-                    |    "@type" : "xsd:dateTimeStamp",
-                    |    "@value" : "$aThingLastModificationDate"
-                    |  },
-                    |  "knora-api:deleteComment" : "This resource is too boring.",
-                    |  "@context" : {
-                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-                    |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-                    |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-                    |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-                    |  }
-                    |}""".stripMargin
+            val jsonLDEntity = SharedTestDataADM.deleteResource(
+                resourceIri = resourceIri,
+                lastModificationDate = aThingLastModificationDate
+            )
 
             val updateRequest = Post(s"$baseApiUrl/v2/resources/delete", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password))
             val updateResponse: HttpResponse = singleAwaitingRequest(updateRequest)
@@ -979,22 +810,10 @@ class ResourcesRouteV2E2ESpec extends E2ESpec(ResourcesRouteV2E2ESpec.config) {
             val resourceIri = "http://rdfh.ch/0001/thing-with-history"
             val resourceLastModificationDate = Instant.parse("2019-02-13T09:05:10Z")
 
-            val jsonLDEntity =
-                s"""|{
-                    |  "@id" : "$resourceIri",
-                    |  "@type" : "anything:Thing",
-                    |  "knora-api:lastModificationDate" : {
-                    |    "@type" : "xsd:dateTimeStamp",
-                    |    "@value" : "$resourceLastModificationDate"
-                    |  },
-                    |  "@context" : {
-                    |    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                    |    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
-                    |    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
-                    |    "xsd" : "http://www.w3.org/2001/XMLSchema#",
-                    |    "anything" : "http://0.0.0.0:3333/ontology/0001/anything/v2#"
-                    |  }
-                    |}""".stripMargin
+            val jsonLDEntity = SharedTestDataADM.eraseResource(
+                resourceIri = resourceIri,
+                lastModificationDate = resourceLastModificationDate
+            )
 
             val updateRequest = Post(s"$baseApiUrl/v2/resources/erase", HttpEntity(RdfMediaTypes.`application/ld+json`, jsonLDEntity)) ~> addCredentials(BasicHttpCredentials(SharedTestDataADM.anythingAdminUser.email, password))
             val updateResponse: HttpResponse = singleAwaitingRequest(updateRequest)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -4092,7 +4092,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
                 assert(status == StatusCodes.OK, response.toString)
 
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/RegionsForPage.jsonld"), writeTestDataFiles)
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/RegionsForPage.jsonld"), false)
 
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 
@@ -4354,7 +4354,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
                 assert(status == StatusCodes.OK, response.toString)
 
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ThingSmallerThanDecimal.jsonld"), writeTestDataFiles)
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ThingSmallerThanDecimal.jsonld"), false)
 
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 
@@ -6215,40 +6215,11 @@ class SearchRouteV2R2RSpec extends R2RSpec {
         }
 
         "get the regions belonging to a page (submitting the complex schema)" in {
-            val gravsearchQuery =
-                """    PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
-                  |    PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
-                  |
-                  |    CONSTRUCT {
-                  |        ?region knora-api:isMainResource true .
-                  |
-                  |        ?region knora-api:isRegionOf <http://rdfh.ch/0803/9d626dc76c03> .
-                  |
-                  |        ?region knora-api:hasGeometry ?geom .
-                  |
-                  |        ?region knora-api:hasComment ?comment .
-                  |
-                  |        ?region knora-api:hasColor ?color .
-                  |    } WHERE {
-                  |
-                  |        ?region a knora-api:Region .
-                  |
-                  |        ?region knora-api:isRegionOf <http://rdfh.ch/0803/9d626dc76c03> .
-                  |
-                  |        ?region knora-api:hasGeometry ?geom .
-                  |
-                  |        ?region knora-api:hasComment ?comment .
-                  |
-                  |        ?region knora-api:hasColor ?color .
-                  |
-                  |    }
-                """.stripMargin
-
-            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, SharedTestDataADM.gravsearchComplexRegionsForPage)) ~> searchPath ~> check {
 
                 assert(status == StatusCodes.OK, response.toString)
 
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/RegionsForPage.jsonld"), writeTestDataFiles)
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/RegionsForPage.jsonld"), false)
 
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 
@@ -6458,33 +6429,11 @@ class SearchRouteV2R2RSpec extends R2RSpec {
         }
 
         "search for an anything:Thing that has a decimal value smaller than 3.0 (submitting the complex schema)" in {
-            val gravsearchQuery =
-                """
-                  |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
-                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
-                  |
-                  |CONSTRUCT {
-                  |     ?thing knora-api:isMainResource true .
-                  |
-                  |     ?thing anything:hasDecimal ?decimal .
-                  |} WHERE {
-                  |
-                  |     ?thing a anything:Thing .
-                  |
-                  |     ?thing anything:hasDecimal ?decimal .
-                  |
-                  |     ?decimal knora-api:decimalValueAsDecimal ?decimalDec .
-                  |
-                  |     FILTER(?decimalDec < "3"^^xsd:decimal)
-                  |}
-                  |
-                """.stripMargin
-
-            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, SharedTestDataADM.gravsearchComplexThingSmallerThanDecimal)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
 
                 assert(status == StatusCodes.OK, response.toString)
 
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ThingSmallerThanDecimal.jsonld"), writeTestDataFiles)
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("src/test/resources/test-data/searchR2RV2/ThingSmallerThanDecimal.jsonld"), false)
 
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
 


### PR DESCRIPTION
This PR incorporates more API v2 routes into the client code generation framework so they can return client test data.

- [x] ontologies route
- [x] resources route
- [x] search route
- [x] lists route

Resolves #1548.
