### PR TITLE
typo in label

### DIFF
--- a/salsah1/src/public/js/imagebase.js
+++ b/salsah1/src/public/js/imagebase.js
@@ -54,7 +54,7 @@ $(function() {
 					arkdiv.append(
 								$('<em>')
 									.addClass('propedit label')
-									.append('Presistent ID (')
+									.append('Persistent ID (')
 									.append(
 										$('<a>').attr({href: 'https://en.wikipedia.org/wiki/Archival_Resource_Key'}).append('ARK'))
 									.append('): ')


### PR DESCRIPTION
`presistent` instead of `persistent`

closes #1547 