### PR TITLE
feat(clientapi): Change signature of function to update user's system admin membership

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
@@ -41,7 +41,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 object GroupsRouteADM {
-    val GroupsBasePath = PathMatcher("admin" / "groups")
+    val GroupsBasePath: PathMatcher[Unit] = PathMatcher("admin" / "groups")
     val GroupsBasePathString: String = "/admin/groups"
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/ProjectsRouteADM.scala
@@ -49,7 +49,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 object ProjectsRouteADM {
-    val ProjectsBasePath = PathMatcher("admin" / "projects")
+    val ProjectsBasePath: PathMatcher[Unit] = PathMatcher("admin" / "projects")
     val ProjectsBasePathString = "/admin/projects"
 }
 
@@ -82,7 +82,6 @@ class ProjectsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) 
     // Classes used in client function definitions.
 
     private val Project = classRef(OntologyConstants.KnoraAdminV2.ProjectClass.toSmartIri)
-    private val StoredProject = Project.toStoredClassRef
     private val ProjectsResponse = classRef(OntologyConstants.KnoraAdminV2.ProjectsResponse.toSmartIri)
     private val ProjectResponse = classRef(OntologyConstants.KnoraAdminV2.ProjectResponse.toSmartIri)
     private val UpdateProjectRequest = classRef(OntologyConstants.KnoraAdminV2.UpdateProjectRequest.toSmartIri)

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/UsersRouteADM.scala
@@ -44,7 +44,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 
 object UsersRouteADM {
-    val UsersBasePath = PathMatcher("admin" / "users")
+    val UsersBasePath: PathMatcher[Unit] = PathMatcher("admin" / "users")
     val UsersBasePathString: String = "/admin/users"
 }
 
@@ -85,7 +85,6 @@ class UsersRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
     private val GroupsResponse = classRef(OntologyConstants.KnoraAdminV2.GroupsResponse.toSmartIri)
     private val User = classRef(OntologyConstants.KnoraAdminV2.UserClass.toSmartIri)
     private val UpdateUserRequest = classRef(OntologyConstants.KnoraAdminV2.UpdateUserRequest.toSmartIri)
-    private val StoredUser = User.toStoredClassRef
 
     private val anythingUser1IriEnc = URLEncoder.encode(SharedTestDataADM.anythingUser1.id, "UTF-8")
     private val multiUserIriEnc = URLEncoder.encode(SharedTestDataADM.multiuserUser.id, "UTF-8")
@@ -554,11 +553,12 @@ class UsersRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wit
 
     private val updateUserSystemAdminMembershipFunction: ClientFunction =
         "updateUserSystemAdminMembership" description "Updates a user's SystemAdmin membership." params (
-            "user" description "The user to be updated." paramType StoredUser
+            "iri" description "The IRI of the user to be updated." paramType UriDatatype,
+            "systemAdmin" description "True if the user should be a system admin" paramType BooleanDatatype
             ) doThis {
             httpPut(
-                path = str("iri") / argMember("user", "id") / str("SystemAdmin"),
-                body = Some(json("systemAdmin" -> argMember("user", "systemAdmin")))
+                path = str("iri") / arg("iri") / str("SystemAdmin"),
+                body = Some(json("systemAdmin" -> arg("systemAdmin")))
             )
         } returns UserResponse
 


### PR DESCRIPTION
This PR changes the signature of the client API function `updateUserSystemAdminMembership` as requested in #1579.

Resolves #1579.