### PR TITLE
fix(api-v2): Fix custom datatypes in knora-api simple ontology

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2ComplexTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2ComplexTransformationRules.scala
@@ -32,10 +32,15 @@ import org.knora.webapi.util.{SmartIri, StringFormatter}
 object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformationRules {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
 
-    override val ontologyMetadata = OntologyMetadataV2(
+    override val ontologyMetadata: OntologyMetadataV2 = OntologyMetadataV2(
         ontologyIri = OntologyConstants.KnoraApiV2Complex.KnoraApiOntologyIri.toSmartIri,
         projectIri = Some(OntologyConstants.KnoraAdmin.SystemProject.toSmartIri),
         label = Some("The knora-api ontology in the complex schema")
+    )
+
+    private val Label: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.Rdfs.Label,
+        propertyType = OntologyConstants.Owl.DatatypeProperty
     )
 
     private val Result: ReadPropertyInfoV2 = makeProperty(
@@ -1757,6 +1762,7 @@ object KnoraBaseToApiV2ComplexTransformationRules extends OntologyTransformation
       * See also [[OntologyConstants.CorrespondingIris]].
       */
     override val externalPropertiesToAdd: Map[SmartIri, ReadPropertyInfoV2] = Set(
+        Label,
         Result,
         Error,
         UserHasPermission,

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2SimpleTransformationRules.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/KnoraBaseToApiV2SimpleTransformationRules.scala
@@ -33,10 +33,15 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private implicit val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
 
-    override val ontologyMetadata = OntologyMetadataV2(
+    override val ontologyMetadata: OntologyMetadataV2 = OntologyMetadataV2(
         ontologyIri = OntologyConstants.KnoraApiV2Simple.KnoraApiOntologyIri.toSmartIri,
         projectIri = Some(OntologyConstants.KnoraAdmin.SystemProject.toSmartIri),
         label = Some("The knora-api ontology in the simple schema")
+    )
+
+    private val Label: ReadPropertyInfoV2 = makeProperty(
+        propertyIri = OntologyConstants.Rdfs.Label,
+        propertyType = OntologyConstants.Owl.DatatypeProperty
     )
 
     private val Result: ReadPropertyInfoV2 = makeProperty(
@@ -207,7 +212,10 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val Date: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.Date,
-        xsdStringRestrictionPattern = Some("(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.String.toSmartIri,
+            pattern = Some("(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?")
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -226,7 +234,10 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val Color: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.Color,
-        xsdStringRestrictionPattern = Some("#([0-9a-fA-F]{3}){1,2}"),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.String.toSmartIri,
+            pattern = Some("#([0-9a-fA-F]{3}){1,2}")
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -245,7 +256,10 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val Interval: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.Interval,
-        xsdStringRestrictionPattern = Some("\\d+(\\.\\d+)?,\\d+(\\.\\d+)?"),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.String.toSmartIri,
+            pattern = Some("\\d+(\\.\\d+)?,\\d+(\\.\\d+)?")
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -264,7 +278,10 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val Geoname: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.Geoname,
-        xsdStringRestrictionPattern = Some("\\d{1,8}"),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.String.toSmartIri,
+            pattern = Some("\\d{1,8}")
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -283,7 +300,9 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val Geom: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.Geom,
-        subClassOf = Some(OntologyConstants.Xsd.String),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.String.toSmartIri
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -302,7 +321,9 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val File: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.File,
-        subClassOf = Some(OntologyConstants.Xsd.Uri),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.Uri.toSmartIri
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -321,7 +342,9 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
 
     private val ListNode: ReadClassInfoV2 = makeDatatype(
         datatypeIri = OntologyConstants.KnoraApiV2Simple.ListNode,
-        xsdStringRestrictionPattern = Some(".+"),
+        datatypeInfo = DatatypeInfoV2(
+            onDatatype = OntologyConstants.Xsd.String.toSmartIri
+        ),
         predicates = Seq(
             makePredicate(
                 predicateIri = OntologyConstants.Rdfs.Label,
@@ -534,6 +557,7 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
       * See also [[OntologyConstants.CorrespondingIris]].
       */
     override val externalPropertiesToAdd: Map[SmartIri, ReadPropertyInfoV2] = Set(
+        Label,
         Result,
         Error,
         ArkUrl,
@@ -625,16 +649,12 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
       * Makes a [[ReadClassInfoV2]] representing an rdfs:Datatype.
       *
       * @param datatypeIri                 the IRI of the datatype.
-      * @param subClassOf                  the superclass of the datatype.
-      * @param xsdStringRestrictionPattern an optional xsd:pattern specifying
-      *                                    the regular expression that restricts its values. This has the effect of making the
-      *                                    class a subclass of a blank node with owl:onDatatype xsd:string.
+      * @param datatypeInfo a [[DatatypeInfoV2]] describing the datatype.
       * @param predicates                  the predicates of the datatype.
       * @return a [[ReadClassInfoV2]].
       */
     private def makeDatatype(datatypeIri: IRI,
-                             subClassOf: Option[IRI] = None,
-                             xsdStringRestrictionPattern: Option[String] = None,
+                             datatypeInfo: DatatypeInfoV2,
                              predicates: Seq[PredicateInfoV2] = Seq.empty[PredicateInfoV2]): ReadClassInfoV2 = {
 
         val rdfType = OntologyConstants.Rdf.Type.toSmartIri -> PredicateInfoV2(
@@ -645,16 +665,13 @@ object KnoraBaseToApiV2SimpleTransformationRules extends OntologyTransformationR
         ReadClassInfoV2(
             entityInfoContent = ClassInfoContentV2(
                 classIri = datatypeIri.toSmartIri,
-                xsdStringRestrictionPattern = xsdStringRestrictionPattern,
+                datatypeInfo = Some(datatypeInfo),
                 predicates = predicates.map {
                     pred => pred.predicateIri -> pred
                 }.toMap + rdfType,
-                subClassOf = subClassOf.toSet.map {
-                    iri: IRI => iri.toSmartIri
-                },
                 ontologySchema = ApiV2Simple
             ),
-            allBaseClasses = subClassOf.map(_.toSmartIri).toSet + datatypeIri.toSmartIri
+            allBaseClasses = Set(datatypeIri.toSmartIri)
         )
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/ontologymessages/OntologyMessagesV2.scala
@@ -40,29 +40,29 @@ import org.knora.webapi.util.{SmartIri, StringFormatter}
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * An abstract trait for messages that can be sent to `ResourcesResponderV2`.
-  */
+ * An abstract trait for messages that can be sent to `ResourcesResponderV2`.
+ */
 sealed trait OntologiesResponderRequestV2 extends KnoraRequestV2 {
 
     def requestingUser: UserADM
 }
 
 /**
-  * Requests that all ontologies in the repository are loaded. This message must be sent only once, when the application
-  * starts, before it accepts any API requests. A successful response will be a [[SuccessResponseV2]].
-  *
-  * @param requestingUser the user making the request.
-  */
+ * Requests that all ontologies in the repository are loaded. This message must be sent only once, when the application
+ * starts, before it accepts any API requests. A successful response will be a [[SuccessResponseV2]].
+ *
+ * @param requestingUser the user making the request.
+ */
 case class LoadOntologiesRequestV2(requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests the creation of an empty ontology. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param ontologyName   the name of the ontology to be created.
-  * @param projectIri     the IRI of the project that the ontology will belong to.
-  * @param apiRequestID   the ID of the API request.
-  * @param requestingUser the user making the request.
-  */
+ * Requests the creation of an empty ontology. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param ontologyName   the name of the ontology to be created.
+ * @param projectIri     the IRI of the project that the ontology will belong to.
+ * @param apiRequestID   the ID of the API request.
+ * @param requestingUser the user making the request.
+ */
 case class CreateOntologyRequestV2(ontologyName: String,
                                    projectIri: SmartIri,
                                    isShared: Boolean = false,
@@ -71,22 +71,22 @@ case class CreateOntologyRequestV2(ontologyName: String,
                                    requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Constructs instances of [[CreateOntologyRequestV2]] based on JSON-LD requests.
-  */
+ * Constructs instances of [[CreateOntologyRequestV2]] based on JSON-LD requests.
+ */
 object CreateOntologyRequestV2 extends KnoraJsonLDRequestReaderV2[CreateOntologyRequestV2] {
     /**
-      * Converts JSON-LD input into a [[CreateOntologyRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[CreateOntologyRequestV2]] representing the input.
-      */
+     * Converts JSON-LD input into a [[CreateOntologyRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[CreateOntologyRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -125,58 +125,58 @@ object CreateOntologyRequestV2 extends KnoraJsonLDRequestReaderV2[CreateOntology
 }
 
 /**
-  * Requests that an ontology is deleted. All the entities in the ontology must be unused in data.
-  *
-  * @param ontologyIri          the IRI of the ontology to delete.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests that an ontology is deleted. All the entities in the ontology must be unused in data.
+ *
+ * @param ontologyIri          the IRI of the ontology to delete.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class DeleteOntologyRequestV2(ontologyIri: SmartIri,
                                    lastModificationDate: Instant,
                                    apiRequestID: UUID,
                                    requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents information taken from an [[InputOntologyV2]], representing a request to update a property
-  * definition.
-  *
-  * @param propertyInfoContent  information to be updated in the property definition.
-  * @param lastModificationDate the ontology's last modification date.
-  */
+ * Represents information taken from an [[InputOntologyV2]], representing a request to update a property
+ * definition.
+ *
+ * @param propertyInfoContent  information to be updated in the property definition.
+ * @param lastModificationDate the ontology's last modification date.
+ */
 case class PropertyUpdateInfo(propertyInfoContent: PropertyInfoContentV2,
                               lastModificationDate: Instant)
 
 /**
-  * Represents information taken from an [[InputOntologyV2]], representing a request to update a class
-  * definition.
-  *
-  * @param classInfoContent     information to be updated in the class definition.
-  * @param lastModificationDate the ontology's last modification date.
-  */
+ * Represents information taken from an [[InputOntologyV2]], representing a request to update a class
+ * definition.
+ *
+ * @param classInfoContent     information to be updated in the class definition.
+ * @param lastModificationDate the ontology's last modification date.
+ */
 case class ClassUpdateInfo(classInfoContent: ClassInfoContentV2,
                            lastModificationDate: Instant)
 
 /**
-  * Assists in the processing of JSON-LD in ontology entity update requests.
-  */
+ * Assists in the processing of JSON-LD in ontology entity update requests.
+ */
 object OntologyUpdateHelper {
     /**
-      * Gets the ontology's last modification date from the request.
-      *
-      * @param inputOntologyV2 an [[InputOntologyV2]] representing the ontology to be updated.
-      * @return the ontology's last modification date.
-      */
+     * Gets the ontology's last modification date from the request.
+     *
+     * @param inputOntologyV2 an [[InputOntologyV2]] representing the ontology to be updated.
+     * @return the ontology's last modification date.
+     */
     def getOntologyLastModificationDate(inputOntologyV2: InputOntologyV2): Instant = {
         inputOntologyV2.ontologyMetadata.lastModificationDate.getOrElse(throw BadRequestException(s"An ontology update request must include the ontology's knora-api:lastModificationDate"))
     }
 
     /**
-      * Gets a class definition from the request.
-      *
-      * @param inputOntologyV2 an [[InputOntologyV2]] that must contain a single class definition.
-      * @return a [[ClassUpdateInfo]] containing the class definition and the ontology's last modification date.
-      */
+     * Gets a class definition from the request.
+     *
+     * @param inputOntologyV2 an [[InputOntologyV2]] that must contain a single class definition.
+     * @return a [[ClassUpdateInfo]] containing the class definition and the ontology's last modification date.
+     */
     def getClassDef(inputOntologyV2: InputOntologyV2): ClassUpdateInfo = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -232,11 +232,11 @@ object OntologyUpdateHelper {
     }
 
     /**
-      * Gets a property definition from the request.
-      *
-      * @param inputOntologyV2 an [[InputOntologyV2]] that must contain a single property definition.
-      * @return a [[PropertyUpdateInfo]] containing the property definition and the ontology's last modification date.
-      */
+     * Gets a property definition from the request.
+     *
+     * @param inputOntologyV2 an [[InputOntologyV2]] that must contain a single property definition.
+     * @return a [[PropertyUpdateInfo]] containing the property definition and the ontology's last modification date.
+     */
     def getPropertyDef(inputOntologyV2: InputOntologyV2): PropertyUpdateInfo = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -297,11 +297,11 @@ object OntologyUpdateHelper {
     )
 
     /**
-      * Gets the values of `rdfs:label` or `rdfs:comment` from a request to update them.
-      *
-      * @param entityInfoContent the data submitted about the entity to be updated.
-      * @return the values of that predicate.
-      */
+     * Gets the values of `rdfs:label` or `rdfs:comment` from a request to update them.
+     *
+     * @param entityInfoContent the data submitted about the entity to be updated.
+     * @return the values of that predicate.
+     */
     def getLabelsOrComments(entityInfoContent: EntityInfoContentV2): PredicateInfoV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -330,35 +330,35 @@ object OntologyUpdateHelper {
 }
 
 /**
-  * Requests the addition of a property to an ontology. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param propertyInfoContent  an [[PropertyInfoContentV2]] containing the property definition.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests the addition of a property to an ontology. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param propertyInfoContent  an [[PropertyInfoContentV2]] containing the property definition.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class CreatePropertyRequestV2(propertyInfoContent: PropertyInfoContentV2,
                                    lastModificationDate: Instant,
                                    apiRequestID: UUID,
                                    requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Constructs instances of [[CreatePropertyRequestV2]] based on JSON-LD requests.
-  */
+ * Constructs instances of [[CreatePropertyRequestV2]] based on JSON-LD requests.
+ */
 object CreatePropertyRequestV2 extends KnoraJsonLDRequestReaderV2[CreatePropertyRequestV2] {
     /**
-      * Converts a JSON-LD request to a [[CreatePropertyRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[CreatePropertyRequestV2]] representing the input.
-      */
+     * Converts a JSON-LD request to a [[CreatePropertyRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[CreatePropertyRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -424,35 +424,35 @@ object CreatePropertyRequestV2 extends KnoraJsonLDRequestReaderV2[CreateProperty
 }
 
 /**
-  * Requests the addition of a class to an ontology. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param classInfoContent     a [[ClassInfoContentV2]] containing the class definition.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests the addition of a class to an ontology. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classInfoContent     a [[ClassInfoContentV2]] containing the class definition.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class CreateClassRequestV2(classInfoContent: ClassInfoContentV2,
                                 lastModificationDate: Instant,
                                 apiRequestID: UUID,
                                 requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Constructs instances of [[CreateClassRequestV2]] based on JSON-LD requests.
-  */
+ * Constructs instances of [[CreateClassRequestV2]] based on JSON-LD requests.
+ */
 object CreateClassRequestV2 extends KnoraJsonLDRequestReaderV2[CreateClassRequestV2] {
     /**
-      * Converts a JSON-LD request to a [[CreateClassRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[CreateClassRequestV2]] representing the input.
-      */
+     * Converts a JSON-LD request to a [[CreateClassRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[CreateClassRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -499,35 +499,35 @@ object CreateClassRequestV2 extends KnoraJsonLDRequestReaderV2[CreateClassReques
 }
 
 /**
-  * Requests the addition of cardinalities to a class. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param classInfoContent     a [[ClassInfoContentV2]] containing the class definition.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests the addition of cardinalities to a class. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classInfoContent     a [[ClassInfoContentV2]] containing the class definition.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class AddCardinalitiesToClassRequestV2(classInfoContent: ClassInfoContentV2,
                                             lastModificationDate: Instant,
                                             apiRequestID: UUID,
                                             requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Constructs instances of [[AddCardinalitiesToClassRequestV2]] based on JSON-LD input.
-  */
+ * Constructs instances of [[AddCardinalitiesToClassRequestV2]] based on JSON-LD input.
+ */
 object AddCardinalitiesToClassRequestV2 extends KnoraJsonLDRequestReaderV2[AddCardinalitiesToClassRequestV2] {
     /**
-      * Converts JSON-LD input into an [[AddCardinalitiesToClassRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return an [[AddCardinalitiesToClassRequestV2]] representing the input.
-      */
+     * Converts JSON-LD input into an [[AddCardinalitiesToClassRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return an [[AddCardinalitiesToClassRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -568,35 +568,35 @@ object AddCardinalitiesToClassRequestV2 extends KnoraJsonLDRequestReaderV2[AddCa
 }
 
 /**
-  * Requests the replacement of a class's cardinalities with new ones. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param classInfoContent     a [[ClassInfoContentV2]] containing the new cardinalities.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests the replacement of a class's cardinalities with new ones. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classInfoContent     a [[ClassInfoContentV2]] containing the new cardinalities.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class ChangeCardinalitiesRequestV2(classInfoContent: ClassInfoContentV2,
                                         lastModificationDate: Instant,
                                         apiRequestID: UUID,
                                         requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Constructs instances of [[ChangeCardinalitiesRequestV2]] based on JSON-LD input.
-  */
+ * Constructs instances of [[ChangeCardinalitiesRequestV2]] based on JSON-LD input.
+ */
 object ChangeCardinalitiesRequestV2 extends KnoraJsonLDRequestReaderV2[ChangeCardinalitiesRequestV2] {
     /**
-      * Converts JSON-LD input into a [[ChangeCardinalitiesRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[ChangeCardinalitiesRequestV2]] representing the input.
-      */
+     * Converts JSON-LD input into a [[ChangeCardinalitiesRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[ChangeCardinalitiesRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -629,56 +629,56 @@ object ChangeCardinalitiesRequestV2 extends KnoraJsonLDRequestReaderV2[ChangeCar
 }
 
 /**
-  * Requests the deletion of a class. A successful response will be a [[ReadOntologyMetadataV2]].
-  *
-  * @param classIri             the IRI of the class to be deleted.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests the deletion of a class. A successful response will be a [[ReadOntologyMetadataV2]].
+ *
+ * @param classIri             the IRI of the class to be deleted.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class DeleteClassRequestV2(classIri: SmartIri,
                                 lastModificationDate: Instant,
                                 apiRequestID: UUID,
                                 requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests the deletion of a property. A successful response will be a [[ReadOntologyMetadataV2]].
-  *
-  * @param propertyIri          the IRI of the property to be deleted.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests the deletion of a property. A successful response will be a [[ReadOntologyMetadataV2]].
+ *
+ * @param propertyIri          the IRI of the property to be deleted.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class DeletePropertyRequestV2(propertyIri: SmartIri,
                                    lastModificationDate: Instant,
                                    apiRequestID: UUID,
                                    requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * A trait for requests to change entity labels or comments.
-  */
+ * A trait for requests to change entity labels or comments.
+ */
 sealed trait ChangeLabelsOrCommentsRequest {
     /**
-      * The predicate to update: `rdfs:label` or `rdfs:comment`.
-      */
+     * The predicate to update: `rdfs:label` or `rdfs:comment`.
+     */
     val predicateToUpdate: SmartIri
 
     /**
-      * The new objects of the predicate.
-      */
+     * The new objects of the predicate.
+     */
     val newObjects: Seq[StringLiteralV2]
 }
 
 /**
-  * Requests that a property's labels or comments are changed. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param propertyIri          the IRI of the property.
-  * @param predicateToUpdate    `rdfs:label` or `rdfs:comment`.
-  * @param newObjects           the property's new labels or comments.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests that a property's labels or comments are changed. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param propertyIri          the IRI of the property.
+ * @param predicateToUpdate    `rdfs:label` or `rdfs:comment`.
+ * @param newObjects           the property's new labels or comments.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class ChangePropertyLabelsOrCommentsRequestV2(propertyIri: SmartIri,
                                                    predicateToUpdate: SmartIri,
                                                    newObjects: Seq[StringLiteralV2],
@@ -687,24 +687,24 @@ case class ChangePropertyLabelsOrCommentsRequestV2(propertyIri: SmartIri,
                                                    requestingUser: UserADM) extends OntologiesResponderRequestV2 with ChangeLabelsOrCommentsRequest
 
 /**
-  * Constructs instances of [[ChangePropertyLabelsOrCommentsRequestV2]] based on JSON-LD input.
-  */
+ * Constructs instances of [[ChangePropertyLabelsOrCommentsRequestV2]] based on JSON-LD input.
+ */
 object ChangePropertyLabelsOrCommentsRequestV2 extends KnoraJsonLDRequestReaderV2[ChangePropertyLabelsOrCommentsRequestV2] {
 
 
     /**
-      * Converts a JSON-LD request to a [[ChangePropertyLabelsOrCommentsRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[ChangePropertyLabelsOrCommentsRequestV2]] representing the input.
-      */
+     * Converts a JSON-LD request to a [[ChangePropertyLabelsOrCommentsRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[ChangePropertyLabelsOrCommentsRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -744,15 +744,15 @@ object ChangePropertyLabelsOrCommentsRequestV2 extends KnoraJsonLDRequestReaderV
 }
 
 /**
-  * Requests that a class's labels or comments are changed. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param classIri             the IRI of the property.
-  * @param predicateToUpdate    `rdfs:label` or `rdfs:comment`.
-  * @param newObjects           the class's new labels or comments.
-  * @param lastModificationDate the ontology's last modification date.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests that a class's labels or comments are changed. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classIri             the IRI of the property.
+ * @param predicateToUpdate    `rdfs:label` or `rdfs:comment`.
+ * @param newObjects           the class's new labels or comments.
+ * @param lastModificationDate the ontology's last modification date.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class ChangeClassLabelsOrCommentsRequestV2(classIri: SmartIri,
                                                 predicateToUpdate: SmartIri,
                                                 newObjects: Seq[StringLiteralV2],
@@ -761,22 +761,22 @@ case class ChangeClassLabelsOrCommentsRequestV2(classIri: SmartIri,
                                                 requestingUser: UserADM) extends OntologiesResponderRequestV2 with ChangeLabelsOrCommentsRequest
 
 /**
-  * Constructs instances of [[ChangeClassLabelsOrCommentsRequestV2]] based on JSON-LD input.
-  */
+ * Constructs instances of [[ChangeClassLabelsOrCommentsRequestV2]] based on JSON-LD input.
+ */
 object ChangeClassLabelsOrCommentsRequestV2 extends KnoraJsonLDRequestReaderV2[ChangeClassLabelsOrCommentsRequestV2] {
     /**
-      * Converts a JSON-LD request to a [[ChangeClassLabelsOrCommentsRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[ChangeClassLabelsOrCommentsRequestV2]] representing the input.
-      */
+     * Converts a JSON-LD request to a [[ChangeClassLabelsOrCommentsRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[ChangeClassLabelsOrCommentsRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -816,14 +816,14 @@ object ChangeClassLabelsOrCommentsRequestV2 extends KnoraJsonLDRequestReaderV2[C
 }
 
 /**
-  * Requests a change in the metadata of an ontology. A successful response will be a [[ReadOntologyMetadataV2]].
-  *
-  * @param ontologyIri          the external ontology IRI.
-  * @param label                the ontology's new label.
-  * @param lastModificationDate the ontology's last modification date, returned in a previous operation.
-  * @param apiRequestID         the ID of the API request.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests a change in the metadata of an ontology. A successful response will be a [[ReadOntologyMetadataV2]].
+ *
+ * @param ontologyIri          the external ontology IRI.
+ * @param label                the ontology's new label.
+ * @param lastModificationDate the ontology's last modification date, returned in a previous operation.
+ * @param apiRequestID         the ID of the API request.
+ * @param requestingUser       the user making the request.
+ */
 case class ChangeOntologyMetadataRequestV2(ontologyIri: SmartIri,
                                            label: String,
                                            lastModificationDate: Instant,
@@ -831,22 +831,22 @@ case class ChangeOntologyMetadataRequestV2(ontologyIri: SmartIri,
                                            requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Constructs instances of [[ChangeOntologyMetadataRequestV2]] based on JSON-LD requests.
-  */
+ * Constructs instances of [[ChangeOntologyMetadataRequestV2]] based on JSON-LD requests.
+ */
 object ChangeOntologyMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[ChangeOntologyMetadataRequestV2] {
     /**
-      * Converts a JSON-LD request to a [[ChangeOntologyMetadataRequestV2]].
-      *
-      * @param jsonLDDocument   the JSON-LD input.
-      * @param apiRequestID     the UUID of the API request.
-      * @param requestingUser   the user making the request.
-      * @param responderManager a reference to the responder manager.
-      * @param storeManager     a reference to the store manager.
-      * @param log              a logging adapter.
-      * @param timeout          a timeout for `ask` messages.
-      * @param executionContext an execution context for futures.
-      * @return a [[ChangeClassLabelsOrCommentsRequestV2]] representing the input.
-      */
+     * Converts a JSON-LD request to a [[ChangeOntologyMetadataRequestV2]].
+     *
+     * @param jsonLDDocument   the JSON-LD input.
+     * @param apiRequestID     the UUID of the API request.
+     * @param requestingUser   the user making the request.
+     * @param responderManager a reference to the responder manager.
+     * @param storeManager     a reference to the store manager.
+     * @param log              a logging adapter.
+     * @param timeout          a timeout for `ask` messages.
+     * @param executionContext an execution context for futures.
+     * @return a [[ChangeClassLabelsOrCommentsRequestV2]] representing the input.
+     */
     override def fromJsonLD(jsonLDDocument: JsonLDDocument,
                             apiRequestID: UUID,
                             requestingUser: UserADM,
@@ -883,170 +883,170 @@ object ChangeOntologyMetadataRequestV2 extends KnoraJsonLDRequestReaderV2[Change
 }
 
 /**
-  * Requests all available information about a list of ontology entities (classes and/or properties). A successful response will be an
-  * [[EntityInfoGetResponseV2]].
-  *
-  * @param classIris      the IRIs of the class entities to be queried.
-  * @param propertyIris   the IRIs of the property entities to be queried.
-  * @param requestingUser the user making the request.
-  */
+ * Requests all available information about a list of ontology entities (classes and/or properties). A successful response will be an
+ * [[EntityInfoGetResponseV2]].
+ *
+ * @param classIris      the IRIs of the class entities to be queried.
+ * @param propertyIris   the IRIs of the property entities to be queried.
+ * @param requestingUser the user making the request.
+ */
 case class EntityInfoGetRequestV2(classIris: Set[SmartIri] = Set.empty[SmartIri], propertyIris: Set[SmartIri] = Set.empty[SmartIri], requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents assertions about one or more ontology entities (resource classes and/or properties).
-  *
-  * @param classInfoMap    a [[Map]] of class entity IRIs to [[ReadClassInfoV2]] objects.
-  * @param propertyInfoMap a [[Map]] of property entity IRIs to [[ReadPropertyInfoV2]] objects.
-  */
+ * Represents assertions about one or more ontology entities (resource classes and/or properties).
+ *
+ * @param classInfoMap    a [[Map]] of class entity IRIs to [[ReadClassInfoV2]] objects.
+ * @param propertyInfoMap a [[Map]] of property entity IRIs to [[ReadPropertyInfoV2]] objects.
+ */
 case class EntityInfoGetResponseV2(classInfoMap: Map[SmartIri, ReadClassInfoV2],
                                    propertyInfoMap: Map[SmartIri, ReadPropertyInfoV2])
 
 /**
-  * Requests all available information about a list of ontology entities (standoff classes and/or properties). A successful response will be an
-  * [[StandoffEntityInfoGetResponseV2]].
-  *
-  * @param standoffClassIris    the IRIs of the resource entities to be queried.
-  * @param standoffPropertyIris the IRIs of the property entities to be queried.
-  * @param requestingUser       the user making the request.
-  */
+ * Requests all available information about a list of ontology entities (standoff classes and/or properties). A successful response will be an
+ * [[StandoffEntityInfoGetResponseV2]].
+ *
+ * @param standoffClassIris    the IRIs of the resource entities to be queried.
+ * @param standoffPropertyIris the IRIs of the property entities to be queried.
+ * @param requestingUser       the user making the request.
+ */
 case class StandoffEntityInfoGetRequestV2(standoffClassIris: Set[SmartIri] = Set.empty[SmartIri], standoffPropertyIris: Set[SmartIri] = Set.empty[SmartIri], requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents assertions about one or more ontology entities (resource classes and/or properties).
-  *
-  * @param standoffClassInfoMap    a [[Map]] of standoff class IRIs to [[ReadClassInfoV2]] objects.
-  * @param standoffPropertyInfoMap a [[Map]] of standoff property IRIs to [[ReadPropertyInfoV2]] objects.
-  */
+ * Represents assertions about one or more ontology entities (resource classes and/or properties).
+ *
+ * @param standoffClassInfoMap    a [[Map]] of standoff class IRIs to [[ReadClassInfoV2]] objects.
+ * @param standoffPropertyInfoMap a [[Map]] of standoff property IRIs to [[ReadPropertyInfoV2]] objects.
+ */
 case class StandoffEntityInfoGetResponseV2(standoffClassInfoMap: Map[SmartIri, ReadClassInfoV2],
                                            standoffPropertyInfoMap: Map[SmartIri, ReadPropertyInfoV2])
 
 /**
-  * Requests information about all standoff classes that are a subclass of a data type standoff class. A successful response will be an
-  * [[StandoffClassesWithDataTypeGetResponseV2]].
-  *
-  * @param requestingUser the user making the request.
-  */
+ * Requests information about all standoff classes that are a subclass of a data type standoff class. A successful response will be an
+ * [[StandoffClassesWithDataTypeGetResponseV2]].
+ *
+ * @param requestingUser the user making the request.
+ */
 case class StandoffClassesWithDataTypeGetRequestV2(requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents assertions about all standoff classes that are a subclass of a data type standoff class.
-  *
-  * @param standoffClassInfoMap a [[Map]] of standoff class entity IRIs to [[ReadClassInfoV2]] objects.
-  */
+ * Represents assertions about all standoff classes that are a subclass of a data type standoff class.
+ *
+ * @param standoffClassInfoMap a [[Map]] of standoff class entity IRIs to [[ReadClassInfoV2]] objects.
+ */
 case class StandoffClassesWithDataTypeGetResponseV2(standoffClassInfoMap: Map[SmartIri, ReadClassInfoV2])
 
 /**
-  * Requests information about all standoff property entities. A successful response will be an
-  * [[StandoffAllPropertyEntitiesGetResponseV2]].
-  *
-  * @param requestingUser the user making the request.
-  */
+ * Requests information about all standoff property entities. A successful response will be an
+ * [[StandoffAllPropertyEntitiesGetResponseV2]].
+ *
+ * @param requestingUser the user making the request.
+ */
 case class StandoffAllPropertyEntitiesGetRequestV2(requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents assertions about all standoff all standoff property entities.
-  *
-  * @param standoffAllPropertiesEntityInfoMap a [[Map]] of standoff property IRIs to [[ReadPropertyInfoV2]] objects.
-  */
+ * Represents assertions about all standoff all standoff property entities.
+ *
+ * @param standoffAllPropertiesEntityInfoMap a [[Map]] of standoff property IRIs to [[ReadPropertyInfoV2]] objects.
+ */
 case class StandoffAllPropertyEntitiesGetResponseV2(standoffAllPropertiesEntityInfoMap: Map[SmartIri, ReadPropertyInfoV2])
 
 /**
-  * Checks whether a Knora resource or value class is a subclass of (or identical to) another class.
-  * A successful response will be a [[CheckSubClassResponseV2]].
-  *
-  * @param subClassIri   the IRI of the subclass.
-  * @param superClassIri the IRI of the superclass.
-  */
+ * Checks whether a Knora resource or value class is a subclass of (or identical to) another class.
+ * A successful response will be a [[CheckSubClassResponseV2]].
+ *
+ * @param subClassIri   the IRI of the subclass.
+ * @param superClassIri the IRI of the superclass.
+ */
 case class CheckSubClassRequestV2(subClassIri: SmartIri, superClassIri: SmartIri, requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents a response to a [[CheckSubClassRequestV2]].
-  *
-  * @param isSubClass `true` if the requested inheritance relationship exists.
-  */
+ * Represents a response to a [[CheckSubClassRequestV2]].
+ *
+ * @param isSubClass `true` if the requested inheritance relationship exists.
+ */
 case class CheckSubClassResponseV2(isSubClass: Boolean)
 
 /**
-  * Requests information about the subclasses of a Knora resource class. A successful response will be
-  * a [[SubClassesGetResponseV2]].
-  *
-  * @param resourceClassIri the IRI of the given resource class.
-  * @param requestingUser   the user making the request.
-  */
+ * Requests information about the subclasses of a Knora resource class. A successful response will be
+ * a [[SubClassesGetResponseV2]].
+ *
+ * @param resourceClassIri the IRI of the given resource class.
+ * @param requestingUser   the user making the request.
+ */
 case class SubClassesGetRequestV2(resourceClassIri: SmartIri, requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Provides information about the subclasses of a Knora resource class.
-  *
-  * @param subClasses a list of [[SubClassInfoV2]] representing the subclasses of the specified class.
-  */
+ * Provides information about the subclasses of a Knora resource class.
+ *
+ * @param subClasses a list of [[SubClassInfoV2]] representing the subclasses of the specified class.
+ */
 case class SubClassesGetResponseV2(subClasses: Seq[SubClassInfoV2])
 
 /**
-  *
-  * Request information about the Knora entities (Knora resource classes, standoff class, resource properties, and standoff properties) of a named graph.
-  * A successful response will be a [[OntologyKnoraEntitiesIriInfoV2]].
-  *
-  * @param ontologyIri    the IRI of the named graph.
-  * @param requestingUser the user making the request.
-  */
+ *
+ * Request information about the Knora entities (Knora resource classes, standoff class, resource properties, and standoff properties) of a named graph.
+ * A successful response will be a [[OntologyKnoraEntitiesIriInfoV2]].
+ *
+ * @param ontologyIri    the IRI of the named graph.
+ * @param requestingUser the user making the request.
+ */
 case class OntologyKnoraEntityIrisGetRequestV2(ontologyIri: SmartIri, requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests metadata about ontologies by project.
-  *
-  * @param projectIris    the IRIs of the projects for which ontologies should be returned. If this set is empty, information
-  *                       about all ontologies is returned.
-  * @param requestingUser the user making the request.
-  */
+ * Requests metadata about ontologies by project.
+ *
+ * @param projectIris    the IRIs of the projects for which ontologies should be returned. If this set is empty, information
+ *                       about all ontologies is returned.
+ * @param requestingUser the user making the request.
+ */
 case class OntologyMetadataGetByProjectRequestV2(projectIris: Set[SmartIri] = Set.empty[SmartIri], requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests metadata about ontologies by ontology IRI.
-  *
-  * @param ontologyIris   the IRIs of the ontologies to be queried. If this set is empty, information
-  *                       about all ontologies is returned.
-  * @param requestingUser the user making the request.
-  */
+ * Requests metadata about ontologies by ontology IRI.
+ *
+ * @param ontologyIris   the IRIs of the ontologies to be queried. If this set is empty, information
+ *                       about all ontologies is returned.
+ * @param requestingUser the user making the request.
+ */
 case class OntologyMetadataGetByIriRequestV2(ontologyIris: Set[SmartIri] = Set.empty[SmartIri], requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests entity definitions for the given ontology.
-  *
-  * @param ontologyIri    the ontology to query for.
-  * @param allLanguages   true if information in all available languages should be returned.
-  * @param requestingUser the user making the request.
-  */
+ * Requests entity definitions for the given ontology.
+ *
+ * @param ontologyIri    the ontology to query for.
+ * @param allLanguages   true if information in all available languages should be returned.
+ * @param requestingUser the user making the request.
+ */
 case class OntologyEntitiesGetRequestV2(ontologyIri: SmartIri, allLanguages: Boolean, requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests the entity definitions for the given class IRIs. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param classIris      the IRIs of the classes to be queried.
-  * @param allLanguages   true if information in all available languages should be returned.
-  * @param requestingUser the user making the request.
-  */
+ * Requests the entity definitions for the given class IRIs. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param classIris      the IRIs of the classes to be queried.
+ * @param allLanguages   true if information in all available languages should be returned.
+ * @param requestingUser the user making the request.
+ */
 case class ClassesGetRequestV2(classIris: Set[SmartIri], allLanguages: Boolean, requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Requests the definitions of the specified properties. A successful response will be a [[ReadOntologyV2]].
-  *
-  * @param propertyIris   the IRIs of the properties to be queried.
-  * @param allLanguages   true if information in all available languages should be returned.
-  * @param requestingUser the user making the request.
-  */
+ * Requests the definitions of the specified properties. A successful response will be a [[ReadOntologyV2]].
+ *
+ * @param propertyIris   the IRIs of the properties to be queried.
+ * @param allLanguages   true if information in all available languages should be returned.
+ * @param requestingUser the user making the request.
+ */
 case class PropertiesGetRequestV2(propertyIris: Set[SmartIri], allLanguages: Boolean, requestingUser: UserADM) extends OntologiesResponderRequestV2
 
 /**
-  * Represents the contents of an ontology to be returned in an API response.
-  *
-  * @param ontologyMetadata metadata about the ontology.
-  * @param classes          information about classes.
-  * @param properties       information about properties.
-  * @param isWholeOntology  `true` if this is the whole specified ontology, `false` if it's just selected entities.
-  * @param userLang         the preferred language in which the information should be returned, or [[None]] if information
-  *                         should be returned in all available languages.
-  */
+ * Represents the contents of an ontology to be returned in an API response.
+ *
+ * @param ontologyMetadata metadata about the ontology.
+ * @param classes          information about classes.
+ * @param properties       information about properties.
+ * @param isWholeOntology  `true` if this is the whole specified ontology, `false` if it's just selected entities.
+ * @param userLang         the preferred language in which the information should be returned, or [[None]] if information
+ *                         should be returned in all available languages.
+ */
 case class ReadOntologyV2(ontologyMetadata: OntologyMetadataV2,
                           classes: Map[SmartIri, ReadClassInfoV2] = Map.empty[SmartIri, ReadClassInfoV2],
                           properties: Map[SmartIri, ReadPropertyInfoV2] = Map.empty[SmartIri, ReadPropertyInfoV2],
@@ -1056,11 +1056,11 @@ case class ReadOntologyV2(ontologyMetadata: OntologyMetadataV2,
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * Converts this [[ReadOntologyV2]] to the specified Knora API v2 schema.
-      *
-      * @param targetSchema the target schema.
-      * @return the converted [[ReadOntologyV2]].
-      */
+     * Converts this [[ReadOntologyV2]] to the specified Knora API v2 schema.
+     *
+     * @param targetSchema the target schema.
+     * @return the converted [[ReadOntologyV2]].
+     */
     override def toOntologySchema(targetSchema: ApiV2Schema): ReadOntologyV2 = {
         // Get rules for transforming internal entities to external entities in the target schema.
         val transformationRules = OntologyTransformationRules.getTransformationRules(ontologyMetadata.ontologyIri, targetSchema)
@@ -1247,26 +1247,26 @@ case class ReadOntologyV2(ontologyMetadata: OntologyMetadataV2,
 }
 
 /**
-  * Represents information about an ontology received as input, either from the client or from the API server (in
-  * the case of a test). This information is necessarily less complete than the information in a [[ReadOntologyV2]],
-  * which takes advantage of additional knowledge that is available from the triplestore.
-  *
-  * @param ontologyMetadata metadata about the ontology.
-  * @param classes          information about classes in the ontology.
-  * @param properties       information about properties in the ontology.
-  * @param individuals      information about OWL named individuals in the ontology.
-  */
+ * Represents information about an ontology received as input, either from the client or from the API server (in
+ * the case of a test). This information is necessarily less complete than the information in a [[ReadOntologyV2]],
+ * which takes advantage of additional knowledge that is available from the triplestore.
+ *
+ * @param ontologyMetadata metadata about the ontology.
+ * @param classes          information about classes in the ontology.
+ * @param properties       information about properties in the ontology.
+ * @param individuals      information about OWL named individuals in the ontology.
+ */
 case class InputOntologyV2(ontologyMetadata: OntologyMetadataV2,
                            classes: Map[SmartIri, ClassInfoContentV2] = Map.empty[SmartIri, ClassInfoContentV2],
                            properties: Map[SmartIri, PropertyInfoContentV2] = Map.empty[SmartIri, PropertyInfoContentV2],
                            individuals: Map[SmartIri, IndividualInfoContentV2] = Map.empty[SmartIri, IndividualInfoContentV2]) {
 
     /**
-      * Converts this [[InputOntologyV2]] to the specified Knora API v2 schema.
-      *
-      * @param targetSchema the target schema.
-      * @return the converted [[InputOntologyV2]].
-      */
+     * Converts this [[InputOntologyV2]] to the specified Knora API v2 schema.
+     *
+     * @param targetSchema the target schema.
+     * @return the converted [[InputOntologyV2]].
+     */
     def toOntologySchema(targetSchema: ApiV2Schema): InputOntologyV2 = {
         InputOntologyV2(
             ontologyMetadata = ontologyMetadata.toOntologySchema(targetSchema),
@@ -1283,13 +1283,13 @@ case class InputOntologyV2(ontologyMetadata: OntologyMetadataV2,
     }
 
     /**
-      * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used in tests after an update, when the
-      * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
-      * read back from the triplestore (in which predicate objects are not escaped). It is also used in generating
-      * client API code.
-      *
-      * @return a copy of this [[InputOntologyV2]] with all predicate objects unescaped.
-      */
+     * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used in tests after an update, when the
+     * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
+     * read back from the triplestore (in which predicate objects are not escaped). It is also used in generating
+     * client API code.
+     *
+     * @return a copy of this [[InputOntologyV2]] with all predicate objects unescaped.
+     */
     def unescape: InputOntologyV2 = {
         InputOntologyV2(
             ontologyMetadata = ontologyMetadata.unescape,
@@ -1307,42 +1307,42 @@ case class InputOntologyV2(ontologyMetadata: OntologyMetadataV2,
 }
 
 /**
-  * Represents a parsing mode used by [[InputOntologyV2]].
-  */
+ * Represents a parsing mode used by [[InputOntologyV2]].
+ */
 sealed trait InputOntologyParsingModeV2
 
 /**
-  * A parsing mode that ignores predicates that are present in Knora responses and absent in client input.
-  * In tests, this allows a Knora response containing an entity to be parsed and compared with the client input
-  * that was used to create the entity.
-  */
+ * A parsing mode that ignores predicates that are present in Knora responses and absent in client input.
+ * In tests, this allows a Knora response containing an entity to be parsed and compared with the client input
+ * that was used to create the entity.
+ */
 case object TestResponseParsingModeV2 extends InputOntologyParsingModeV2
 
 /**
-  * A parsing mode that rejects data not allowed in client input.
-  */
+ * A parsing mode that rejects data not allowed in client input.
+ */
 case object ClientInputParsingModeV2 extends InputOntologyParsingModeV2
 
 /**
-  * A parsing mode for parsing everything returned in a Knora ontology response.
-  */
+ * A parsing mode for parsing everything returned in a Knora ontology response.
+ */
 case object KnoraOutputParsingModeV2 extends InputOntologyParsingModeV2
 
 /**
-  * Processes JSON-LD received either from the client or from the API server. This is intended to support
-  * two use cases:
-  *
-  * 1. When an update request is received, an [[InputOntologyV2]] can be used to construct an update request message.
-  * 1. In a test, in which the submitted JSON-LD is similar to the server's response, both can be converted to [[InputOntologyV2]] objects for comparison.
-  */
+ * Processes JSON-LD received either from the client or from the API server. This is intended to support
+ * two use cases:
+ *
+ * 1. When an update request is received, an [[InputOntologyV2]] can be used to construct an update request message.
+ * 1. In a test, in which the submitted JSON-LD is similar to the server's response, both can be converted to [[InputOntologyV2]] objects for comparison.
+ */
 object InputOntologyV2 {
     /**
-      * Constructs an [[InputOntologyV2]] based on a JSON-LD document.
-      *
-      * @param jsonLDDocument a JSON-LD document representing information about the ontology.
-      * @param parsingMode    the parsing mode to be used.
-      * @return an [[InputOntologyV2]] representing the same information.
-      */
+     * Constructs an [[InputOntologyV2]] based on a JSON-LD document.
+     *
+     * @param jsonLDDocument a JSON-LD document representing information about the ontology.
+     * @param parsingMode    the parsing mode to be used.
+     * @return an [[InputOntologyV2]] representing the same information.
+     */
     def fromJsonLD(jsonLDDocument: JsonLDDocument, parsingMode: InputOntologyParsingModeV2 = ClientInputParsingModeV2): InputOntologyV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -1427,10 +1427,10 @@ object InputOntologyV2 {
 }
 
 /**
-  * Returns metadata about Knora ontologies.
-  *
-  * @param ontologies the metadata to be returned.
-  */
+ * Returns metadata about Knora ontologies.
+ *
+ * @param ontologies the metadata to be returned.
+ */
 case class ReadOntologyMetadataV2(ontologies: Set[OntologyMetadataV2]) extends KnoraResponseV2 with KnoraReadV2[ReadOntologyMetadataV2] {
 
     override def toOntologySchema(targetSchema: ApiV2Schema): ReadOntologyMetadataV2 = {
@@ -1475,21 +1475,21 @@ case class ReadOntologyMetadataV2(ontologies: Set[OntologyMetadataV2]) extends K
 }
 
 /**
-  * Represents a predicate that is asserted about a given ontology entity, and the objects of that predicate.
-  *
-  * @param predicateIri the IRI of the predicate.
-  * @param objects      the objects of the predicate.
-  */
+ * Represents a predicate that is asserted about a given ontology entity, and the objects of that predicate.
+ *
+ * @param predicateIri the IRI of the predicate.
+ * @param objects      the objects of the predicate.
+ */
 case class PredicateInfoV2(predicateIri: SmartIri,
                            objects: Seq[OntologyLiteralV2] = Seq.empty[OntologyLiteralV2]) {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * Converts this [[PredicateInfoV2]] to another ontology schema.
-      *
-      * @param targetSchema the target schema.
-      * @return the converted [[PredicateInfoV2]].
-      */
+     * Converts this [[PredicateInfoV2]] to another ontology schema.
+     *
+     * @param targetSchema the target schema.
+     * @return the converted [[PredicateInfoV2]].
+     */
     def toOntologySchema(targetSchema: OntologySchema): PredicateInfoV2 = {
         copy(
             predicateIri = predicateIri.toOntologySchema(targetSchema),
@@ -1501,12 +1501,12 @@ case class PredicateInfoV2(predicateIri: SmartIri,
     }
 
     /**
-      * Requires this predicate to have a single IRI object, and returns that object.
-      *
-      * @param errorFun a function that throws an error. It will be called if the predicate does not have a single
-      *                 IRI object.
-      * @return the predicate's IRI object.
-      */
+     * Requires this predicate to have a single IRI object, and returns that object.
+     *
+     * @param errorFun a function that throws an error. It will be called if the predicate does not have a single
+     *                 IRI object.
+     * @return the predicate's IRI object.
+     */
     def requireIriObject(errorFun: => Nothing): SmartIri = {
         objects match {
             case Seq(SmartIriLiteralV2(iri)) => iri
@@ -1515,12 +1515,12 @@ case class PredicateInfoV2(predicateIri: SmartIri,
     }
 
     /**
-      * Requires this predicate to have at least one IRI, and returns those objects.
-      *
-      * @param errorFun a function that throws an error. It will be called if the predicate has no objects,
-      *                 or has non-IRI objects.
-      * @return the predicate's IRI objects.
-      */
+     * Requires this predicate to have at least one IRI, and returns those objects.
+     *
+     * @param errorFun a function that throws an error. It will be called if the predicate has no objects,
+     *                 or has non-IRI objects.
+     * @return the predicate's IRI objects.
+     */
     def requireIriObjects(errorFun: => Nothing): Set[SmartIri] = {
         if (objects.isEmpty) {
             errorFun
@@ -1533,12 +1533,12 @@ case class PredicateInfoV2(predicateIri: SmartIri,
     }
 
     /**
-      * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
-      * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
-      * read back from the triplestore (in which predicate objects are not escaped).
-      *
-      * @return this predicate with its objects unescaped.
-      */
+     * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
+     * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
+     * read back from the triplestore (in which predicate objects are not escaped).
+     *
+     * @return this predicate with its objects unescaped.
+     */
     def unescape: PredicateInfoV2 = {
         copy(
             objects = objects.map {
@@ -1566,19 +1566,19 @@ case class PredicateInfoV2(predicateIri: SmartIri,
 }
 
 /**
-  * Represents the OWL cardinalities that Knora supports.
-  */
+ * Represents the OWL cardinalities that Knora supports.
+ */
 object Cardinality extends Enumeration {
 
     /**
-      * Represents information about an OWL cardinality.
-      *
-      * @param owlCardinalityIri   the IRI of the OWL cardinality, which must be a member of the set
-      *                            [[OntologyConstants.Owl.cardinalityOWLRestrictions]].
-      * @param owlCardinalityValue the value of the OWL cardinality, which must be 0 or 1.
-      * @param guiOrder            the SALSAH GUI order.
-      * @return a [[Value]].
-      */
+     * Represents information about an OWL cardinality.
+     *
+     * @param owlCardinalityIri   the IRI of the OWL cardinality, which must be a member of the set
+     *                            [[OntologyConstants.Owl.cardinalityOWLRestrictions]].
+     * @param owlCardinalityValue the value of the OWL cardinality, which must be 0 or 1.
+     * @param guiOrder            the SALSAH GUI order.
+     * @return a [[Value]].
+     */
     case class OwlCardinalityInfo(owlCardinalityIri: IRI, owlCardinalityValue: Int, guiOrder: Option[Int] = None) {
         if (!OntologyConstants.Owl.cardinalityOWLRestrictions.contains(owlCardinalityIri)) {
             throw InconsistentTriplestoreDataException(s"Invalid OWL cardinality property: $owlCardinalityIri")
@@ -1596,11 +1596,11 @@ object Cardinality extends Enumeration {
     }
 
     /**
-      * Represents a Knora cardinality with an optional SALSAH GUI order.
-      *
-      * @param cardinality the Knora cardinality.
-      * @param guiOrder    the SALSAH GUI order.
-      */
+     * Represents a Knora cardinality with an optional SALSAH GUI order.
+     *
+     * @param cardinality the Knora cardinality.
+     * @param guiOrder    the SALSAH GUI order.
+     */
     case class KnoraCardinalityInfo(cardinality: Value, guiOrder: Option[Int] = None) {
         override def toString: String = cardinality.toString
     }
@@ -1615,8 +1615,8 @@ object Cardinality extends Enumeration {
     val valueMap: Map[String, Value] = values.map(v => (v.toString, v)).toMap
 
     /**
-      * The valid mappings between Knora cardinalities and OWL cardinalities.
-      */
+     * The valid mappings between Knora cardinalities and OWL cardinalities.
+     */
     private val knoraCardinality2OwlCardinalityMap: Map[Value, OwlCardinalityInfo] = Map(
         MayHaveOne -> OwlCardinalityInfo(owlCardinalityIri = OntologyConstants.Owl.MaxCardinality, owlCardinalityValue = 1),
         MayHaveMany -> OwlCardinalityInfo(owlCardinalityIri = OntologyConstants.Owl.MinCardinality, owlCardinalityValue = 0),
@@ -1629,12 +1629,12 @@ object Cardinality extends Enumeration {
     }
 
     /**
-      * Given the name of a value in this enumeration, returns the value. If the value is not found, throws an
-      * [[InconsistentTriplestoreDataException]].
-      *
-      * @param name the name of the value.
-      * @return the requested value.
-      */
+     * Given the name of a value in this enumeration, returns the value. If the value is not found, throws an
+     * [[InconsistentTriplestoreDataException]].
+     *
+     * @param name the name of the value.
+     * @return the requested value.
+     */
     def lookup(name: String): Value = {
         valueMap.get(name) match {
             case Some(value) => value
@@ -1643,12 +1643,12 @@ object Cardinality extends Enumeration {
     }
 
     /**
-      * Converts information about an OWL cardinality restriction to a [[Value]] of this enumeration.
-      *
-      * @param propertyIri    the IRI of the property that the OWL cardinality applies to.
-      * @param owlCardinality information about an OWL cardinality.
-      * @return a [[Value]].
-      */
+     * Converts information about an OWL cardinality restriction to a [[Value]] of this enumeration.
+     *
+     * @param propertyIri    the IRI of the property that the OWL cardinality applies to.
+     * @param owlCardinality information about an OWL cardinality.
+     * @return a [[Value]].
+     */
     def owlCardinality2KnoraCardinality(propertyIri: IRI, owlCardinality: OwlCardinalityInfo): KnoraCardinalityInfo = {
         val cardinality = owlCardinality2KnoraCardinalityMap.getOrElse(owlCardinality.copy(guiOrder = None), throw InconsistentTriplestoreDataException(s"Invalid OWL cardinality $owlCardinality for $propertyIri"))
 
@@ -1659,24 +1659,24 @@ object Cardinality extends Enumeration {
     }
 
     /**
-      * Converts a [[Value]] of this enumeration to information about an OWL cardinality restriction.
-      *
-      * @param knoraCardinality a [[Value]].
-      * @return an [[OwlCardinalityInfo]].
-      */
+     * Converts a [[Value]] of this enumeration to information about an OWL cardinality restriction.
+     *
+     * @param knoraCardinality a [[Value]].
+     * @return an [[OwlCardinalityInfo]].
+     */
     def knoraCardinality2OwlCardinality(knoraCardinality: KnoraCardinalityInfo): OwlCardinalityInfo = {
         knoraCardinality2OwlCardinalityMap(knoraCardinality.cardinality).copy(guiOrder = knoraCardinality.guiOrder)
     }
 
     /**
-      * Checks whether a cardinality that is directly defined on a class is compatible with an inherited cardinality on the
-      * same property. This will be true only if the directly defined cardinality is at least as restrictive as the
-      * inherited one.
-      *
-      * @param directCardinality      the directly defined cardinality.
-      * @param inheritableCardinality the inherited cardinality.
-      * @return `true` if the directly defined cardinality is compatible with the inherited one.
-      */
+     * Checks whether a cardinality that is directly defined on a class is compatible with an inherited cardinality on the
+     * same property. This will be true only if the directly defined cardinality is at least as restrictive as the
+     * inherited one.
+     *
+     * @param directCardinality      the directly defined cardinality.
+     * @param inheritableCardinality the inherited cardinality.
+     * @return `true` if the directly defined cardinality is compatible with the inherited one.
+     */
     def isCompatible(directCardinality: Value, inheritableCardinality: Value): Boolean = {
         if (directCardinality == inheritableCardinality) {
             true
@@ -1693,63 +1693,63 @@ object Cardinality extends Enumeration {
 
 
 /**
-  * Represents information about an ontology entity.
-  */
+ * Represents information about an ontology entity.
+ */
 sealed trait EntityInfoContentV2 {
     /**
-      * The predicates of the entity, and their objects.
-      */
+     * The predicates of the entity, and their objects.
+     */
     val predicates: Map[SmartIri, PredicateInfoV2]
 
     protected implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * Checks that a predicate is present in this [[EntityInfoContentV2]] and that it has a single IRI object, and
-      * returns the object as a [[SmartIri]].
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @param errorFun     a function that will be called if the predicate is absent or if its object is not an IRI.
-      * @return a [[SmartIri]] representing the predicate's object.
-      */
+     * Checks that a predicate is present in this [[EntityInfoContentV2]] and that it has a single IRI object, and
+     * returns the object as a [[SmartIri]].
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @param errorFun     a function that will be called if the predicate is absent or if its object is not an IRI.
+     * @return a [[SmartIri]] representing the predicate's object.
+     */
     def requireIriObject(predicateIri: SmartIri, errorFun: => Nothing): SmartIri = {
         predicates.getOrElse(predicateIri, errorFun).requireIriObject(errorFun)
     }
 
     /**
-      * Checks that a predicate is present in this [[EntityInfoContentV2]] and that it at least one IRI object, and
-      * returns those objects as a set of [[SmartIri]] instances.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @param errorFun     a function that will be called if the predicate is absent or if its objects are not IRIs.
-      * @return a set of [[SmartIri]] instances representing the predicate's objects.
-      */
+     * Checks that a predicate is present in this [[EntityInfoContentV2]] and that it at least one IRI object, and
+     * returns those objects as a set of [[SmartIri]] instances.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @param errorFun     a function that will be called if the predicate is absent or if its objects are not IRIs.
+     * @return a set of [[SmartIri]] instances representing the predicate's objects.
+     */
     def requireIriObjects(predicateIri: SmartIri, errorFun: => Nothing): Set[SmartIri] = {
         predicates.getOrElse(predicateIri, errorFun).requireIriObjects(errorFun)
     }
 
     /**
-      * A convenience method that returns the canonical `rdf:type` of this entity. Throws [[InconsistentTriplestoreDataException]]
-      * if the entity's predicates do not include `rdf:type`.
-      *
-      * @return the entity's `rdf:type`.
-      */
+     * A convenience method that returns the canonical `rdf:type` of this entity. Throws [[InconsistentTriplestoreDataException]]
+     * if the entity's predicates do not include `rdf:type`.
+     *
+     * @return the entity's `rdf:type`.
+     */
     def getRdfType: SmartIri
 
     /**
-      * A convenience method that returns all the objects of this entity's `rdf:type` predicate. Throws [[InconsistentTriplestoreDataException]]
-      * * if the entity's predicates do not include `rdf:type`.
-      *
-      * @return all the values of `rdf:type` for this entity, sorted for determinism.
-      */
+     * A convenience method that returns all the objects of this entity's `rdf:type` predicate. Throws [[InconsistentTriplestoreDataException]]
+     * * if the entity's predicates do not include `rdf:type`.
+     *
+     * @return all the values of `rdf:type` for this entity, sorted for determinism.
+     */
     def getRdfTypes: Seq[SmartIri]
 
     /**
-      * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
-      * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
-      * read back from the triplestore (in which predicate objects are not escaped).
-      *
-      * @return the predicates of this [[EntityInfoContentV2]], with their objects unescaped.
-      */
+     * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
+     * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
+     * read back from the triplestore (in which predicate objects are not escaped).
+     *
+     * @return the predicates of this [[EntityInfoContentV2]], with their objects unescaped.
+     */
     protected def unescapePredicateObjects: Map[SmartIri, PredicateInfoV2] = {
         predicates.map {
             case (predicateIri, predicateInfo) => predicateIri -> predicateInfo.unescape
@@ -1757,12 +1757,12 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Gets a predicate and its object from an entity in a specific language.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @param userLang     the language in which the object should to be returned.
-      * @return the requested predicate and object.
-      */
+     * Gets a predicate and its object from an entity in a specific language.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @param userLang     the language in which the object should to be returned.
+     * @return the requested predicate and object.
+     */
     def getPredicateAndStringLiteralObjectWithLang(predicateIri: SmartIri, settings: SettingsImpl, userLang: String): Option[(SmartIri, String)] = {
         getPredicateStringLiteralObject(
             predicateIri = predicateIri,
@@ -1771,14 +1771,14 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Returns an object for a given predicate. If requested, attempts to return the object in the user's preferred
-      * language, in the system's default language, or in any language, in that order.
-      *
-      * @param predicateIri   the IRI of the predicate.
-      * @param preferredLangs the user's preferred language and the system's default language.
-      * @return an object for the predicate, or [[None]] if this entity doesn't have the specified predicate, or
-      *         if the predicate has no objects.
-      */
+     * Returns an object for a given predicate. If requested, attempts to return the object in the user's preferred
+     * language, in the system's default language, or in any language, in that order.
+     *
+     * @param predicateIri   the IRI of the predicate.
+     * @param preferredLangs the user's preferred language and the system's default language.
+     * @return an object for the predicate, or [[None]] if this entity doesn't have the specified predicate, or
+     *         if the predicate has no objects.
+     */
     def getPredicateStringLiteralObject(predicateIri: SmartIri, preferredLangs: Option[(String, String)] = None): Option[String] = {
         // Does the predicate exist?
         predicates.get(predicateIri) match {
@@ -1809,11 +1809,11 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Returns all the non-language-specific string objects specified for a given predicate.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @return the predicate's objects, or an empty set if this entity doesn't have the specified predicate.
-      */
+     * Returns all the non-language-specific string objects specified for a given predicate.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @return the predicate's objects, or an empty set if this entity doesn't have the specified predicate.
+     */
     def getPredicateStringLiteralObjectsWithoutLang(predicateIri: SmartIri): Seq[String] = {
         predicates.get(predicateIri) match {
             case Some(predicateInfo) => predicateInfo.objects.collect {
@@ -1825,11 +1825,11 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Returns all the IRI objects specified for a given predicate.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @return the predicate's IRI objects, or an empty set if this entity doesn't have the specified predicate.
-      */
+     * Returns all the IRI objects specified for a given predicate.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @return the predicate's IRI objects, or an empty set if this entity doesn't have the specified predicate.
+     */
     def getPredicateIriObjects(predicateIri: SmartIri): Seq[SmartIri] = {
         predicates.get(predicateIri) match {
             case Some(predicateInfo) => predicateInfo.objects.collect {
@@ -1841,12 +1841,12 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Returns the first object specified as a boolean value for the given predicate, or `false` if the
-      * entity doesn't have that predicate.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @return the predicate's object, if given, otherwise `false`.
-      */
+     * Returns the first object specified as a boolean value for the given predicate, or `false` if the
+     * entity doesn't have that predicate.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @return the predicate's object, if given, otherwise `false`.
+     */
     def getPredicateBooleanObject(predicateIri: SmartIri): Boolean = {
         val values: Seq[Boolean] = predicates.get(predicateIri) match {
             case Some(predicateInfo) => predicateInfo.objects.collect {
@@ -1864,19 +1864,19 @@ sealed trait EntityInfoContentV2 {
     }
 
     /**
-      * Returns the first object specified as an IRI for the given predicate.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @return the predicate's object, if given.
-      */
+     * Returns the first object specified as an IRI for the given predicate.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @return the predicate's object, if given.
+     */
     def getPredicateIriObject(predicateIri: SmartIri): Option[SmartIri] = getPredicateIriObjects(predicateIri).headOption
 
     /**
-      * Returns all the objects specified for a given predicate, along with the language tag of each object.
-      *
-      * @param predicateIri the IRI of the predicate.
-      * @return a map of language tags to objects, or an empty map if this entity doesn't have the specified predicate.
-      */
+     * Returns all the objects specified for a given predicate, along with the language tag of each object.
+     *
+     * @param predicateIri the IRI of the predicate.
+     * @return a map of language tags to objects, or an empty map if this entity doesn't have the specified predicate.
+     */
     def getPredicateObjectsWithLangs(predicateIri: SmartIri): Map[String, String] = {
         predicates.get(predicateIri) match {
             case Some(predicateInfo) => predicateInfo.objects.collect {
@@ -1889,8 +1889,8 @@ sealed trait EntityInfoContentV2 {
 }
 
 /**
-  * Processes predicates from a JSON-LD class or property definition.
-  */
+ * Processes predicates from a JSON-LD class or property definition.
+ */
 object EntityInfoContentV2 {
     private def stringToLiteral(str: String): StringLiteralV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
@@ -1899,12 +1899,12 @@ object EntityInfoContentV2 {
     }
 
     /**
-      * Processes predicates from a JSON-LD class or property definition. Converts `@type` to `rdf:type`. Ignores
-      * `\@id`, `rdfs:subClassOf` and `rdfs:subPropertyOf`.
-      *
-      * @param jsonLDObject the JSON-LD class or property definition.
-      * @return a map of predicate IRIs to [[PredicateInfoV2]] objects.
-      */
+     * Processes predicates from a JSON-LD class or property definition. Converts `@type` to `rdf:type`. Ignores
+     * `\@id`, `rdfs:subClassOf` and `rdfs:subPropertyOf`.
+     *
+     * @param jsonLDObject the JSON-LD class or property definition.
+     * @return a map of predicate IRIs to [[PredicateInfoV2]] objects.
+     */
     def predicatesFromJsonLDObject(jsonLDObject: JsonLDObject): Map[SmartIri, PredicateInfoV2] = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -1915,7 +1915,7 @@ object EntityInfoContentV2 {
             objects = Seq(SmartIriLiteralV2(entityType))
         )
 
-        val predicates = jsonLDObject.value - JsonLDConstants.ID - JsonLDConstants.TYPE - OntologyConstants.Rdfs.SubClassOf - OntologyConstants.Rdfs.SubPropertyOf
+        val predicates = jsonLDObject.value - JsonLDConstants.ID - JsonLDConstants.TYPE - OntologyConstants.Rdfs.SubClassOf - OntologyConstants.Rdfs.SubPropertyOf - OntologyConstants.Owl.WithRestrictions
 
         predicates.map {
             case (predicateIriStr: IRI, predicateValue: JsonLDValue) =>
@@ -1948,7 +1948,7 @@ object EntityInfoContentV2 {
                                 objects = JsonLDArray(Seq(objObj)).toObjsWithLang
                             )
                         } else {
-                            throw BadRequestException(s"Unexpected object value: $objObj")
+                            throw BadRequestException(s"Unexpected object value for predicate $predicateIri: $objObj")
                         }
 
                     case objArray: JsonLDArray =>
@@ -2001,31 +2001,31 @@ object EntityInfoContentV2 {
 }
 
 /**
-  * Represents information about an ontolgoy entity, as returned in an API response.
-  */
+ * Represents information about an ontolgoy entity, as returned in an API response.
+ */
 sealed trait ReadEntityInfoV2 {
     /**
-      * Provides basic information about the entity.
-      */
+     * Provides basic information about the entity.
+     */
     val entityInfoContent: EntityInfoContentV2
 
     protected implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     /**
-      * Returns the contents of a JSON-LD object containing non-language-specific information about the entity.
-      *
-      * @param targetSchema the API v2 schema in which the response will be returned.
-      */
+     * Returns the contents of a JSON-LD object containing non-language-specific information about the entity.
+     *
+     * @param targetSchema the API v2 schema in which the response will be returned.
+     */
     protected def getNonLanguageSpecific(targetSchema: ApiV2Schema): Map[IRI, JsonLDValue]
 
     /**
-      * Returns a JSON-LD object representing the entity, with language-specific information provided in a single language.
-      *
-      * @param targetSchema the API v2 schema in which the response will be returned.
-      * @param userLang     the user's preferred language.
-      * @param settings     the application settings.
-      * @return a JSON-LD object representing the entity.
-      */
+     * Returns a JSON-LD object representing the entity, with language-specific information provided in a single language.
+     *
+     * @param targetSchema the API v2 schema in which the response will be returned.
+     * @param userLang     the user's preferred language.
+     * @param settings     the application settings.
+     * @return a JSON-LD object representing the entity.
+     */
     def toJsonLDWithSingleLanguage(targetSchema: ApiV2Schema, userLang: String, settings: SettingsImpl): JsonLDObject = {
         val label: Option[(IRI, JsonLDString)] = entityInfoContent.getPredicateAndStringLiteralObjectWithLang(OntologyConstants.Rdfs.Label.toSmartIri, settings, userLang).map {
             case (k: SmartIri, v: String) => (k.toString, JsonLDString(v))
@@ -2039,12 +2039,12 @@ sealed trait ReadEntityInfoV2 {
     }
 
     /**
-      * Returns a JSON-LD object representing the entity, with language-specific information provided in all
-      * available languages.
-      *
-      * @param targetSchema the API v2 schema in which the response will be returned.
-      * @return a JSON-LD object representing the entity.
-      */
+     * Returns a JSON-LD object representing the entity, with language-specific information provided in all
+     * available languages.
+     *
+     * @param targetSchema the API v2 schema in which the response will be returned.
+     * @return a JSON-LD object representing the entity.
+     */
     def toJsonLDWithAllLanguages(targetSchema: ApiV2Schema): JsonLDObject = {
         val labelObjs: Map[String, String] = entityInfoContent.getPredicateObjectsWithLangs(OntologyConstants.Rdfs.Label.toSmartIri)
 
@@ -2067,23 +2067,23 @@ sealed trait ReadEntityInfoV2 {
 }
 
 /**
-  * Represents an OWL class definition as returned in an API response.
-  *
-  * @param entityInfoContent       a [[ReadClassInfoV2]] providing information about the class.
-  * @param allBaseClasses          a set of the IRIs of all the base classes of the class.
-  * @param isResourceClass         `true` if this is a subclass of `knora-base:Resource`.
-  * @param isStandoffClass         `true` if this is a subclass of `knora-base:StandoffTag`.
-  * @param isValueClass            `true` if the class is a Knora value class.
-  * @param canBeInstantiated       `true` if the class is a Knora resource class that can be instantiated via the API.
-  * @param inheritedCardinalities  a [[Map]] of properties to [[Cardinality.Value]] objects representing the class's
-  *                                inherited cardinalities on those properties.
-  * @param standoffDataType        if this is a standoff tag class, the standoff datatype tag class (if any) that it
-  *                                is a subclass of.
-  * @param knoraResourceProperties a [[Set]] of IRIs of properties in `allCardinalities` that are subproperties of `knora-base:resourceProperty`.
-  * @param linkProperties          a [[Set]] of IRIs of properties in `allCardinalities` that point to resources.
-  * @param linkValueProperties     a [[Set]] of IRIs of properties in `allCardinalities` that point to `LinkValue` objects.
-  * @param fileValueProperties     a [[Set]] of IRIs of properties in `allCardinalities` that point to `FileValue` objects.
-  */
+ * Represents an OWL class definition as returned in an API response.
+ *
+ * @param entityInfoContent       a [[ReadClassInfoV2]] providing information about the class.
+ * @param allBaseClasses          a set of the IRIs of all the base classes of the class.
+ * @param isResourceClass         `true` if this is a subclass of `knora-base:Resource`.
+ * @param isStandoffClass         `true` if this is a subclass of `knora-base:StandoffTag`.
+ * @param isValueClass            `true` if the class is a Knora value class.
+ * @param canBeInstantiated       `true` if the class is a Knora resource class that can be instantiated via the API.
+ * @param inheritedCardinalities  a [[Map]] of properties to [[Cardinality.Value]] objects representing the class's
+ *                                inherited cardinalities on those properties.
+ * @param standoffDataType        if this is a standoff tag class, the standoff datatype tag class (if any) that it
+ *                                is a subclass of.
+ * @param knoraResourceProperties a [[Set]] of IRIs of properties in `allCardinalities` that are subproperties of `knora-base:resourceProperty`.
+ * @param linkProperties          a [[Set]] of IRIs of properties in `allCardinalities` that point to resources.
+ * @param linkValueProperties     a [[Set]] of IRIs of properties in `allCardinalities` that point to `LinkValue` objects.
+ * @param fileValueProperties     a [[Set]] of IRIs of properties in `allCardinalities` that point to `FileValue` objects.
+ */
 case class ReadClassInfoV2(entityInfoContent: ClassInfoContentV2,
                            allBaseClasses: Set[SmartIri],
                            isResourceClass: Boolean = false,
@@ -2097,13 +2097,13 @@ case class ReadClassInfoV2(entityInfoContent: ClassInfoContentV2,
                            linkValueProperties: Set[SmartIri] = Set.empty[SmartIri],
                            fileValueProperties: Set[SmartIri] = Set.empty[SmartIri]) extends ReadEntityInfoV2 with KnoraReadV2[ReadClassInfoV2] {
     /**
-      * All the class's cardinalities, both direct and indirect.
-      */
+     * All the class's cardinalities, both direct and indirect.
+     */
     lazy val allCardinalities: Map[SmartIri, KnoraCardinalityInfo] = inheritedCardinalities ++ entityInfoContent.directCardinalities
 
     /**
-      * All the class's cardinalities for subproperties of `knora-base:resourceProperty`.
-      */
+     * All the class's cardinalities for subproperties of `knora-base:resourceProperty`.
+     */
     lazy val allResourcePropertyCardinalities: Map[SmartIri, KnoraCardinalityInfo] = allCardinalities.filter {
         case (propertyIri, _) => knoraResourceProperties.contains(propertyIri)
     }
@@ -2247,11 +2247,12 @@ case class ReadClassInfoV2(entityInfoContent: ClassInfoContentV2,
                 Map(
                     OntologyConstants.Owl.OnDatatype -> JsonLDUtil.iriToJsonLDObject(datatypeInfo.onDatatype.toString)
                 ) ++ datatypeInfo.pattern.map {
-                    pattern => OntologyConstants.Owl.WithRestrictions -> JsonLDArray(
-                        Seq(
-                            JsonLDObject(Map(OntologyConstants.Xsd.Pattern -> JsonLDString(pattern)))
+                    pattern =>
+                        OntologyConstants.Owl.WithRestrictions -> JsonLDArray(
+                            Seq(
+                                JsonLDObject(Map(OntologyConstants.Xsd.Pattern -> JsonLDString(pattern)))
+                            )
                         )
-                    )
                 }
 
             case None => Map.empty
@@ -2300,17 +2301,17 @@ case class ReadClassInfoV2(entityInfoContent: ClassInfoContentV2,
 }
 
 /**
-  * Represents an OWL property definition as returned in an API response.
-  *
-  * @param entityInfoContent                   a [[PropertyInfoContentV2]] providing information about the property.
-  * @param isResourceProp                      `true` if the property is a subproperty of `knora-base:resourceProperty`.
-  * @param isEditable                          `true` if the property's value is editable via the Knora API.
-  * @param isLinkProp                          `true` if the property is a subproperty of `knora-base:hasLinkTo`.
-  * @param isLinkValueProp                     `true` if the property is a subproperty of `knora-base:hasLinkToValue`.
-  * @param isFileValueProp                     `true` if the property is a subproperty of `knora-base:hasFileValue`.
-  * @param isStandoffInternalReferenceProperty if `true`, this is a subproperty (directly or indirectly) of
-  *                                            [[OntologyConstants.KnoraBase.StandoffTagHasInternalReference]].
-  */
+ * Represents an OWL property definition as returned in an API response.
+ *
+ * @param entityInfoContent                   a [[PropertyInfoContentV2]] providing information about the property.
+ * @param isResourceProp                      `true` if the property is a subproperty of `knora-base:resourceProperty`.
+ * @param isEditable                          `true` if the property's value is editable via the Knora API.
+ * @param isLinkProp                          `true` if the property is a subproperty of `knora-base:hasLinkTo`.
+ * @param isLinkValueProp                     `true` if the property is a subproperty of `knora-base:hasLinkToValue`.
+ * @param isFileValueProp                     `true` if the property is a subproperty of `knora-base:hasFileValue`.
+ * @param isStandoffInternalReferenceProperty if `true`, this is a subproperty (directly or indirectly) of
+ *                                            [[OntologyConstants.KnoraBase.StandoffTagHasInternalReference]].
+ */
 case class ReadPropertyInfoV2(entityInfoContent: PropertyInfoContentV2,
                               isResourceProp: Boolean = false,
                               isEditable: Boolean = false,
@@ -2413,10 +2414,10 @@ case class ReadPropertyInfoV2(entityInfoContent: PropertyInfoContentV2,
 }
 
 /**
-  * Represents an OWL named individual definition as returned in an API response.
-  *
-  * @param entityInfoContent an [[IndividualInfoContentV2]] representing information about the named individual.
-  */
+ * Represents an OWL named individual definition as returned in an API response.
+ *
+ * @param entityInfoContent an [[IndividualInfoContentV2]] representing information about the named individual.
+ */
 case class ReadIndividualInfoV2(entityInfoContent: IndividualInfoContentV2) extends ReadEntityInfoV2 with KnoraReadV2[ReadIndividualInfoV2] {
     override def toOntologySchema(targetSchema: ApiV2Schema): ReadIndividualInfoV2 = copy(
         entityInfoContent = entityInfoContent.toOntologySchema(targetSchema)
@@ -2446,25 +2447,25 @@ case class ReadIndividualInfoV2(entityInfoContent: IndividualInfoContentV2) exte
 }
 
 /**
-  * Represents a definition of an `rdfs:Datatype`.
-  *
-  * @param onDatatype                  the base datatype to be extended.
-  * @param pattern an optional `xsd:pattern` specifying the regular expression that restricts its values.
-  */
+ * Represents a definition of an `rdfs:Datatype`.
+ *
+ * @param onDatatype the base datatype to be extended.
+ * @param pattern    an optional `xsd:pattern` specifying the regular expression that restricts its values.
+ */
 case class DatatypeInfoV2(onDatatype: SmartIri, pattern: Option[String] = None)
 
 /**
-  * Represents assertions about an OWL class.
-  *
-  * @param classIri            the IRI of the class.
-  * @param predicates          a [[Map]] of predicate IRIs to [[PredicateInfoV2]] objects.
-  * @param directCardinalities a [[Map]] of properties to [[Cardinality.Value]] objects representing the cardinalities
-  *                            that are directly defined on the class (as opposed to inherited) on those properties.
-  * @param datatypeInfo        if the class's `rdf:type` is `rdfs:Datatype`, a [[DatatypeInfoV2]] describing it.
-  * @param subClassOf          the classes that this class is a subclass of.
-  * @param ontologySchema      indicates whether this ontology entity belongs to an internal ontology (for use in the
-  *                            triplestore) or an external one (for use in the Knora API).
-  */
+ * Represents assertions about an OWL class.
+ *
+ * @param classIri            the IRI of the class.
+ * @param predicates          a [[Map]] of predicate IRIs to [[PredicateInfoV2]] objects.
+ * @param directCardinalities a [[Map]] of properties to [[Cardinality.Value]] objects representing the cardinalities
+ *                            that are directly defined on the class (as opposed to inherited) on those properties.
+ * @param datatypeInfo        if the class's `rdf:type` is `rdfs:Datatype`, a [[DatatypeInfoV2]] describing it.
+ * @param subClassOf          the classes that this class is a subclass of.
+ * @param ontologySchema      indicates whether this ontology entity belongs to an internal ontology (for use in the
+ *                            triplestore) or an external one (for use in the Knora API).
+ */
 case class ClassInfoContentV2(classIri: SmartIri,
                               predicates: Map[SmartIri, PredicateInfoV2] = Map.empty[SmartIri, PredicateInfoV2],
                               directCardinalities: Map[SmartIri, KnoraCardinalityInfo] = Map.empty[SmartIri, KnoraCardinalityInfo],
@@ -2549,20 +2550,20 @@ case class ClassInfoContentV2(classIri: SmartIri,
     override def getRdfTypes: Seq[SmartIri] = requireIriObjects(OntologyConstants.Rdf.Type.toSmartIri, throw InconsistentTriplestoreDataException(s"The rdf:type of $classIri is missing or invalid")).toVector.sorted
 
     /**
-      * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
-      * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
-      * read back from the triplestore (in which predicate objects are not escaped).
-      *
-      * @return a copy of this object with its predicate objects unescaped.
-      */
+     * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
+     * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
+     * read back from the triplestore (in which predicate objects are not escaped).
+     *
+     * @return a copy of this object with its predicate objects unescaped.
+     */
     def unescape: ClassInfoContentV2 = {
         copy(predicates = unescapePredicateObjects)
     }
 }
 
 /**
-  * Can read a [[ClassInfoContentV2]] from JSON-LD.
-  */
+ * Can read a [[ClassInfoContentV2]] from JSON-LD.
+ */
 object ClassInfoContentV2 {
 
     // The predicates that are allowed in a class definition that is read from JSON-LD representing client input.
@@ -2585,12 +2586,12 @@ object ClassInfoContentV2 {
     )
 
     /**
-      * Converts a JSON-LD class definition into a [[ClassInfoContentV2]].
-      *
-      * @param jsonLDClassDef a JSON-LD object representing a class definition.
-      * @param parsingMode    the parsing mode to be used.
-      * @return a [[ClassInfoContentV2]] representing the class definition.
-      */
+     * Converts a JSON-LD class definition into a [[ClassInfoContentV2]].
+     *
+     * @param jsonLDClassDef a JSON-LD object representing a class definition.
+     * @param parsingMode    the parsing mode to be used.
+     * @return a [[ClassInfoContentV2]] representing the class definition.
+     */
     def fromJsonLDObject(jsonLDClassDef: JsonLDObject, parsingMode: InputOntologyParsingModeV2): ClassInfoContentV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -2701,8 +2702,34 @@ object ClassInfoContentV2 {
             case None => (Set.empty[SmartIri], Map.empty[SmartIri, KnoraCardinalityInfo])
         }
 
+        // If this is a custom datatype, get its definition.
+        val datatypeInfo: Option[DatatypeInfoV2] = jsonLDClassDef.maybeIriInObject(OntologyConstants.Owl.OnDatatype, stringFormatter.toSmartIriWithErr) match {
+            case Some(onDatatype: SmartIri) =>
+                val pattern: Option[String] = jsonLDClassDef.maybeObject(OntologyConstants.Owl.WithRestrictions) match {
+                    case Some(jsonLDValue: JsonLDValue) =>
+                        jsonLDValue match {
+                            case jsonLDObject: JsonLDObject =>
+                                Some(jsonLDObject.requireString(OntologyConstants.Xsd.Pattern))
+
+                            case other => throw BadRequestException(s"Object of owl:withRestrictions must be an object, but got $other")
+                        }
+
+                    case None => None
+                }
+
+                Some(
+                    DatatypeInfoV2(
+                        onDatatype = onDatatype,
+                        pattern = pattern
+                    )
+                )
+
+            case None => None
+        }
+
         ClassInfoContentV2(
             classIri = classIri,
+            datatypeInfo = datatypeInfo,
             predicates = EntityInfoContentV2.predicatesFromJsonLDObject(filteredClassDef),
             directCardinalities = directCardinalities,
             subClassOf = subClassOf,
@@ -2713,14 +2740,14 @@ object ClassInfoContentV2 {
 }
 
 /**
-  * Represents assertions about an RDF property.
-  *
-  * @param propertyIri    the IRI of the queried property.
-  * @param predicates     a [[Map]] of predicate IRIs to [[PredicateInfoV2]] objects.
-  * @param subPropertyOf  the property's direct superproperties.
-  * @param ontologySchema indicates whether this ontology entity belongs to an internal ontology (for use in the
-  *                       triplestore) or an external one (for use in the Knora API).
-  */
+ * Represents assertions about an RDF property.
+ *
+ * @param propertyIri    the IRI of the queried property.
+ * @param predicates     a [[Map]] of predicate IRIs to [[PredicateInfoV2]] objects.
+ * @param subPropertyOf  the property's direct superproperties.
+ * @param ontologySchema indicates whether this ontology entity belongs to an internal ontology (for use in the
+ *                       triplestore) or an external one (for use in the Knora API).
+ */
 case class PropertyInfoContentV2(propertyIri: SmartIri,
                                  predicates: Map[SmartIri, PredicateInfoV2] = Map.empty[SmartIri, PredicateInfoV2],
                                  subPropertyOf: Set[SmartIri] = Set.empty[SmartIri],
@@ -2807,20 +2834,20 @@ case class PropertyInfoContentV2(propertyIri: SmartIri,
     override def getRdfTypes: Seq[SmartIri] = requireIriObjects(OntologyConstants.Rdf.Type.toSmartIri, throw InconsistentTriplestoreDataException(s"The rdf:type of $propertyIri is missing or invalid")).toVector.sorted
 
     /**
-      * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
-      * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
-      * read back from the triplestore (in which predicate objects are not escaped).
-      *
-      * @return a copy of this object with its predicate objects unescaped.
-      */
+     * Undoes the SPARQL-escaping of predicate objects. This method is meant to be used after an update, when the
+     * input (whose predicate objects have been escaped for use in SPARQL) needs to be compared with the updated data
+     * read back from the triplestore (in which predicate objects are not escaped).
+     *
+     * @return a copy of this object with its predicate objects unescaped.
+     */
     def unescape: PropertyInfoContentV2 = {
         copy(predicates = unescapePredicateObjects)
     }
 }
 
 /**
-  * Can read a [[PropertyInfoContentV2]] from JSON-LD, and provides constants used by that class.
-  */
+ * Can read a [[PropertyInfoContentV2]] from JSON-LD, and provides constants used by that class.
+ */
 object PropertyInfoContentV2 {
     // The predicates allowed in a property definition that is read from JSON-LD representing client input.
     private val AllowedJsonLDPropertyPredicatesInClientInput = Set(
@@ -2838,12 +2865,12 @@ object PropertyInfoContentV2 {
     )
 
     /**
-      * Reads a [[PropertyInfoContentV2]] from a JSON-LD object.
-      *
-      * @param jsonLDPropertyDef the JSON-LD object representing a property definition.
-      * @param parsingMode       the parsing mode to be used.
-      * @return a [[PropertyInfoContentV2]] representing the property definition.
-      */
+     * Reads a [[PropertyInfoContentV2]] from a JSON-LD object.
+     *
+     * @param jsonLDPropertyDef the JSON-LD object representing a property definition.
+     * @param parsingMode       the parsing mode to be used.
+     * @return a [[PropertyInfoContentV2]] representing the property definition.
+     */
     def fromJsonLDObject(jsonLDPropertyDef: JsonLDObject, parsingMode: InputOntologyParsingModeV2): PropertyInfoContentV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
@@ -2891,13 +2918,13 @@ object PropertyInfoContentV2 {
 }
 
 /**
-  * Represents assertions about an OWL named individual.
-  *
-  * @param individualIri  the IRI of the named individual.
-  * @param predicates     the predicates of the named individual.
-  * @param ontologySchema indicates whether this named individual belongs to an internal ontology (for use in the
-  *                       triplestore) or an external one (for use in the Knora API).
-  */
+ * Represents assertions about an OWL named individual.
+ *
+ * @param individualIri  the IRI of the named individual.
+ * @param predicates     the predicates of the named individual.
+ * @param ontologySchema indicates whether this named individual belongs to an internal ontology (for use in the
+ *                       triplestore) or an external one (for use in the Knora API).
+ */
 case class IndividualInfoContentV2(individualIri: SmartIri,
                                    predicates: Map[SmartIri, PredicateInfoV2],
                                    ontologySchema: OntologySchema) extends EntityInfoContentV2 with KnoraContentV2[IndividualInfoContentV2] {
@@ -2931,8 +2958,8 @@ case class IndividualInfoContentV2(individualIri: SmartIri,
 }
 
 /**
-  * Can read an [[IndividualInfoContentV2]] from JSON-LD.
-  */
+ * Can read an [[IndividualInfoContentV2]] from JSON-LD.
+ */
 object IndividualInfoContentV2 {
     def fromJsonLDObject(jsonLDIndividualDef: JsonLDObject): IndividualInfoContentV2 = {
         implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
@@ -2950,14 +2977,14 @@ object IndividualInfoContentV2 {
 }
 
 /**
-  * Represents the IRIs of Knora entities (Knora resource classes, standoff class, resource properties, and standoff properties) defined in a particular ontology.
-  *
-  * @param ontologyIri          the IRI of the ontology.
-  * @param classIris            the classes defined in the ontology.
-  * @param propertyIris         the properties defined in the ontology.
-  * @param standoffClassIris    the standoff classes defined in the ontology.
-  * @param standoffPropertyIris the standoff properties defined in the ontology.
-  */
+ * Represents the IRIs of Knora entities (Knora resource classes, standoff class, resource properties, and standoff properties) defined in a particular ontology.
+ *
+ * @param ontologyIri          the IRI of the ontology.
+ * @param classIris            the classes defined in the ontology.
+ * @param propertyIris         the properties defined in the ontology.
+ * @param standoffClassIris    the standoff classes defined in the ontology.
+ * @param standoffPropertyIris the standoff properties defined in the ontology.
+ */
 case class OntologyKnoraEntitiesIriInfoV2(ontologyIri: SmartIri,
                                           classIris: Set[SmartIri],
                                           propertyIris: Set[SmartIri],
@@ -2965,22 +2992,22 @@ case class OntologyKnoraEntitiesIriInfoV2(ontologyIri: SmartIri,
                                           standoffPropertyIris: Set[SmartIri])
 
 /**
-  * Represents information about a subclass of a resource class.
-  *
-  * @param id    the IRI of the subclass.
-  * @param label the `rdfs:label` of the subclass.
-  */
+ * Represents information about a subclass of a resource class.
+ *
+ * @param id    the IRI of the subclass.
+ * @param label the `rdfs:label` of the subclass.
+ */
 case class SubClassInfoV2(id: SmartIri, label: String)
 
 /**
-  * Returns metadata about an ontology.
-  *
-  * @param ontologyIri          the IRI of the ontology.
-  * @param projectIri           the IRI of the project that the ontology belongs to.
-  * @param label                the label of the ontology, if any.
-  * @param lastModificationDate the ontology's last modification date, if any.
-  * @param ontologyVersion      the version string attached to the ontology, if any.
-  */
+ * Returns metadata about an ontology.
+ *
+ * @param ontologyIri          the IRI of the ontology.
+ * @param projectIri           the IRI of the project that the ontology belongs to.
+ * @param label                the label of the ontology, if any.
+ * @param lastModificationDate the ontology's last modification date, if any.
+ * @param ontologyVersion      the version string attached to the ontology, if any.
+ */
 case class OntologyMetadataV2(ontologyIri: SmartIri,
                               projectIri: Option[SmartIri] = None,
                               label: Option[String] = None,
@@ -3003,12 +3030,12 @@ case class OntologyMetadataV2(ontologyIri: SmartIri,
     }
 
     /**
-      * Undoes the SPARQL-escaping of the `rdfs:label` of this ontology. This method is meant to be used in tests after an update, when the
-      * input (which has been escaped for use in SPARQL) needs to be compared with the updated data
-      * read back from the triplestore (which is not escaped).
-      *
-      * @return a copy of this [[OntologyMetadataV2]] with the `rdfs:label` unescaped.
-      */
+     * Undoes the SPARQL-escaping of the `rdfs:label` of this ontology. This method is meant to be used in tests after an update, when the
+     * input (which has been escaped for use in SPARQL) needs to be compared with the updated data
+     * read back from the triplestore (which is not escaped).
+     *
+     * @return a copy of this [[OntologyMetadataV2]] with the `rdfs:label` unescaped.
+     */
     def unescape: OntologyMetadataV2 = {
         val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDate.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDate.jsonld
@@ -4,14 +4,11 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a date as a period with different possible precisions.",
     "rdfs:label" : "Date literal",
-    "rdfs:subClassOf" : {
-      "@type" : "rdfs:Datatype",
-      "owl:onDatatype" : {
-        "@id" : "xsd:string"
-      },
-      "owl:withRestrictions" : {
-        "xsd:pattern" : "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
-      }
+    "owl:onDatatype" : {
+      "@id" : "xsd:string"
+    },
+    "owl:withRestrictions" : {
+      "xsd:pattern" : "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
     }
   } ],
   "@id" : "http://api.knora.org/ontology/knora-api/simple/v2",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDate.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDate.rdf
@@ -11,16 +11,12 @@
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Date">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date as a period with different possible precisions.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date literal</rdfs:label>
-	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-c62eb8f2d37b489c9a659d20ed39dbe0-b0">
-			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-c62eb8f2d37b489c9a659d20ed39dbe0-b1">
-					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
-				</rdf:Description>
-			</owl:withRestrictions>
-		</rdfs:Datatype>
-	</rdfs:subClassOf>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<owl:withRestrictions>
+		<rdf:Description rdf:nodeID="genid-301dc38dab7747b79c76d568907641a9-b0">
+			<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
+		</rdf:Description>
+	</owl:withRestrictions>
 </rdfs:Datatype>
 
 </rdf:RDF>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDate.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiDate.ttl
@@ -9,9 +9,7 @@
 <http://api.knora.org/ontology/knora-api/simple/v2#Date> a rdfs:Datatype;
   rdfs:comment "Represents a date as a period with different possible precisions.";
   rdfs:label "Date literal";
-  rdfs:subClassOf [ a rdfs:Datatype;
-      owl:onDatatype xsd:string;
-      owl:withRestrictions [
-          xsd:pattern "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
-        ]
+  owl:onDatatype xsd:string;
+  owl:withRestrictions [
+      xsd:pattern "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
     ] .

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.jsonld
@@ -98,14 +98,11 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a color.",
     "rdfs:label" : "Color literal",
-    "rdfs:subClassOf" : {
-      "@type" : "rdfs:Datatype",
-      "owl:onDatatype" : {
-        "@id" : "xsd:string"
-      },
-      "owl:withRestrictions" : {
-        "xsd:pattern" : "#([0-9a-fA-F]{3}){1,2}"
-      }
+    "owl:onDatatype" : {
+      "@id" : "xsd:string"
+    },
+    "owl:withRestrictions" : {
+      "xsd:pattern" : "#([0-9a-fA-F]{3}){1,2}"
     }
   }, {
     "@id" : "knora-api:DDDRepresentation",
@@ -156,14 +153,11 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a date as a period with different possible precisions.",
     "rdfs:label" : "Date literal",
-    "rdfs:subClassOf" : {
-      "@type" : "rdfs:Datatype",
-      "owl:onDatatype" : {
-        "@id" : "xsd:string"
-      },
-      "owl:withRestrictions" : {
-        "xsd:pattern" : "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
-      }
+    "owl:onDatatype" : {
+      "@id" : "xsd:string"
+    },
+    "owl:withRestrictions" : {
+      "xsd:pattern" : "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
     }
   }, {
     "@id" : "knora-api:DocumentRepresentation",
@@ -213,7 +207,7 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a file URI.",
     "rdfs:label" : "File URI",
-    "rdfs:subClassOf" : {
+    "owl:onDatatype" : {
       "@id" : "xsd:anyURI"
     }
   }, {
@@ -265,7 +259,7 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a geometry specification in JSON.",
     "rdfs:label" : "Geometry specification",
-    "rdfs:subClassOf" : {
+    "owl:onDatatype" : {
       "@id" : "xsd:string"
     }
   }, {
@@ -273,28 +267,22 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a Geoname code.",
     "rdfs:label" : "Geoname code",
-    "rdfs:subClassOf" : {
-      "@type" : "rdfs:Datatype",
-      "owl:onDatatype" : {
-        "@id" : "xsd:string"
-      },
-      "owl:withRestrictions" : {
-        "xsd:pattern" : "\\d{1,8}"
-      }
+    "owl:onDatatype" : {
+      "@id" : "xsd:string"
+    },
+    "owl:withRestrictions" : {
+      "xsd:pattern" : "\\d{1,8}"
     }
   }, {
     "@id" : "knora-api:Interval",
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents an interval.",
     "rdfs:label" : "Interval literal",
-    "rdfs:subClassOf" : {
-      "@type" : "rdfs:Datatype",
-      "owl:onDatatype" : {
-        "@id" : "xsd:string"
-      },
-      "owl:withRestrictions" : {
-        "xsd:pattern" : "\\d+(\\.\\d+)?,\\d+(\\.\\d+)?"
-      }
+    "owl:onDatatype" : {
+      "@id" : "xsd:string"
+    },
+    "owl:withRestrictions" : {
+      "xsd:pattern" : "\\d+(\\.\\d+)?,\\d+(\\.\\d+)?"
     }
   }, {
     "@id" : "knora-api:LinkObj",
@@ -352,14 +340,8 @@
     "@type" : "rdfs:Datatype",
     "rdfs:comment" : "Represents a list node.",
     "rdfs:label" : "List Node",
-    "rdfs:subClassOf" : {
-      "@type" : "rdfs:Datatype",
-      "owl:onDatatype" : {
-        "@id" : "xsd:string"
-      },
-      "owl:withRestrictions" : {
-        "xsd:pattern" : ".+"
-      }
+    "owl:onDatatype" : {
+      "@id" : "xsd:string"
     }
   }, {
     "@id" : "knora-api:MovingImageRepresentation",
@@ -1011,6 +993,9 @@
     },
     "rdfs:comment" : "Provides the ARK URL of a particular version of a resource.",
     "rdfs:label" : "version ARK URL"
+  }, {
+    "@id" : "rdfs:label",
+    "@type" : "owl:DatatypeProperty"
   } ],
   "@id" : "http://api.knora.org/ontology/knora-api/simple/v2",
   "@type" : "owl:Ontology",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.rdf
@@ -12,24 +12,24 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b6"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Resource">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b69"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b67"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b0">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b0">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl">
@@ -39,7 +39,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b1">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b1">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasComment">
@@ -51,7 +51,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b2">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b2">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink">
@@ -63,7 +63,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b3">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b3">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo">
@@ -75,7 +75,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b4">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b4">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isAnnotationOf">
@@ -86,7 +86,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b5">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b5">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl">
@@ -96,37 +96,39 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b6">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b6">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+	<owl:onProperty>
+		<owl:DatatypeProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+	</owl:onProperty>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#AudioRepresentation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b12"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Representation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b62"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b7">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b7">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b8">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b8">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasAudioFile">
@@ -138,52 +140,48 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b9">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b9">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b10">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b10">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b11">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b11">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b12">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b12">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Color">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Color literal</rdfs:label>
-	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b13">
-			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b14">
-					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">#([0-9a-fA-F]{3}){1,2}</xsd:pattern>
-				</rdf:Description>
-			</owl:withRestrictions>
-		</rdfs:Datatype>
-	</rdfs:subClassOf>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<owl:withRestrictions>
+		<rdf:Description rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b13">
+			<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">#([0-9a-fA-F]{3}){1,2}</xsd:pattern>
+		</rdf:Description>
+	</owl:withRestrictions>
 </rdfs:Datatype>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#DDDRepresentation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b19"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b19"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b15">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b14">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b16">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b15">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDDDFile">
@@ -195,51 +193,47 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b17">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b16">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b18">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b17">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b19">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b18">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b20">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b19">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Date">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date as a period with different possible precisions.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Date literal</rdfs:label>
-	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b21">
-			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b22">
-					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
-				</rdf:Description>
-			</owl:withRestrictions>
-		</rdfs:Datatype>
-	</rdfs:subClassOf>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<owl:withRestrictions>
+		<rdf:Description rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b20">
+			<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">(GREGORIAN|JULIAN):\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?(:\d{1,4}(-\d{1,2}(-\d{1,2})?)?( BC| AD| BCE| CE)?)?</xsd:pattern>
+		</rdf:Description>
+	</owl:withRestrictions>
 </rdfs:Datatype>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#DocumentRepresentation">
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b26"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b23">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b21">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b24">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b22">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasDocumentFile">
@@ -251,121 +245,113 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b25">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b23">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b26">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b24">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b27">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b25">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b28">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b26">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#File">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file URI.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">File URI</rdfs:label>
-	<rdfs:subClassOf rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#anyURI"/>
 </rdfs:Datatype>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#ForbiddenResource">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b32"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b29">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b27">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b30">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b28">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b31">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b29">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b32">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b30">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b33">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b31">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b34">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b32">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Geom">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometry specification in JSON.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geometry specification</rdfs:label>
-	<rdfs:subClassOf rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 </rdfs:Datatype>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Geoname">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Geoname code.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Geoname code</rdfs:label>
-	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b35">
-			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b36">
-					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d{1,8}</xsd:pattern>
-				</rdf:Description>
-			</owl:withRestrictions>
-		</rdfs:Datatype>
-	</rdfs:subClassOf>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<owl:withRestrictions>
+		<rdf:Description rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b33">
+			<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d{1,8}</xsd:pattern>
+		</rdf:Description>
+	</owl:withRestrictions>
 </rdfs:Datatype>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#Interval">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Interval literal</rdfs:label>
-	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b37">
-			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b38">
-					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d+(\.\d+)?,\d+(\.\d+)?</xsd:pattern>
-				</rdf:Description>
-			</owl:withRestrictions>
-		</rdfs:Datatype>
-	</rdfs:subClassOf>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+	<owl:withRestrictions>
+		<rdf:Description rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b34">
+			<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">\d+(\.\d+)?,\d+(\.\d+)?</xsd:pattern>
+		</rdf:Description>
+	</owl:withRestrictions>
 </rdfs:Datatype>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#LinkObj">
 	<knora-api:resourceIcon rdf:datatype="http://www.w3.org/2001/XMLSchema#string">link.gif</knora-api:resourceIcon>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b41"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b39">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b35">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b40">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b36">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b41">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b37">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b42">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b38">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasLinkTo">
@@ -377,52 +363,43 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b43">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b39">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b44">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b40">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b45">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b41">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <rdfs:Datatype rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a list node.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">List Node</rdfs:label>
-	<rdfs:subClassOf>
-		<rdfs:Datatype rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b46">
-			<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
-			<owl:withRestrictions>
-				<rdf:Description rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b47">
-					<xsd:pattern rdf:datatype="http://www.w3.org/2001/XMLSchema#string">.+</xsd:pattern>
-				</rdf:Description>
-			</owl:withRestrictions>
-		</rdfs:Datatype>
-	</rdfs:subClassOf>
+	<owl:onDatatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
 </rdfs:Datatype>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#MovingImageRepresentation">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b47"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b48">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b42">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b49">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b43">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b50">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b44">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasMovingImageFile">
@@ -434,15 +411,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b51">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b45">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b52">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b46">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b53">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b47">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -451,21 +428,21 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b54"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b56"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b54">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b48">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b55">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b49">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasColor">
@@ -477,11 +454,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b56">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b50">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b57">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b51">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasGeometry">
@@ -493,15 +470,15 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b58">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b52">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b59">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b53">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b60">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b54">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#isRegionOf">
@@ -513,19 +490,19 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b61">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b55">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b62">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b56">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b63">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b57">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b64">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b58">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasFile">
@@ -537,39 +514,39 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b65">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b59">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b66">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b60">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b67">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b61">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b68">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b62">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b69">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b63">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b70">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b64">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b71">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b65">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b72">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b66">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b73">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b67">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -577,26 +554,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b69"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b73"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b74">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b68">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b75">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b69">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b76">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b70">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b77">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b71">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasStillImageFile">
@@ -608,11 +585,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b78">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b72">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b79">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b73">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -620,26 +597,26 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b83"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b79"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b80">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b74">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b81">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b75">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b82">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b76">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b83">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b77">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile">
@@ -651,11 +628,11 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b84">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b78">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b85">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b79">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -663,34 +640,34 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b85"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b86">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b80">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b87">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b81">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasIncomingLink"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b88">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b82">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b89">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b83">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#hasTextFile"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b90">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b84">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/simple/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-9550094ebbd849bcbff2257f63f579bf-b91">
+<owl:Restriction rdf:nodeID="genid-c107dde11b6a4de6bf7ad096fdb346b9-b85">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologySimple.ttl
@@ -90,6 +90,8 @@ knora-api:versionArkUrl a owl:DatatypeProperty;
   rdfs:comment "Provides the ARK URL of a particular version of a resource.";
   rdfs:label "version ARK URL" .
 
+rdfs:label a owl:DatatypeProperty .
+
 knora-api:AudioRepresentation a owl:Class;
   rdfs:comment "Represents a file containing audio data";
   rdfs:label "Representation (Audio)";
@@ -146,11 +148,9 @@ knora-api:hasAudioFile a owl:DatatypeProperty;
 knora-api:Color a rdfs:Datatype;
   rdfs:comment "Represents a color.";
   rdfs:label "Color literal";
-  rdfs:subClassOf [ a rdfs:Datatype;
-      owl:onDatatype xsd:string;
-      owl:withRestrictions [
-          xsd:pattern "#([0-9a-fA-F]{3}){1,2}"
-        ]
+  owl:onDatatype xsd:string;
+  owl:withRestrictions [
+      xsd:pattern "#([0-9a-fA-F]{3}){1,2}"
     ] .
 
 knora-api:DDDRepresentation a owl:Class;
@@ -186,11 +186,9 @@ knora-api:hasDDDFile a owl:DatatypeProperty;
 knora-api:Date a rdfs:Datatype;
   rdfs:comment "Represents a date as a period with different possible precisions.";
   rdfs:label "Date literal";
-  rdfs:subClassOf [ a rdfs:Datatype;
-      owl:onDatatype xsd:string;
-      owl:withRestrictions [
-          xsd:pattern "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
-        ]
+  owl:onDatatype xsd:string;
+  owl:withRestrictions [
+      xsd:pattern "(GREGORIAN|JULIAN):\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?(:\\d{1,4}(-\\d{1,2}(-\\d{1,2})?)?( BC| AD| BCE| CE)?)?"
     ] .
 
 knora-api:DocumentRepresentation a owl:Class;
@@ -225,7 +223,7 @@ knora-api:hasDocumentFile a owl:DatatypeProperty;
 knora-api:File a rdfs:Datatype;
   rdfs:comment "Represents a file URI.";
   rdfs:label "File URI";
-  rdfs:subClassOf xsd:anyURI .
+  owl:onDatatype xsd:anyURI .
 
 knora-api:ForbiddenResource a owl:Class;
   rdfs:comment "A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.";
@@ -253,26 +251,22 @@ knora-api:ForbiddenResource a owl:Class;
 knora-api:Geom a rdfs:Datatype;
   rdfs:comment "Represents a geometry specification in JSON.";
   rdfs:label "Geometry specification";
-  rdfs:subClassOf xsd:string .
+  owl:onDatatype xsd:string .
 
 knora-api:Geoname a rdfs:Datatype;
   rdfs:comment "Represents a Geoname code.";
   rdfs:label "Geoname code";
-  rdfs:subClassOf [ a rdfs:Datatype;
-      owl:onDatatype xsd:string;
-      owl:withRestrictions [
-          xsd:pattern "\\d{1,8}"
-        ]
+  owl:onDatatype xsd:string;
+  owl:withRestrictions [
+      xsd:pattern "\\d{1,8}"
     ] .
 
 knora-api:Interval a rdfs:Datatype;
   rdfs:comment "Represents an interval.";
   rdfs:label "Interval literal";
-  rdfs:subClassOf [ a rdfs:Datatype;
-      owl:onDatatype xsd:string;
-      owl:withRestrictions [
-          xsd:pattern "\\d+(\\.\\d+)?,\\d+(\\.\\d+)?"
-        ]
+  owl:onDatatype xsd:string;
+  owl:withRestrictions [
+      xsd:pattern "\\d+(\\.\\d+)?,\\d+(\\.\\d+)?"
     ] .
 
 knora-api:LinkObj a owl:Class;
@@ -312,12 +306,7 @@ knora-api:hasLinkTo a owl:ObjectProperty;
 knora-api:ListNode a rdfs:Datatype;
   rdfs:comment "Represents a list node.";
   rdfs:label "List Node";
-  rdfs:subClassOf [ a rdfs:Datatype;
-      owl:onDatatype xsd:string;
-      owl:withRestrictions [
-          xsd:pattern ".+"
-        ]
-    ] .
+  owl:onDatatype xsd:string .
 
 knora-api:MovingImageRepresentation a owl:Class;
   rdfs:comment "A resource containing moving image data";

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.jsonld
@@ -6966,6 +6966,9 @@
     },
     "rdfs:comment" : "Provides the date of a particular version of a resource.",
     "rdfs:label" : "version date"
+  }, {
+    "@id" : "rdfs:label",
+    "@type" : "owl:DatatypeProperty"
   } ],
   "@id" : "http://api.knora.org/ontology/knora-api/v2",
   "@type" : "owl:Ontology",

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.rdf
@@ -18,50 +18,50 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A generic class for representing annotations</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annotation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b0"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b1"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b2"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b3"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b4"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b5"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b6"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b7"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b8"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b9"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b10"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b11"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b12"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b13"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b14"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b15"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b16"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b17"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b18"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b19"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b0"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b1"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b2"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b3"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b4"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b5"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b6"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b7"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b8"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b9"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b10"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b11"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b12"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b13"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b14"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b15"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b16"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b17"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b18"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b19"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Resource">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents something in the world, or an abstract thing</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Resource</rdfs:label>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b422"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b423"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b424"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b425"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b426"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b427"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b428"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b429"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b430"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b431"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b432"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b433"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b434"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b435"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b436"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b437"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b438"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b422"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b423"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b424"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b425"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b426"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b427"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b428"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b429"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b430"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b431"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b432"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b433"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b434"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b435"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b436"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b437"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b438"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b0">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b0">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -72,7 +72,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b1">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b1">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -83,7 +83,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b2">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b2">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -94,7 +94,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b3">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b3">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -105,7 +105,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b4">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b4">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -115,7 +115,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b5">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b5">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -125,7 +125,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b6">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b6">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -135,7 +135,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b7">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b7">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasComment">
@@ -150,7 +150,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b8">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b8">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -165,7 +165,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b9">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b9">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -174,7 +174,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b10">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b10">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -189,7 +189,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b11">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b11">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
@@ -204,7 +204,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b12">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b12">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOf">
@@ -218,7 +218,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b13">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b13">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isAnnotationOfValue">
@@ -231,7 +231,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b14">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b14">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -241,7 +241,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b15">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b15">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -250,7 +250,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b16">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b16">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -261,7 +261,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b17">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b17">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -272,7 +272,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b18">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b18">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -283,62 +283,64 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b19">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b19">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
-	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+	<owl:onProperty>
+		<owl:DatatypeProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+	</owl:onProperty>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#AudioFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an audio file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b20"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b21"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b22"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b23"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b24"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b25"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b26"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b27"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b28"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b29"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b30"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b31"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b32"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b33"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b34"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b35"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b20"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b21"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b22"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b23"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b24"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b25"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b26"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b27"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b28"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b29"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b30"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b31"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b32"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b33"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b34"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b35"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#FileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b199"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b200"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b201"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b202"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b203"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b204"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b205"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b206"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b207"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b208"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b209"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b210"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b211"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b212"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b213"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b199"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b200"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b201"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b202"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b203"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b204"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b205"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b206"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b207"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b208"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b209"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b210"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b211"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b212"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b213"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b20">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b20">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b21">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b21">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b22">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b22">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#audioFileValueHasDuration">
@@ -350,22 +352,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b23">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b23">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b24">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b24">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b25">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b25">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b26">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b26">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -378,7 +380,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b27">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b27">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -391,22 +393,22 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b28">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b28">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b29">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b29">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b30">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b30">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b31">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b31">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -417,7 +419,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b32">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b32">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -428,7 +430,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b33">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b33">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -440,7 +442,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b34">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b34">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -452,7 +454,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b35">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b35">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -462,85 +464,85 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containing audio data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Audio)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b36"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b37"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b38"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b39"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b40"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b41"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b42"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b43"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b44"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b45"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b46"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b47"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b48"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b49"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b50"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b51"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b52"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b53"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b36"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b37"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b38"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b39"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b40"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b41"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b42"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b43"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b44"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b45"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b46"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b47"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b48"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b49"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b50"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b51"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b52"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b53"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Representation">
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can store a file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b404"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b405"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b406"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b407"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b408"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b409"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b410"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b411"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b412"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b413"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b414"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b415"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b416"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b417"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b418"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b419"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b420"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b421"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b404"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b405"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b406"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b407"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b408"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b409"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b410"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b411"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b412"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b413"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b414"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b415"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b416"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b417"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b418"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b419"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b420"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b421"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b36">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b36">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b37">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b37">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b38">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b38">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b39">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b39">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b40">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b40">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b41">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b41">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b42">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b42">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b43">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b43">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasAudioFileValue">
@@ -555,62 +557,62 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b44">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b44">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b45">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b45">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b46">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b46">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b47">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b47">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b48">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b48">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b49">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b49">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b50">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b50">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b51">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b51">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b52">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b52">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b53">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b53">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#BooleanBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b54"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b54"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b54">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b54">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean">
@@ -627,105 +629,105 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b55"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b56"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b57"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b58"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b59"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b60"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b61"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b62"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b63"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b64"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b65"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b66"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b67"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b68"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b55"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b56"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b57"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b58"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b59"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b60"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b61"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b62"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b63"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b64"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b65"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b66"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b67"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b68"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#Value">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">The base class of classes representing Knora values</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b697"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b698"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b699"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b700"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b701"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b702"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b703"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b704"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b705"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b706"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b707"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b708"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b709"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b697"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b698"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b699"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b700"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b701"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b702"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b703"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b704"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b705"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b706"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b707"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b708"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b709"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b55">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b55">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b56">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b56">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b57">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b57">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b58">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b58">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b59">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b59">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b60">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b60">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b61">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b61">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b62">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b62">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b63">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b63">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b64">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b64">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b65">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b65">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b66">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b66">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b67">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b67">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b68">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b68">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -733,7 +735,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ColorBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b69">
+		<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b69">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor">
@@ -752,87 +754,87 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in HTML format, e.g. "#33eeff"</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b70"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b71"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b72"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b73"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b74"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b75"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b76"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b77"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b78"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b79"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b80"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b81"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b82"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b83"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b70"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b71"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b72"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b73"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b74"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b75"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b76"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b77"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b78"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b79"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b80"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b81"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b82"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b83"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b70">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b70">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b71">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b71">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b72">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b72">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b73">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b73">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b74">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b74">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b75">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b75">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b76">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b76">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b77">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b77">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b78">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b78">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b79">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b79">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b80">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b80">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b81">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b81">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b82">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b82">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b83">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b83">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -841,93 +843,93 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">This represents some 3D-object with mesh data, point cloud, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b84"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b85"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b86"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b87"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b88"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b89"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b90"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b91"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b92"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b93"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b94"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b95"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b96"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b97"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b98"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b84"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b85"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b86"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b87"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b88"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b89"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b90"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b91"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b92"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b93"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b94"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b95"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b96"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b97"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b98"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b84">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b84">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b85">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b85">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b86">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b86">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b87">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b87">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b88">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b88">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b89">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b89">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b90">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b90">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b91">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b91">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b92">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b92">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b93">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b93">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b94">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b94">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b95">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b95">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b96">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b96">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b97">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b97">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b98">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b98">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -937,61 +939,61 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a file containg 3D data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (3D)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b99"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b100"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b101"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b102"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b103"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b104"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b105"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b106"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b107"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b108"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b109"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b110"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b111"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b112"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b113"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b114"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b115"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b116"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b99"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b100"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b101"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b102"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b103"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b104"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b105"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b106"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b107"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b108"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b109"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b110"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b111"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b112"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b113"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b114"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b115"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b116"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b99">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b99">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b100">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b100">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b101">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b101">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b102">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b102">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b103">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b103">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b104">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b104">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b105">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b105">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b106">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b106">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDDDFileValue">
@@ -1006,69 +1008,69 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b107">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b107">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b108">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b108">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b109">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b109">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b110">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b110">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b111">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b111">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b112">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b112">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b113">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b113">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b114">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b114">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b115">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b115">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b116">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b116">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DateBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b117"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b118"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b119"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b120"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b121"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b122"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b123"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b124"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b125"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b117"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b118"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b119"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b120"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b121"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b122"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b123"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b124"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b125"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b117">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b117">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar">
@@ -1080,7 +1082,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b118">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b118">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay">
@@ -1092,7 +1094,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b119">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b119">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra">
@@ -1104,7 +1106,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b120">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b120">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth">
@@ -1116,7 +1118,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b121">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b121">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear">
@@ -1128,7 +1130,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b122">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b122">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay">
@@ -1140,7 +1142,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b123">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b123">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra">
@@ -1152,7 +1154,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b124">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b124">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth">
@@ -1164,7 +1166,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b125">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b125">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear">
@@ -1181,135 +1183,135 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a Knora date value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b126"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b127"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b128"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b129"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b130"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b131"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b132"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b133"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b134"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b135"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b136"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b137"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b138"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b139"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b140"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b141"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b142"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b143"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b144"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b145"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b146"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b147"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b126"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b127"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b128"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b129"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b130"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b131"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b132"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b133"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b134"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b135"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b136"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b137"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b138"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b139"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b140"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b141"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b142"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b143"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b144"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b145"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b146"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b147"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b126">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b126">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b127">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b127">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b128">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b128">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b129">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b129">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b130">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b130">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b131">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b131">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b132">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b132">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b133">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b133">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b134">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b134">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b135">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b135">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b136">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b136">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b137">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b137">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b138">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b138">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b139">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b139">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b140">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b140">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b141">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b141">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b142">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b142">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b143">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b143">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b144">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b144">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b145">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b145">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b146">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b146">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b147">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b147">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -1317,7 +1319,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DecimalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b148">
+		<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b148">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal">
@@ -1336,87 +1338,87 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary-precision decimal value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b149"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b150"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b151"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b152"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b153"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b154"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b155"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b156"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b157"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b158"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b159"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b160"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b161"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b162"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b149"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b150"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b151"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b152"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b153"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b154"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b155"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b156"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b157"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b158"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b159"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b160"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b161"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b162"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b149">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b149">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b150">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b150">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b151">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b151">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b152">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b152">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b153">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b153">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b154">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b154">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b155">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b155">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b156">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b156">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b157">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b157">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b158">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b158">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b159">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b159">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b160">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b160">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b161">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b161">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b162">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b162">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -1424,51 +1426,51 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#DocumentFileValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b163"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b164"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b165"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b166"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b167"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b168"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b169"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b170"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b171"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b172"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b173"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b174"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b175"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b176"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b177"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b178"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b179"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b180"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b163"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b164"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b165"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b166"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b167"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b168"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b169"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b170"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b171"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b172"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b173"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b174"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b175"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b176"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b177"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b178"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b179"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b180"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b163">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b163">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b164">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b164">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b165">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b165">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b166">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b166">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b167">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b167">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b168">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b168">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#documentFileValueHasDimX">
@@ -1480,7 +1482,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b169">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b169">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#documentFileValueHasDimY">
@@ -1492,7 +1494,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b170">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b170">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#documentFileValueHasPageCount">
@@ -1504,52 +1506,52 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b171">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b171">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b172">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b172">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b173">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b173">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b174">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b174">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b175">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b175">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b176">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b176">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b177">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b177">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b178">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b178">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b179">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b179">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b180">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b180">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -1558,61 +1560,61 @@
 	<knora-api:isResourceClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isResourceClass>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Document)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b181"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b182"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b183"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b184"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b185"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b186"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b187"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b188"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b189"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b190"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b191"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b192"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b193"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b194"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b195"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b196"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b197"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b198"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b181"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b182"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b183"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b184"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b185"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b186"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b187"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b188"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b189"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b190"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b191"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b192"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b193"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b194"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b195"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b196"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b197"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b198"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b181">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b181">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b182">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b182">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b183">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b183">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b184">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b184">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b185">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b185">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b186">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b186">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b187">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b187">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b188">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b188">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasDocumentFileValue">
@@ -1627,125 +1629,125 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b189">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b189">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b190">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b190">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b191">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b191">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b192">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b192">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b193">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b193">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b194">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b194">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b195">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b195">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b196">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b196">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b197">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b197">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b198">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b198">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b199">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b199">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b200">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b200">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b201">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b201">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b202">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b202">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b203">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b203">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b204">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b204">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b205">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b205">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b206">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b206">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b207">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b207">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b208">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b208">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b209">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b209">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b210">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b210">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b211">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b211">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b212">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b212">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b213">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b213">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -1755,110 +1757,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A ForbiddenResource is a proxy for a resource that the client has insufficient permissions to see.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b214"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b215"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b216"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b217"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b218"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b219"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b220"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b221"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b222"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b223"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b224"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b225"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b226"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b227"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b228"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b229"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b230"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b231"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b214"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b215"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b216"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b217"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b218"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b219"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b220"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b221"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b222"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b223"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b224"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b225"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b226"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b227"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b228"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b229"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b230"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b231"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b214">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b214">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b215">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b215">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b216">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b216">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b217">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b217">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b218">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b218">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b219">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b219">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b220">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b220">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b221">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b221">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b222">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b222">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b223">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b223">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b224">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b224">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b225">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b225">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b226">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b226">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b227">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b227">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b228">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b228">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b229">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b229">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b230">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b230">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b231">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b231">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -1867,47 +1869,47 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometrical objects as JSON string</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b232"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b233"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b234"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b235"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b236"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b237"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b238"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b239"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b240"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b241"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b242"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b243"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b244"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b245"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b232"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b233"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b234"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b235"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b236"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b237"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b238"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b239"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b240"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b241"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b242"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b243"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b244"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b245"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b232">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b232">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b233">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b233">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b234">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b234">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b235">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b235">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b236">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b236">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b237">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b237">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geometryValueAsGeometry">
@@ -1919,42 +1921,42 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b238">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b238">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b239">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b239">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b240">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b240">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b241">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b241">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b242">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b242">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b243">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b243">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b244">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b244">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b245">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b245">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -1962,47 +1964,47 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#GeonameValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b246"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b247"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b248"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b249"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b250"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b251"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b252"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b253"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b254"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b255"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b256"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b257"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b258"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b259"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b246"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b247"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b248"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b249"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b250"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b251"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b252"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b253"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b254"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b255"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b256"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b257"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b258"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b259"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b246">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b246">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b247">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b247">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b248">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b248">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b249">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b249">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b250">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b250">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b251">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b251">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#geonameValueAsGeonameCode">
@@ -2014,42 +2016,42 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b252">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b252">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b253">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b253">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b254">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b254">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b255">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b255">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b256">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b256">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b257">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b257">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b258">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b258">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b259">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b259">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -2057,7 +2059,7 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
 	<rdfs:subClassOf>
-		<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b260">
+		<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b260">
 			<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 			<owl:onProperty>
 				<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intValueAsInt">
@@ -2076,97 +2078,97 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b261"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b262"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b263"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b264"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b265"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b266"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b267"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b268"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b269"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b270"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b271"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b272"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b273"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b274"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b261"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b262"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b263"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b264"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b265"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b266"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b267"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b268"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b269"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b270"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b271"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b272"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b273"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b274"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b261">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b261">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b262">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b262">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b263">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b263">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b264">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b264">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b265">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b265">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b266">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b266">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b267">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b267">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b268">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b268">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b269">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b269">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b270">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b270">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b271">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b271">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b272">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b272">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b273">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b273">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b274">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b274">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#IntervalBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b275"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b276"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b275"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b276"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b275">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b275">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd">
@@ -2178,7 +2180,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b276">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b276">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart">
@@ -2195,93 +2197,93 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a time interval, e.g. in an audio recording</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b277"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b278"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b279"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b280"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b281"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b282"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b283"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b284"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b285"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b286"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b287"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b288"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b289"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b290"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b291"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b277"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b278"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b279"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b280"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b281"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b282"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b283"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b284"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b285"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b286"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b287"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b288"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b289"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b290"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b291"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b277">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b277">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b278">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b278">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b279">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b279">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b280">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b280">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b281">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b281">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b282">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b282">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b283">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b283">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b284">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b284">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b285">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b285">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b286">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b286">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b287">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b287">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b288">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b288">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b289">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b289">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b290">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b290">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b291">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b291">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -2293,72 +2295,72 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a generic link object</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Link Object</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b292"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b293"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b294"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b295"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b296"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b297"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b298"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b299"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b300"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b301"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b302"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b303"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b304"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b305"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b306"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b307"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b308"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b309"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b310"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b311"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b292"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b293"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b294"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b295"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b296"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b297"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b298"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b299"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b300"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b301"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b302"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b303"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b304"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b305"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b306"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b307"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b308"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b309"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b310"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b311"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b292">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b292">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b293">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b293">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b294">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b294">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b295">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b295">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b296">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b296">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b297">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b297">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b298">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b298">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b299">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b299">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b300">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b300">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b301">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b301">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkTo">
@@ -2373,7 +2375,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b302">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b302">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasLinkToValue">
@@ -2388,47 +2390,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b303">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b303">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b304">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b304">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b305">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b305">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b306">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b306">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b307">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b307">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b308">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b308">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b309">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b309">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b310">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b310">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b311">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b311">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2438,60 +2440,60 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A reification node that describes direct links between resources</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
 	<rdfs:subClassOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Statement"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b312"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b313"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b314"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b315"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b316"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b317"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b318"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b319"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b320"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b321"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b322"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b323"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b324"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b325"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b326"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b327"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b328"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b312"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b313"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b314"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b315"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b316"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b317"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b318"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b319"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b320"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b321"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b322"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b323"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b324"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b325"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b326"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b327"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b328"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b312">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b312">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b313">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b313">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b314">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b314">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b315">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b315">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b316">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b316">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b317">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b317">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b318">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b318">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b319">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b319">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSource">
@@ -2503,7 +2505,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b320">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b320">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasSourceIri">
@@ -2515,7 +2517,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b321">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b321">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTarget">
@@ -2527,7 +2529,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b322">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b322">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#linkValueHasTargetIri">
@@ -2539,103 +2541,103 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b323">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b323">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b324">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b324">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b325">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b325">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b326">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b326">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b327">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b327">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b328">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b328">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListNode">
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a flat or hierarchical list</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b329"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b330"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b329"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b330"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b329">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b329">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b330">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b330">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#ListValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b331"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b332"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b333"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b334"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b335"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b336"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b337"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b338"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b339"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b340"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b341"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b342"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b343"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b344"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b331"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b332"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b333"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b334"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b335"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b336"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b337"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b338"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b339"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b340"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b341"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b342"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b343"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b344"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b331">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b331">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b332">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b332">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b333">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b333">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b334">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b334">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b335">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b335">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b336">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b336">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b337">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b337">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b338">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b338">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#listValueAsListNode">
@@ -2647,32 +2649,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b339">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b339">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b340">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b340">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b341">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b341">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b342">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b342">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b343">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b343">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b344">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b344">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -2681,72 +2683,72 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a moving image file</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b345"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b346"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b347"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b348"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b349"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b350"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b351"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b352"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b353"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b354"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b355"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b356"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b357"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b358"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b359"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b360"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b361"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b362"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b363"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b345"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b346"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b347"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b348"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b349"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b350"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b351"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b352"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b353"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b354"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b355"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b356"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b357"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b358"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b359"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b360"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b361"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b362"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b363"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b345">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b345">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b346">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b346">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b347">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b347">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b348">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b348">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b349">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b349">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b350">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b350">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b351">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b351">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b352">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b352">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b353">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b353">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b354">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b354">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimX">
@@ -2758,7 +2760,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b355">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b355">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDimY">
@@ -2770,7 +2772,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b356">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b356">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasDuration">
@@ -2782,7 +2784,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b357">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b357">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#movingImageFileValueHasFps">
@@ -2794,32 +2796,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b358">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b358">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b359">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b359">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b360">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b360">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b361">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b361">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b362">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b362">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b363">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b363">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -2829,66 +2831,66 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing moving image data</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Movie)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b364"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b365"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b366"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b367"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b368"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b369"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b370"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b371"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b372"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b373"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b374"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b375"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b376"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b377"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b378"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b379"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b380"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b381"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b364"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b365"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b366"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b367"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b368"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b369"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b370"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b371"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b372"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b373"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b374"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b375"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b376"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b377"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b378"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b379"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b380"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b381"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b364">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b364">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b365">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b365">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b366">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b366">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b367">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b367">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b368">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b368">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b369">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b369">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b370">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b370">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b371">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b371">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b372">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b372">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasMovingImageFileValue">
@@ -2903,47 +2905,47 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b373">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b373">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b374">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b374">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b375">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b375">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b376">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b376">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b377">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b377">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b378">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b378">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b379">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b379">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b380">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b380">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b381">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b381">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -2955,65 +2957,65 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a geometric region of a resource. The geometry is represented currently as JSON string.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Region</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Resource"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b382"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b383"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b384"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b385"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b386"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b387"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b388"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b389"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b390"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b391"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b392"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b393"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b394"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b395"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b396"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b397"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b398"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b399"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b400"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b401"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b402"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b403"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b382"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b383"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b384"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b385"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b386"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b387"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b388"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b389"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b390"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b391"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b392"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b393"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b394"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b395"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b396"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b397"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b398"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b399"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b400"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b401"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b402"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b403"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b382">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b382">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b383">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b383">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b384">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b384">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b385">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b385">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b386">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b386">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b387">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b387">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b388">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b388">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b389">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b389">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasColor">
@@ -3029,11 +3031,11 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b390">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b390">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b391">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b391">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasGeometry">
@@ -3048,32 +3050,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b392">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b392">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b393">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b393">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b394">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b394">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b395">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b395">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b396">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b396">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b397">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b397">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOf">
@@ -3088,7 +3090,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b398">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b398">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#isRegionOfValue">
@@ -3103,67 +3105,67 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b399">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b399">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b400">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b400">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b401">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b401">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b402">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b402">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b403">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b403">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b404">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b404">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b405">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b405">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b406">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b406">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b407">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b407">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b408">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b408">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b409">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b409">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b410">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b410">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b411">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b411">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasFileValue">
@@ -3177,121 +3179,121 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b412">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b412">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b413">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b413">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b414">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b414">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b415">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b415">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b416">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b416">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b417">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b417">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b418">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b418">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b419">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b419">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b420">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b420">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b421">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b421">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b422">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b422">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b423">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b423">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b424">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b424">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b425">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b425">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b426">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b426">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b427">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b427">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b428">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b428">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b429">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b429">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b430">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b430">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b431">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b431">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b432">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b432">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b433">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b433">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b434">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b434">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b435">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b435">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b436">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b436">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b437">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b437">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b438">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b438">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
 </owl:Restriction>
@@ -3300,39 +3302,39 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a boolean in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#BooleanBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b439"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b440"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b441"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b442"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b443"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b444"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b445"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b446"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b447"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b448"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b449"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b439"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b440"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b441"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b442"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b443"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b444"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b445"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b446"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b447"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b448"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b449"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a knora-base value type in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b461"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b462"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b463"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b464"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b465"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b466"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b467"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b468"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b469"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b470"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b461"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b462"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b463"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b464"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b465"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b466"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b467"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b468"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b469"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b470"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b439">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b439">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#booleanValueAsBoolean"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b440">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b440">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3342,7 +3344,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b441">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b441">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3352,7 +3354,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b442">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b442">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3362,7 +3364,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b443">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b443">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3374,7 +3376,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b444">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b444">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3384,7 +3386,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b445">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b445">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3394,7 +3396,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b446">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b446">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3404,7 +3406,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b447">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b447">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3415,7 +3417,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b448">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b448">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
@@ -3427,7 +3429,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b449">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b449">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -3442,69 +3444,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a color in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ColorBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b450"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b451"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b452"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b453"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b454"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b455"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b456"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b457"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b458"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b459"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b460"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b450"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b451"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b452"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b453"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b454"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b455"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b456"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b457"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b458"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b459"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b460"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b450">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b450">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#colorValueAsColor"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b451">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b451">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b452">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b452">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b453">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b453">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b454">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b454">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b455">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b455">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b456">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b456">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b457">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b457">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b458">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b458">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b459">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b459">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b460">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b460">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3512,63 +3514,63 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#StandoffTag">
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a standoff markup tag</rdfs:comment>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b546"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b547"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b548"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b549"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b550"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b551"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b552"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b553"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b554"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b555"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b546"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b547"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b548"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b549"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b550"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b551"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b552"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b553"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b554"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b555"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b461">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b461">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b462">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b462">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b463">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b463">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b464">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b464">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b465">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b465">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b466">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b466">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b467">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b467">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b468">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b468">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b469">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b469">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b470">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b470">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3578,117 +3580,117 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a date in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DateBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b471"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b472"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b473"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b474"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b475"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b476"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b477"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b478"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b479"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b480"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b481"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b482"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b483"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b484"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b485"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b486"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b487"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b488"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b489"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b471"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b472"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b473"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b474"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b475"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b476"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b477"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b478"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b479"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b480"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b481"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b482"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b483"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b484"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b485"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b486"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b487"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b488"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b489"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b471">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b471">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasCalendar"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b472">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b472">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b473">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b473">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b474">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b474">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b475">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b475">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasEndYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b476">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b476">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartDay"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b477">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b477">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartEra"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b478">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b478">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartMonth"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b479">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b479">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#dateValueHasStartYear"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b480">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b480">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b481">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b481">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b482">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b482">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b483">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b483">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b484">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b484">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b485">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b485">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b486">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b486">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b487">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b487">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b488">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b488">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b489">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b489">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3698,69 +3700,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a decimal (floating point) value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#DecimalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b490"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b491"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b492"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b493"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b494"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b495"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b496"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b497"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b498"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b499"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b500"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b490"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b491"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b492"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b493"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b494"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b495"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b496"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b497"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b498"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b499"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b500"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b490">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b490">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#decimalValueAsDecimal"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b491">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b491">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b492">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b492">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b493">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b493">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b494">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b494">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b495">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b495">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b496">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b496">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b497">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b497">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b498">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b498">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b499">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b499">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b500">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b500">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3770,69 +3772,69 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an integer value in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b501"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b502"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b503"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b504"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b505"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b506"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b507"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b508"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b509"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b510"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b511"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b501"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b502"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b503"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b504"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b505"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b506"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b507"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b508"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b509"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b510"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b511"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b501">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b501">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intValueAsInt"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b502">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b502">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b503">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b503">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b504">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b504">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b505">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b505">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b506">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b506">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b507">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b507">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b508">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b508">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b509">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b509">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b510">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b510">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b511">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b511">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3842,39 +3844,39 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an internal reference in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b512"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b513"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b514"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b515"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b516"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b517"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b518"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b519"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b520"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b521"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b522"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b512"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b513"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b514"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b515"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b516"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b517"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b518"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b519"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b520"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b521"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b522"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b512">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b512">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b513">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b513">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b514">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b514">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b515">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b515">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b516">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b516">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasInternalReference">
@@ -3883,32 +3885,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b517">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b517">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b518">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b518">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b519">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b519">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b520">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b520">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b521">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b521">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b522">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b522">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3918,75 +3920,75 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an interval in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#IntervalBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b523"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b524"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b525"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b526"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b527"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b528"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b529"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b530"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b531"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b532"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b533"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b534"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b523"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b524"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b525"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b526"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b527"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b528"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b529"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b530"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b531"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b532"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b533"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b534"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b523">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b523">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b524">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b524">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#intervalValueHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b525">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b525">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b526">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b526">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b527">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b527">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b528">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b528">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b529">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b529">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b530">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b530">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b531">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b531">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b532">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b532">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b533">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b533">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b534">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b534">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
@@ -3995,39 +3997,39 @@
 	<knora-api:isStandoffClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isStandoffClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a reference to a Knora resource in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffTag"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b535"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b536"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b537"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b538"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b539"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b540"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b541"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b542"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b543"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b544"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b545"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b535"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b536"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b537"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b538"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b539"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b540"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b541"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b542"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b543"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b544"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b545"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b535">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b535">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b536">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b536">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b537">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b537">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b538">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b538">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b539">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b539">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#standoffTagHasLink">
@@ -4036,73 +4038,73 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b540">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b540">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b541">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b541">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b542">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b542">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b543">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b543">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b544">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b544">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b545">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b545">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b546">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b546">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b547">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b547">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b548">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b548">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b549">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b549">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b550">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b550">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b551">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b551">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b552">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b552">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b553">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b553">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b554">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b554">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b555">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b555">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
@@ -4111,73 +4113,73 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a timestamp in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TimeBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b556"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b557"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b558"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b559"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b560"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b561"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b562"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b563"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b564"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b565"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b566"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b556"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b557"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b558"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b559"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b560"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b561"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b562"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b563"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b564"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b565"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b566"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TimeBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b667"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b667"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b556">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b556">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b557">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b557">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b558">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b558">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b559">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b559">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b560">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b560">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b561">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b561">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b562">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b562">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b563">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b563">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b564">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b564">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b565">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b565">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b566">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b566">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -4193,73 +4195,73 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents an arbitrary URI in a TextValue</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#StandoffDataTypeTag"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b567"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b568"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b569"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b570"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b571"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b572"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b573"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b574"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b575"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b576"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b577"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b567"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b568"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b569"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b570"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b571"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b572"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b573"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b574"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b575"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b576"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b577"/>
 </owl:Class>
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#UriBase">
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#ValueBase"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b682"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b682"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b567">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b567">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEnd"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b568">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b568">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b569">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b569">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b570">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b570">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasEndParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b571">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b571">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasOriginalXMLID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b572">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b572">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStart"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b573">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b573">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b574">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b574">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParent"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b575">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b575">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasStartParentIndex"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b576">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b576">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#standoffTagHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b577">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b577">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
@@ -4276,71 +4278,71 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A file containing a two-dimensional still image</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b578"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b579"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b580"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b581"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b582"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b583"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b584"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b585"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b586"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b587"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b588"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b589"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b590"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b591"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b592"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b593"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b594"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b595"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b578"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b579"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b580"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b581"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b582"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b583"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b584"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b585"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b586"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b587"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b588"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b589"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b590"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b591"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b592"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b593"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b594"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b595"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b578">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b578">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b579">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b579">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b580">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b580">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b581">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b581">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b582">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b582">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b583">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b583">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b584">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b584">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b585">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b585">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b586">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b586">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b587">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b587">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimX">
@@ -4352,7 +4354,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b588">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b588">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasDimY">
@@ -4364,7 +4366,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b589">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b589">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#stillImageFileValueHasIIIFBaseUrl">
@@ -4376,32 +4378,32 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b590">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b590">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b591">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b591">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b592">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b592">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b593">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b593">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b594">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b594">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b595">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b595">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -4411,81 +4413,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource that can contain a two-dimensional still image file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Image)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b596"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b597"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b598"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b599"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b600"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b601"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b602"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b603"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b604"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b605"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b606"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b607"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b608"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b609"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b610"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b611"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b612"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b613"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b596"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b597"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b598"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b599"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b600"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b601"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b602"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b603"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b604"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b605"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b606"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b607"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b608"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b609"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b610"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b611"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b612"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b613"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b596">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b596">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b597">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b597">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b598">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b598">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b599">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b599">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b600">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b600">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b601">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b601">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b602">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b602">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b603">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b603">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b604">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b604">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b605">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b605">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b606">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b606">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b607">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b607">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue">
@@ -4500,32 +4502,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b608">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b608">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b609">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b609">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b610">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b610">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b611">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b611">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b612">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b612">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b613">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b613">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4534,93 +4536,93 @@
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A text file such as plain Unicode text, LaTeX, TEI/XML, etc.</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#FileValue"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b614"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b615"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b616"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b617"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b618"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b619"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b620"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b621"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b622"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b623"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b624"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b625"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b626"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b627"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b628"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b614"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b615"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b616"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b617"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b618"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b619"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b620"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b621"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b622"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b623"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b624"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b625"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b626"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b627"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b628"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b614">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b614">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b615">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b615">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b616">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b616">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b617">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b617">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b618">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b618">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b619">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b619">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueAsUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b620">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b620">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#fileValueHasFilename"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b621">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b621">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b622">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b622">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b623">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b623">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b624">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b624">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b625">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b625">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b626">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b626">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b627">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b627">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b628">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b628">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
@@ -4630,81 +4632,81 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">A resource containing a text file</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Representation (Text)</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Representation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b629"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b630"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b631"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b632"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b633"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b634"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b635"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b636"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b637"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b638"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b639"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b640"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b641"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b642"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b643"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b644"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b645"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b646"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b629"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b630"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b631"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b632"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b633"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b634"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b635"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b636"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b637"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b638"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b639"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b640"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b641"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b642"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b643"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b644"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b645"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b646"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b629">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b629">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b630">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b630">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b631">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b631">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b632">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b632">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b633">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b633">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b634">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b634">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b635">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b635">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b636">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b636">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b637">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b637">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b638">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b638">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b639">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b639">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b640">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b640">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue">
@@ -4719,32 +4721,32 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b641">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b641">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b642">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b642">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b643">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b643">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b644">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b644">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b645">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b645">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b646">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b646">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
@@ -4752,63 +4754,63 @@
 <owl:Class rdf:about="http://api.knora.org/ontology/knora-api/v2#TextValue">
 	<knora-api:isValueClass rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isValueClass>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b647"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b648"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b649"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b650"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b651"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b652"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b653"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b654"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b655"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b656"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b657"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b658"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b659"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b660"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b661"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b662"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b663"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b664"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b665"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b666"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b647"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b648"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b649"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b650"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b651"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b652"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b653"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b654"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b655"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b656"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b657"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b658"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b659"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b660"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b661"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b662"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b663"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b664"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b665"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b666"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b647">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b647">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b648">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b648">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b649">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b649">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b650">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b650">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b651">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b651">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b652">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b652">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b653">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b653">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b654">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b654">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsHtml">
@@ -4820,7 +4822,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b655">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b655">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueAsXml">
@@ -4832,7 +4834,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b656">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b656">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasLanguage">
@@ -4844,7 +4846,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b657">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b657">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMapping">
@@ -4856,7 +4858,7 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b658">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b658">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMarkup">
@@ -4868,7 +4870,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b659">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b659">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty>
 		<owl:DatatypeProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasMaxStandoffStartIndex">
@@ -4880,7 +4882,7 @@
 		</owl:DatatypeProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b660">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b660">
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty>
 		<owl:ObjectProperty rdf:about="http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff">
@@ -4892,37 +4894,37 @@
 		</owl:ObjectProperty>
 	</owl:onProperty>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b661">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b661">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b662">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b662">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b663">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b663">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b664">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b664">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b665">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b665">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b666">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b666">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b667">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b667">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#timeValueAsTimeStamp"/>
 </owl:Restriction>
@@ -4931,92 +4933,92 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a timestamp</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TimeBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b668"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b669"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b670"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b671"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b672"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b673"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b674"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b675"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b676"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b677"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b678"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b679"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b680"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b681"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b668"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b669"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b670"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b671"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b672"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b673"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b674"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b675"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b676"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b677"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b678"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b679"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b680"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b681"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b668">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b668">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b669">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b669">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b670">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b670">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b671">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b671">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b672">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b672">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b673">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b673">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b674">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b674">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b675">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b675">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#timeValueAsTimeStamp"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b676">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b676">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b677">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b677">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b678">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b678">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b679">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b679">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b680">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b680">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b681">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b681">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b682">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b682">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
@@ -5025,140 +5027,140 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Represents a URI</rdfs:comment>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#UriBase"/>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#Value"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b683"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b684"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b685"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b686"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b687"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b688"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b689"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b690"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b691"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b692"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b693"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b694"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b695"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b696"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b683"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b684"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b685"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b686"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b687"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b688"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b689"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b690"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b691"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b692"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b693"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b694"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b695"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b696"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b683">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b683">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b684">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b684">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b685">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b685">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b686">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b686">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b687">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b687">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b688">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b688">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b689">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b689">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b690">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b690">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#uriValueAsUri"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b691">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b691">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b692">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b692">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b693">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b693">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b694">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b694">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b695">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b695">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b696">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b696">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b697">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b697">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b698">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b698">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b699">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b699">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b700">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b700">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b701">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b701">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b702">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b702">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b703">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b703">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b704">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b704">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b705">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b705">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueAsString"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b706">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b706">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueCreationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b707">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b707">
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b708">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b708">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#valueHasUUID"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b709">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b709">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
@@ -5167,110 +5169,110 @@
 	<rdfs:comment rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff.  The transformation's result is ecptected to be HTML.</rdfs:comment>
 	<rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">a TextRepresentation representing an XSL transformation that can be applied to an XML created from standoff. The transformation's result is ecptected to be HTML.</rdfs:label>
 	<rdfs:subClassOf rdf:resource="http://api.knora.org/ontology/knora-api/v2#TextRepresentation"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b710"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b711"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b712"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b713"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b714"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b715"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b716"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b717"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b718"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b719"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b720"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b721"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b722"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b723"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b724"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b725"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b726"/>
-	<rdfs:subClassOf rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b727"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b710"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b711"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b712"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b713"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b714"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b715"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b716"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b717"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b718"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b719"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b720"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b721"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b722"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b723"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b724"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b725"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b726"/>
+	<rdfs:subClassOf rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b727"/>
 </owl:Class>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b710">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b710">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#arkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b711">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b711">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToProject"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b712">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b712">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#attachedToUser"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b713">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b713">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#creationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b714">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b714">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteComment"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b715">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b715">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deleteDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b716">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b716">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#deletedBy"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b717">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b717">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasIncomingLinkValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b718">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b718">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasPermissions"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b719">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b719">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkTo"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b720">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b720">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">0</owl:minCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasStandoffLinkToValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b721">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b721">
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#hasTextFileValue"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b722">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b722">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#isDeleted"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b723">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b723">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#lastModificationDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b724">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b724">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#userHasPermission"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b725">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b725">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionArkUrl"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b726">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b726">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:maxCardinality>
 	<owl:onProperty rdf:resource="http://api.knora.org/ontology/knora-api/v2#versionDate"/>
 </owl:Restriction>
-<owl:Restriction rdf:nodeID="genid-a851b42761b94b1c8afffe4b061ec5b3-b727">
+<owl:Restriction rdf:nodeID="genid-5ca32980982d4298afbf4d9d7b86f8a3-b727">
 	<knora-api:isInherited rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</knora-api:isInherited>
 	<owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">1</owl:cardinality>
 	<owl:onProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>

--- a/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
+++ b/webapi/src/test/resources/test-data/ontologyR2RV2/knoraApiOntologyWithValueObjects.ttl
@@ -263,6 +263,8 @@ knora-api:versionDate a owl:DatatypeProperty;
   rdfs:comment "Provides the date of a particular version of a resource.";
   rdfs:label "version date" .
 
+rdfs:label a owl:DatatypeProperty .
+
 knora-api:AudioFileValue a owl:Class;
   knora-api:isValueClass true;
   rdfs:comment "Represents an audio file";


### PR DESCRIPTION
This PR:

- Fixes the definitions of custom datatypes in the `knora-api` ontology in the simple schema.
- Adds `rdfs:label a owl:DatatypeProperty` so it can be used in cardinalities.

@tobiasschweizer Do you think this will affect `knora-api-js-lib`?

Fixes #1593.
