### PR TITLE
feat(api-v2): Allow querying for rdfs:label in Gravsearch

### DIFF
--- a/docs/src/paradox/03-apis/api-v2/query-language.md
+++ b/docs/src/paradox/03-apis/api-v2/query-language.md
@@ -616,6 +616,39 @@ CONSTRUCT {
 }
 ```
 
+### Filtering on `rdfs:label`
+
+The `rdfs:label` of a resource is not a Knora value, but you can still search for it.
+This can be done in the same ways in the simple or complex schema:
+
+Using a string literal object:
+
+```
+?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
+```
+
+Using a variable and a FILTER:
+
+```
+?book rdfs:label ?label .
+FILTER(?label = "Zeitglöcklein des Lebens und Leidens Christi")
+```
+
+Using the `regex` function:
+
+```
+?book rdfs:label ?bookLabel .
+FILTER regex(?bookLabel, "Zeit", "i")
+```
+
+To match words in an `rdfs:label` using the full-text search index, use the
+`knora-api:matchLabel` function, which works like `knora-api:matchText`,
+except that the first argument is a variable representing a resource:
+
+```
+FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
+```
+
 ### CONSTRUCT Clause
 
 In the `CONSTRUCT` clause of a Gravsearch query, the variable representing the

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -134,6 +134,13 @@ object OntologyConstants {
     }
 
     /**
+     * The object types of resource metadata properties.
+     */
+    val ResourceMetadataPropertyAxioms: Map[IRI, IRI] = Map(
+        OntologyConstants.Rdfs.Label -> OntologyConstants.Xsd.String
+    )
+
+    /**
      * Ontology labels that are reserved for built-in ontologies.
      */
     val BuiltInOntologyLabels: Set[String] = Set(
@@ -1135,5 +1142,4 @@ object OntologyConstants {
         val KnoraExplicitNamedGraph: IRI = "http://www.knora.org/explicit"
         val GraphDBExplicitNamedGraph: IRI = "http://www.ontotext.com/explicit"
     }
-
 }

--- a/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/OntologyConstants.scala
@@ -929,6 +929,7 @@ object OntologyConstants {
         val MatchTextFunction: IRI = KnoraApiV2PrefixExpansion + "matchText"
         val MatchInStandoffFunction: IRI = KnoraApiV2PrefixExpansion + "matchInStandoff"
         val MatchTextInStandoffFunction: IRI = KnoraApiV2PrefixExpansion + "matchTextInStandoff"
+        val MatchLabelFunction: IRI = KnoraApiV2PrefixExpansion + "matchLabel"
         val StandoffLinkFunction: IRI = KnoraApiV2PrefixExpansion + "standoffLink"
     }
 
@@ -968,6 +969,7 @@ object OntologyConstants {
         val MatchesTextIndex: IRI = KnoraApiV2PrefixExpansion + "matchesTextIndex" // virtual property to be replaced by a triplestore-specific one
         val MatchFunction: IRI = KnoraApiV2PrefixExpansion + "match"
         val MatchTextFunction: IRI = KnoraApiV2PrefixExpansion + "matchText"
+        val MatchLabelFunction: IRI = KnoraApiV2PrefixExpansion + "matchLabel"
 
         val ResourceProperty: IRI = KnoraApiV2PrefixExpansion + "resourceProperty"
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchQueryChecker.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchQueryChecker.scala
@@ -135,7 +135,6 @@ object GravsearchQueryChecker {
 
     // A set of predicates that aren't allowed in Gravsearch.
     val forbiddenPredicates: Set[IRI] = Set(
-        OntologyConstants.Rdfs.Label,
         OntologyConstants.KnoraApiV2Complex.AttachedToUser,
         OntologyConstants.KnoraApiV2Complex.HasPermissions,
         OntologyConstants.KnoraApiV2Complex.CreationDate,

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -1768,66 +1768,29 @@ abstract class AbstractPrequeryGenerator(constructClause: ConstructClause,
     private def handleKnoraFunctionCall(functionCallExpression: FunctionCallExpression, typeInspectionResult: GravsearchTypeInspectionResult, isTopLevel: Boolean): TransformedFilterPattern = {
         val functionIri: SmartIri = functionCallExpression.functionIri.iri
 
-        functionIri.toString match {
-
-            case OntologyConstants.KnoraApiV2Simple.MatchFunction =>
-                // deprecated
-                handleMatchFunctionInSimpleSchema(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
-            case OntologyConstants.KnoraApiV2Complex.MatchFunction =>
-                // deprecated
-                handleMatchFunctionInComplexSchema(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
-            case OntologyConstants.KnoraApiV2Complex.MatchInStandoffFunction =>
-                // deprecated
-                handleMatchInStandoffFunction(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
-            case OntologyConstants.KnoraApiV2Simple.MatchTextFunction =>
-                handleMatchTextFunctionInSimpleSchema(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
-            case OntologyConstants.KnoraApiV2Complex.MatchTextFunction =>
-                handleMatchTextFunctionInComplexSchema(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
-            case OntologyConstants.KnoraApiV2Complex.MatchTextInStandoffFunction =>
-                handleMatchTextInStandoffFunction(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
-            case OntologyConstants.KnoraApiV2Complex.StandoffLinkFunction =>
-                handleStandoffLinkFunction(
-                    functionCallExpression = functionCallExpression,
-                    typeInspectionResult = typeInspectionResult,
-                    isTopLevel = isTopLevel
-                )
-
+        // Get a Scala function that implements the Gravsearch function.
+        val functionFunction: (FunctionCallExpression, GravsearchTypeInspectionResult, Boolean) => TransformedFilterPattern = functionIri.toString match {
+            case OntologyConstants.KnoraApiV2Simple.MatchFunction => handleMatchFunctionInSimpleSchema // deprecated
+            case OntologyConstants.KnoraApiV2Complex.MatchFunction => handleMatchFunctionInComplexSchema // deprecated
+            case OntologyConstants.KnoraApiV2Complex.MatchInStandoffFunction => handleMatchInStandoffFunction // deprecated
+            case OntologyConstants.KnoraApiV2Simple.MatchTextFunction => handleMatchTextFunctionInSimpleSchema
+            case OntologyConstants.KnoraApiV2Complex.MatchTextFunction => handleMatchTextFunctionInComplexSchema
+            case OntologyConstants.KnoraApiV2Simple.MatchLabelFunction => handleMatchLabelFunctionInSimpleSchema
+            case OntologyConstants.KnoraApiV2Complex.MatchLabelFunction => handleMatchLabelFunctionInComplexSchema
+            case OntologyConstants.KnoraApiV2Complex.MatchTextInStandoffFunction => handleMatchTextInStandoffFunction
+            case OntologyConstants.KnoraApiV2Complex.StandoffLinkFunction => handleStandoffLinkFunction
             case OntologyConstants.KnoraApiV2Complex.ToSimpleDateFunction =>
                 throw GravsearchException(s"Function ${functionIri.toSparql} must be used in a comparison expression")
 
             case _ => throw NotImplementedException(s"Function ${functionCallExpression.functionIri} not found")
         }
 
+        // Call the Scala function.
+        functionFunction(
+            functionCallExpression,
+            typeInspectionResult,
+            isTopLevel
+        )
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspectionRunner.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspectionRunner.scala
@@ -78,7 +78,7 @@ class GravsearchTypeInspectionRunner(responderData: ResponderData,
             }
 
             // In the initial intermediate result, none of the entities have types yet.
-            initialResult: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult.newInstance(typeableEntities)
+            initialResult: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(typeableEntities)
 
             // Run the pipeline and get its result.
             lastResult: IntermediateTypeInspectionResult <- typeInspectionPipeline.inspectTypes(

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -265,7 +265,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                                     None
                                             }
 
-                                        case other =>
+                                        case _ =>
                                             // We don't have the predicate's type.
                                             Set.empty[GravsearchEntityTypeInfo]
                                     }
@@ -1002,6 +1002,26 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters +
                                     (textVar -> (currentTextVarTypesFromFilters + OntologyConstants.KnoraApiV2Complex.TextValue.toSmartIri))
+                            )
+
+                        case OntologyConstants.KnoraApiV2Simple.MatchLabelFunction =>
+                            // The first argument is a variable representing a resource.
+                            val resourceVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
+                            val currentResourceVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty[SmartIri])
+
+                            acc.copy(
+                                typedEntitiesInFilters = acc.typedEntitiesInFilters +
+                                    (resourceVar -> (currentResourceVarTypesFromFilters + OntologyConstants.KnoraApiV2Simple.Resource.toSmartIri))
+                            )
+
+                        case OntologyConstants.KnoraApiV2Complex.MatchLabelFunction =>
+                            // The first argument is a variable representing a resource.
+                            val resourceVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
+                            val currentResourceVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty[SmartIri])
+
+                            acc.copy(
+                                typedEntitiesInFilters = acc.typedEntitiesInFilters +
+                                    (resourceVar -> (currentResourceVarTypesFromFilters + OntologyConstants.KnoraApiV2Complex.Resource.toSmartIri))
                             )
 
                         case OntologyConstants.KnoraApiV2Complex.MatchInStandoffFunction =>

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/IntermediateTypeInspectionResult.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/IntermediateTypeInspectionResult.scala
@@ -80,11 +80,6 @@ case class IntermediateTypeInspectionResult(entities: Map[TypeableEntity, Set[Gr
 }
 
 object IntermediateTypeInspectionResult {
-    // The object types of built-in properties.
-    private val builtInPropertyObjectTypes: Map[IRI, IRI] = Map(
-        OntologyConstants.Rdfs.Label -> OntologyConstants.Xsd.String
-    )
-
     /**
       * Constructs an [[IntermediateTypeInspectionResult]] for the given set of typeable entities, with built-in
       * types specified (e.g. for `rdfs:label`).
@@ -100,13 +95,13 @@ object IntermediateTypeInspectionResult {
             case typeableIri: TypeableIri => typeableIri.iri.toString
         }
 
-        // Find the IRIs that represent built-in properties, and get their object types.
-        val builtInPropertyTypesUsed: Map[TypeableIri, PropertyTypeInfo] = builtInPropertyObjectTypes.filterKeys(irisUsed).map {
+        // Find the IRIs that represent resource metadata properties, and get their object types.
+        val resourceMetadataPropertyTypesUsed: Map[TypeableIri, PropertyTypeInfo] = OntologyConstants.ResourceMetadataPropertyAxioms.filterKeys(irisUsed).map {
             case (propertyIri, objectTypeIri) => TypeableIri(propertyIri.toSmartIri) -> PropertyTypeInfo(objectTypeIri = objectTypeIri.toSmartIri)
         }
 
         // Add those types to the IntermediateTypeInspectionResult.
-        builtInPropertyTypesUsed.foldLeft(emptyResult) {
+        resourceMetadataPropertyTypesUsed.foldLeft(emptyResult) {
             case (acc: IntermediateTypeInspectionResult, (entity: TypeableIri, entityType: PropertyTypeInfo)) =>
                 acc.addTypes(entity, Set(entityType))
         }

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/IntermediateTypeInspectionResult.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/search/gravsearch/types/IntermediateTypeInspectionResult.scala
@@ -86,7 +86,7 @@ object IntermediateTypeInspectionResult {
       *
       * @param entities the set of typeable entities found in the WHERE clause of a Gravsearch query.
       */
-    def newInstance(entities: Set[TypeableEntity])(implicit stringFormatter: StringFormatter): IntermediateTypeInspectionResult = {
+    def apply(entities: Set[TypeableEntity])(implicit stringFormatter: StringFormatter): IntermediateTypeInspectionResult = {
         // Make an IntermediateTypeInspectionResult in which each typeable entity has no types.
         val emptyResult = new IntermediateTypeInspectionResult(entities = entities.map(entity => entity -> Set.empty[GravsearchEntityTypeInfo]).toMap)
 

--- a/webapi/src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld
+++ b/webapi/src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld
@@ -1,0 +1,58 @@
+{
+  "@graph" : [ {
+    "@id" : "http://rdfh.ch/0803/c5058f3a",
+    "@type" : "incunabula:book",
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0803"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/91e19f1e01"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2016-03-02T15:05:10Z"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:userHasPermission" : "RV",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/c5058f3a5.20160302T150510Z"
+    },
+    "rdfs:label" : "Zeitglöcklein des Lebens und Leidens Christi"
+  }, {
+    "@id" : "http://rdfh.ch/0803/ff17e5ef9601",
+    "@type" : "incunabula:book",
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j"
+    },
+    "knora-api:attachedToProject" : {
+      "@id" : "http://rdfh.ch/projects/0803"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/91e19f1e01"
+    },
+    "knora-api:creationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2016-03-02T15:05:23Z"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:userHasPermission" : "RV",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0803/ff17e5ef9601j.20160302T150523Z"
+    },
+    "rdfs:label" : "Zeitglöcklein des Lebens und Leidens Christi"
+  } ],
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "incunabula" : "http://0.0.0.0:3333/ontology/0803/incunabula/v2#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -8271,5 +8271,49 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }
+
+        "search for an rdfs:label using knora-api:matchLabel in the simple schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "search for an rdfs:label using knora-api:matchLabel in the complex schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -8315,5 +8315,51 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }
+
+        "search for an rdfs:label using the regex function in the simple schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    ?book rdfs:label ?bookLabel .
+                  |    FILTER regex(?bookLabel, "Zeit", "i")
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeit.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "search for an rdfs:label using the regex function in the complex schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    ?book rdfs:label ?bookLabel .
+                  |    FILTER regex(?bookLabel, "Zeit", "i")
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeit.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -81,7 +81,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
     private val timeTagResourceIri = new MutableTestIri
 
     // If true, writes all API responses to test data files. If false, compares the API responses to the existing test data files.
-    private val writeTestDataFiles = true
+    private val writeTestDataFiles = false
 
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
         RdfDataObject(path = "_test_data/demo_data/images-demo-data.ttl", name = "http://www.knora.org/data/00FF/images"),
@@ -8179,6 +8179,96 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 // Compare it to the original XML.
                 val xmlDiff: Diff = DiffBuilder.compare(Input.fromString(xmlStr)).withTest(Input.fromString(xmlFromResponse)).build()
                 xmlDiff.hasDifferences should be(false)
+            }
+        }
+
+        "search for an rdfs:label using a literal in the simple schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    ?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), writeTestDataFiles)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "search for an rdfs:label using a literal in the complex schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    ?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "search for an rdfs:label using a variable in the simple schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    ?book rdfs:label ?label .
+                  |    FILTER(?label = "Zeitglöcklein des Lebens und Leidens Christi")
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "search for an rdfs:label using a variable in the complex schema" in {
+            val gravsearchQuery: String =
+                """
+                  |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?book knora-api:isMainResource true .
+                  |
+                  |} WHERE {
+                  |    ?book rdf:type incunabula:book .
+                  |    ?book rdfs:label ?label .
+                  |    FILTER(?label = "Zeitglöcklein des Lebens und Leidens Christi")
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }
     }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -8324,7 +8324,6 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                   |
                   |CONSTRUCT {
                   |    ?book knora-api:isMainResource true .
-                  |
                   |} WHERE {
                   |    ?book rdf:type incunabula:book .
                   |    ?book rdfs:label ?bookLabel .
@@ -8334,7 +8333,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
                 val searchResponseStr = responseAs[String]
                 assert(status == StatusCodes.OK, searchResponseStr)
-                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeit.jsonld"), false)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }
@@ -8347,7 +8346,6 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                   |
                   |CONSTRUCT {
                   |    ?book knora-api:isMainResource true .
-                  |
                   |} WHERE {
                   |    ?book rdf:type incunabula:book .
                   |    ?book rdfs:label ?bookLabel .
@@ -8357,7 +8355,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
                 val searchResponseStr = responseAs[String]
                 assert(status == StatusCodes.OK, searchResponseStr)
-                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/BooksWithTitleContainingZeit.jsonld"), false)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("src/test/resources/test-data/searchR2RV2/ZeitglöckleinViaLabel.jsonld"), false)
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchParserSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/GravsearchParserSpec.scala
@@ -22,154 +22,13 @@ package org.knora.webapi.responders.v2.search.gravsearch
 import org.knora.webapi.responders.v2.search._
 import org.knora.webapi.util.IriConversions._
 import org.knora.webapi.util.StringFormatter
-import org.knora.webapi.{ApiV2Simple, ApiV2Complex, CoreSpec, GravsearchException}
+import org.knora.webapi.{ApiV2Complex, ApiV2Simple, CoreSpec, GravsearchException}
 
 /**
-  * Tests [[GravsearchParser]].
-  */
+ * Tests [[GravsearchParser]].
+ */
 class GravsearchParserSpec extends CoreSpec() {
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
-
-    "The GravsearchParser object" should {
-        "parse a Gravsearch query" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(Query)
-            parsed should ===(ParsedQuery)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with a BIND" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithBind)
-            parsed should ===(ParsedQueryWithBind)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with a FILTER containing a Boolean operator" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryForAThingRelatingToAnotherThing)
-            parsed should ===(ParsedQueryForAThingRelatingToAnotherThing)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with FILTER NOT EXISTS" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithFilterNotExists)
-            parsed should ===(ParsedQueryWithFilterNotExists)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with MINUS" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithMinus)
-            parsed should ===(ParsedQueryWithMinus)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with OFFSET" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithOffset)
-            parsed should ===(ParsedQueryWithOffset)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with a FILTER containing a regex function" in {
-            val parsed = GravsearchParser.parseQuery(queryWithFilterContainingRegex)
-            parsed should ===(ParsedQueryWithFilterContainingRegex)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "accept a custom 'match' function in a FILTER" in {
-            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithMatchFunction)
-            parsed should ===(ParsedQueryWithMatchFunction)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query with a FILTER containing a lang function" in {
-            val parsed = GravsearchParser.parseQuery(QueryWithFilterContainingLang)
-            parsed should ===(ParsedQueryWithLangFunction)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query containing a FILTER in an OPTIONAL" in {
-            val parsed = GravsearchParser.parseQuery(QueryWithFilterInOptional)
-            parsed should ===(ParsedQueryWithFilterInOptional)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query containing a nested OPTIONAL" in {
-            val parsed = GravsearchParser.parseQuery(QueryStrWithNestedOptional)
-            parsed should ===(ParsedQueryWithNestedOptional)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query containing a UNION in an OPTIONAL" in {
-            val parsed = GravsearchParser.parseQuery(QueryStrWithUnionInOptional)
-            parsed should ===(ParsedQueryWithUnionInOptional)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "parse a Gravsearch query containing an IRI as a function argument" in {
-            val parsed = GravsearchParser.parseQuery(QueryWithIriArgInFunction)
-            parsed should ===(ParsedQueryWithIriArgInFunction)
-            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
-            reparsed should ===(parsed)
-        }
-
-        "reject a SELECT query" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(SparqlSelect)
-            }
-        }
-
-        "reject a DESCRIBE query" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(SparqlDescribe)
-            }
-        }
-
-        "reject an INSERT" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(SparqlInsert)
-            }
-        }
-
-        "reject a DELETE" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(SparqlDelete)
-            }
-        }
-
-        "reject an internal ontology IRI" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(QueryWithInternalEntityIri)
-            }
-        }
-
-        "reject left-nested UNIONs" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(QueryWithLeftNestedUnion)
-            }
-        }
-
-        "reject right-nested UNIONs" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(QueryStrWithRightNestedUnion)
-            }
-        }
-
-        "reject an unsupported FILTER" in {
-            assertThrows[GravsearchException] {
-                GravsearchParser.parseQuery(QueryWithWrongFilter)
-            }
-        }
-    }
 
     val Query: String =
         """
@@ -648,6 +507,19 @@ class GravsearchParserSpec extends CoreSpec() {
           |}
         """.stripMargin
 
+    val QueryWithMatchTextFunction: String =
+        """
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?thing knora-api:isMainResource true .
+          |} WHERE {
+          |    ?thing a anything:Thing .
+          |    ?thing anything:hasText ?text .
+          |    FILTER(knora-api:matchText(?text, "foo"))
+          |}
+        """.stripMargin
 
     val QueryWithFilterContainingLang: String =
         """
@@ -712,7 +584,7 @@ class GravsearchParserSpec extends CoreSpec() {
           |    } ORDER BY ?date
         """.stripMargin
 
-    private val ParsedQueryWithFilterInOptional = ConstructQuery(
+    private val ParsedQueryWithFilterInOptional: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(
                 StatementPattern(
@@ -1002,7 +874,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQuery = ConstructQuery(
+    val ParsedQuery: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(
                 StatementPattern(
@@ -1260,7 +1132,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithBind = ConstructQuery(
+    val ParsedQueryWithBind: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
@@ -1340,7 +1212,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryForAThingRelatingToAnotherThing = ConstructQuery(
+    val ParsedQueryForAThingRelatingToAnotherThing: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(
                 StatementPattern(
@@ -1451,7 +1323,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithFilterNotExists = ConstructQuery(
+    val ParsedQueryWithFilterNotExists: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
@@ -1513,7 +1385,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithMinus = ConstructQuery(
+    val ParsedQueryWithMinus: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
@@ -1575,7 +1447,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithOffset = ConstructQuery(
+    val ParsedQueryWithOffset: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
@@ -1626,7 +1498,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithFilterContainingRegex = ConstructQuery(
+    val ParsedQueryWithFilterContainingRegex: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(
                 StatementPattern(
@@ -1760,7 +1632,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithMatchFunction = ConstructQuery(
+    val ParsedQueryWithMatchFunction: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
@@ -1840,7 +1712,87 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithLangFunction = ConstructQuery(
+    val ParsedQueryWithMatchTextFunction: ConstructQuery = ConstructQuery(
+        constructClause = ConstructClause(
+            statements = Vector(StatementPattern(
+                subj = QueryVariable(variableName = "thing"),
+                pred = IriRef(
+                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri,
+                    propertyPathOperator = None
+                ),
+                obj = XsdLiteral(
+                    value = "true",
+                    datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                ),
+                namedGraph = None
+            )),
+            querySchema = Some(ApiV2Simple)
+        ),
+        querySchema = Some(ApiV2Simple),
+        offset = 0,
+        orderBy = Nil,
+        whereClause = WhereClause(
+            patterns = Vector(
+                StatementPattern(
+                    subj = QueryVariable(variableName = "thing"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = IriRef(
+                        iri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    namedGraph = None
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "thing"),
+                    pred = IriRef(
+                        iri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#hasText".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = QueryVariable(variableName = "text"),
+                    namedGraph = None
+                ),
+                FilterPattern(expression = FunctionCallExpression(
+                    functionIri = IriRef(
+                        iri = "http://api.knora.org/ontology/knora-api/simple/v2#matchText".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    args = Vector(
+                        QueryVariable(variableName = "text"),
+                        XsdLiteral(
+                            value = "foo",
+                            datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
+                        )
+                    )
+                ))
+            ),
+            positiveEntities = Set(
+                QueryVariable(variableName = "thing"),
+                IriRef(
+                    iri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#hasText".toSmartIri,
+                    propertyPathOperator = None
+                ),
+                IriRef(
+                    iri = "http://api.knora.org/ontology/knora-api/simple/v2#isMainResource".toSmartIri,
+                    propertyPathOperator = None
+                ),
+                IriRef(
+                    iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                    propertyPathOperator = None
+                ),
+                QueryVariable(variableName = "text"),
+                IriRef(
+                    iri = "http://0.0.0.0:3333/ontology/0001/anything/simple/v2#Thing".toSmartIri,
+                    propertyPathOperator = None
+                )
+            ),
+            querySchema = Some(ApiV2Simple)
+        )
+    )
+
+    val ParsedQueryWithLangFunction: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(StatementPattern(
                 subj = QueryVariable(variableName = "thing"),
@@ -1915,7 +1867,7 @@ class GravsearchParserSpec extends CoreSpec() {
         )
     )
 
-    val ParsedQueryWithNestedOptional = ConstructQuery(
+    val ParsedQueryWithNestedOptional: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(
                 StatementPattern(
@@ -2072,7 +2024,7 @@ class GravsearchParserSpec extends CoreSpec() {
           |}
         """.stripMargin
 
-    val ParsedQueryWithIriArgInFunction = ConstructQuery(
+    val ParsedQueryWithIriArgInFunction: ConstructQuery = ConstructQuery(
         constructClause = ConstructClause(
             statements = Vector(
                 StatementPattern(
@@ -2197,4 +2149,152 @@ class GravsearchParserSpec extends CoreSpec() {
             querySchema = Some(ApiV2Complex)
         )
     )
+
+    "The GravsearchParser object" should {
+        "parse a Gravsearch query" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(Query)
+            parsed should ===(ParsedQuery)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with a BIND" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithBind)
+            parsed should ===(ParsedQueryWithBind)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with a FILTER containing a Boolean operator" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryForAThingRelatingToAnotherThing)
+            parsed should ===(ParsedQueryForAThingRelatingToAnotherThing)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with FILTER NOT EXISTS" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithFilterNotExists)
+            parsed should ===(ParsedQueryWithFilterNotExists)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with MINUS" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithMinus)
+            parsed should ===(ParsedQueryWithMinus)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with OFFSET" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithOffset)
+            parsed should ===(ParsedQueryWithOffset)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with a FILTER containing a regex function" in {
+            val parsed = GravsearchParser.parseQuery(queryWithFilterContainingRegex)
+            parsed should ===(ParsedQueryWithFilterContainingRegex)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "accept a custom 'match' function in a FILTER" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithMatchFunction)
+            parsed should ===(ParsedQueryWithMatchFunction)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "accept a custom 'matchText' function in a FILTER" in {
+            val parsed: ConstructQuery = GravsearchParser.parseQuery(QueryWithMatchTextFunction)
+            parsed should ===(ParsedQueryWithMatchTextFunction)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query with a FILTER containing a lang function" in {
+            val parsed = GravsearchParser.parseQuery(QueryWithFilterContainingLang)
+            parsed should ===(ParsedQueryWithLangFunction)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query containing a FILTER in an OPTIONAL" in {
+            val parsed = GravsearchParser.parseQuery(QueryWithFilterInOptional)
+            parsed should ===(ParsedQueryWithFilterInOptional)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query containing a nested OPTIONAL" in {
+            val parsed = GravsearchParser.parseQuery(QueryStrWithNestedOptional)
+            parsed should ===(ParsedQueryWithNestedOptional)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query containing a UNION in an OPTIONAL" in {
+            val parsed = GravsearchParser.parseQuery(QueryStrWithUnionInOptional)
+            parsed should ===(ParsedQueryWithUnionInOptional)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "parse a Gravsearch query containing an IRI as a function argument" in {
+            val parsed = GravsearchParser.parseQuery(QueryWithIriArgInFunction)
+            parsed should ===(ParsedQueryWithIriArgInFunction)
+            val reparsed = GravsearchParser.parseQuery(parsed.toSparql)
+            reparsed should ===(parsed)
+        }
+
+        "reject a SELECT query" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(SparqlSelect)
+            }
+        }
+
+        "reject a DESCRIBE query" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(SparqlDescribe)
+            }
+        }
+
+        "reject an INSERT" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(SparqlInsert)
+            }
+        }
+
+        "reject a DELETE" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(SparqlDelete)
+            }
+        }
+
+        "reject an internal ontology IRI" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(QueryWithInternalEntityIri)
+            }
+        }
+
+        "reject left-nested UNIONs" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(QueryWithLeftNestedUnion)
+            }
+        }
+
+        "reject right-nested UNIONs" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(QueryStrWithRightNestedUnion)
+            }
+        }
+
+        "reject an unsupported FILTER" in {
+            assertThrows[GravsearchException] {
+                GravsearchParser.parseQuery(QueryWithWrongFilter)
+            }
+        }
+    }
 }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec.scala
@@ -585,83 +585,46 @@ class NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec extends CoreSpec
         """.stripMargin
 
     val transformedQueryWithDateOptionalSortCriterionAndFilter: SelectQuery =
-    SelectQuery(
-        variables = Vector(
-            QueryVariable(variableName = "thing"),
-            GroupConcat(
-                inputVariable = QueryVariable(variableName = "date"),
-                separator = StringFormatter.INFORMATION_SEPARATOR_ONE,
-                outputVariableName = "date__Concat",
-            )
-        ),
-        offset = 0,
-        groupBy = Vector(
-            QueryVariable(variableName = "thing"),
-            QueryVariable(variableName = "date__valueHasStartJDN")
-        ),
-        orderBy = Vector(
-            OrderCriterion(
-                queryVariable = QueryVariable(variableName = "date__valueHasStartJDN"),
-                isAscending = false
+        SelectQuery(
+            variables = Vector(
+                QueryVariable(variableName = "thing"),
+                GroupConcat(
+                    inputVariable = QueryVariable(variableName = "date"),
+                    separator = StringFormatter.INFORMATION_SEPARATOR_ONE,
+                    outputVariableName = "date__Concat",
+                )
             ),
-            OrderCriterion(
-                queryVariable = QueryVariable(variableName = "thing"),
-                isAscending = true
-            )
-        ),
-        whereClause = WhereClause(
-            patterns = Vector(
-                StatementPattern(
-                    subj = QueryVariable(variableName = "thing"),
-                    pred = IriRef(
-                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-                        propertyPathOperator = None
-                    ),
-                    obj = IriRef(
-                        iri = "http://www.knora.org/ontology/knora-base#Resource".toSmartIri,
-                        propertyPathOperator = None
-                    ),
-                    namedGraph = None
+            offset = 0,
+            groupBy = Vector(
+                QueryVariable(variableName = "thing"),
+                QueryVariable(variableName = "date__valueHasStartJDN")
+            ),
+            orderBy = Vector(
+                OrderCriterion(
+                    queryVariable = QueryVariable(variableName = "date__valueHasStartJDN"),
+                    isAscending = false
                 ),
-                StatementPattern(
-                    subj = QueryVariable(variableName = "thing"),
-                    pred = IriRef(
-                        iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-                        propertyPathOperator = None
-                    ),
-                    obj = XsdLiteral(
-                        value = "false",
-                        datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-                    ),
-                    namedGraph = Some(IriRef(
-                        iri = "http://www.knora.org/explicit".toSmartIri,
-                        propertyPathOperator = None
-                    ))
-                ),
-                StatementPattern(
-                    subj = QueryVariable(variableName = "thing"),
-                    pred = IriRef(
-                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
-                        propertyPathOperator = None
-                    ),
-                    obj = IriRef(
-                        iri = "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
-                        propertyPathOperator = None
-                    ),
-                    namedGraph = None
-                ),
-                OptionalPattern(patterns = Vector(
+                OrderCriterion(
+                    queryVariable = QueryVariable(variableName = "thing"),
+                    isAscending = true
+                )
+            ),
+            whereClause = WhereClause(
+                patterns = Vector(
                     StatementPattern(
                         subj = QueryVariable(variableName = "thing"),
                         pred = IriRef(
-                            iri = "http://www.knora.org/ontology/0001/anything#hasDate".toSmartIri,
+                            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
                             propertyPathOperator = None
                         ),
-                        obj = QueryVariable(variableName = "date"),
+                        obj = IriRef(
+                            iri = "http://www.knora.org/ontology/knora-base#Resource".toSmartIri,
+                            propertyPathOperator = None
+                        ),
                         namedGraph = None
                     ),
                     StatementPattern(
-                        subj = QueryVariable(variableName = "date"),
+                        subj = QueryVariable(variableName = "thing"),
                         pred = IriRef(
                             iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
                             propertyPathOperator = None
@@ -676,33 +639,70 @@ class NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec extends CoreSpec
                         ))
                     ),
                     StatementPattern(
-                        subj = QueryVariable(variableName = "date"),
+                        subj = QueryVariable(variableName = "thing"),
                         pred = IriRef(
-                            iri = "http://www.knora.org/ontology/knora-base#valueHasStartJDN".toSmartIri,
+                            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
                             propertyPathOperator = None
                         ),
-                        obj = QueryVariable(variableName = "date__valueHasStartJDN"),
-                        namedGraph = Some(IriRef(
-                            iri = "http://www.knora.org/explicit".toSmartIri,
+                        obj = IriRef(
+                            iri = "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
                             propertyPathOperator = None
-                        ))
+                        ),
+                        namedGraph = None
                     ),
-                    FilterPattern(expression = CompareExpression(
-                        leftArg = QueryVariable(variableName = "date__valueHasStartJDN"),
-                        operator = CompareExpressionOperator.GREATER_THAN,
-                        rightArg = XsdLiteral(
-                            value = "2455928",
-                            datatype = "http://www.w3.org/2001/XMLSchema#integer".toSmartIri
-                        )
+                    OptionalPattern(patterns = Vector(
+                        StatementPattern(
+                            subj = QueryVariable(variableName = "thing"),
+                            pred = IriRef(
+                                iri = "http://www.knora.org/ontology/0001/anything#hasDate".toSmartIri,
+                                propertyPathOperator = None
+                            ),
+                            obj = QueryVariable(variableName = "date"),
+                            namedGraph = None
+                        ),
+                        StatementPattern(
+                            subj = QueryVariable(variableName = "date"),
+                            pred = IriRef(
+                                iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                                propertyPathOperator = None
+                            ),
+                            obj = XsdLiteral(
+                                value = "false",
+                                datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                            ),
+                            namedGraph = Some(IriRef(
+                                iri = "http://www.knora.org/explicit".toSmartIri,
+                                propertyPathOperator = None
+                            ))
+                        ),
+                        StatementPattern(
+                            subj = QueryVariable(variableName = "date"),
+                            pred = IriRef(
+                                iri = "http://www.knora.org/ontology/knora-base#valueHasStartJDN".toSmartIri,
+                                propertyPathOperator = None
+                            ),
+                            obj = QueryVariable(variableName = "date__valueHasStartJDN"),
+                            namedGraph = Some(IriRef(
+                                iri = "http://www.knora.org/explicit".toSmartIri,
+                                propertyPathOperator = None
+                            ))
+                        ),
+                        FilterPattern(expression = CompareExpression(
+                            leftArg = QueryVariable(variableName = "date__valueHasStartJDN"),
+                            operator = CompareExpressionOperator.GREATER_THAN,
+                            rightArg = XsdLiteral(
+                                value = "2455928",
+                                datatype = "http://www.w3.org/2001/XMLSchema#integer".toSmartIri
+                            )
+                        ))
                     ))
-                ))
+                ),
+                positiveEntities = Set(),
+                querySchema = None
             ),
-            positiveEntities = Set(),
-            querySchema = None
-        ),
-        limit = Some(25),
-        useDistinct = true
-    )
+            limit = Some(25),
+            useDistinct = true
+        )
 
     val inputQueryWithDecimalOptionalSortCriterion: String =
         """
@@ -1028,47 +1028,84 @@ class NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec extends CoreSpec
             useDistinct = true
         )
 
-        val transformedQueryWithDecimalOptionalSortCriterionAndFilterComplex: SelectQuery =
-            SelectQuery(
-                variables = Vector(
-                    QueryVariable(variableName = "thing"),
-                    GroupConcat(
-                        inputVariable = QueryVariable(variableName = "decimal"),
-                        separator = StringFormatter.INFORMATION_SEPARATOR_ONE,
-                        outputVariableName = "decimal__Concat",
-                    )
+    val transformedQueryWithDecimalOptionalSortCriterionAndFilterComplex: SelectQuery =
+        SelectQuery(
+            variables = Vector(
+                QueryVariable(variableName = "thing"),
+                GroupConcat(
+                    inputVariable = QueryVariable(variableName = "decimal"),
+                    separator = StringFormatter.INFORMATION_SEPARATOR_ONE,
+                    outputVariableName = "decimal__Concat",
+                )
+            ),
+            offset = 0,
+            groupBy = Vector(
+                QueryVariable(variableName = "thing"),
+                QueryVariable(variableName = "decimal__valueHasDecimal")
+            ),
+            orderBy = Vector(
+                OrderCriterion(
+                    queryVariable = QueryVariable(variableName = "decimal__valueHasDecimal"),
+                    isAscending = true
                 ),
-                offset = 0,
-                groupBy = Vector(
-                    QueryVariable(variableName = "thing"),
-                    QueryVariable(variableName = "decimal__valueHasDecimal")
-                ),
-                orderBy = Vector(
-                    OrderCriterion(
-                        queryVariable = QueryVariable(variableName = "decimal__valueHasDecimal"),
-                        isAscending = true
+                OrderCriterion(
+                    queryVariable = QueryVariable(variableName = "thing"),
+                    isAscending = true
+                )
+            ),
+            whereClause = WhereClause(
+                patterns = Vector(
+                    StatementPattern(
+                        subj = QueryVariable(variableName = "thing"),
+                        pred = IriRef(
+                            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                            propertyPathOperator = None
+                        ),
+                        obj = IriRef(
+                            iri = "http://www.knora.org/ontology/knora-base#Resource".toSmartIri,
+                            propertyPathOperator = None
+                        ),
+                        namedGraph = None
                     ),
-                    OrderCriterion(
-                        queryVariable = QueryVariable(variableName = "thing"),
-                        isAscending = true
-                    )
-                ),
-                whereClause = WhereClause(
-                    patterns = Vector(
+                    StatementPattern(
+                        subj = QueryVariable(variableName = "thing"),
+                        pred = IriRef(
+                            iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                            propertyPathOperator = None
+                        ),
+                        obj = XsdLiteral(
+                            value = "false",
+                            datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                        ),
+                        namedGraph = Some(IriRef(
+                            iri = "http://www.knora.org/explicit".toSmartIri,
+                            propertyPathOperator = None
+                        ))
+                    ),
+                    StatementPattern(
+                        subj = QueryVariable(variableName = "thing"),
+                        pred = IriRef(
+                            iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                            propertyPathOperator = None
+                        ),
+                        obj = IriRef(
+                            iri = "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
+                            propertyPathOperator = None
+                        ),
+                        namedGraph = None
+                    ),
+                    OptionalPattern(patterns = Vector(
                         StatementPattern(
                             subj = QueryVariable(variableName = "thing"),
                             pred = IriRef(
-                                iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                                iri = "http://www.knora.org/ontology/0001/anything#hasDecimal".toSmartIri,
                                 propertyPathOperator = None
                             ),
-                            obj = IriRef(
-                                iri = "http://www.knora.org/ontology/knora-base#Resource".toSmartIri,
-                                propertyPathOperator = None
-                            ),
+                            obj = QueryVariable(variableName = "decimal"),
                             namedGraph = None
                         ),
                         StatementPattern(
-                            subj = QueryVariable(variableName = "thing"),
+                            subj = QueryVariable(variableName = "decimal"),
                             pred = IriRef(
                                 iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
                                 propertyPathOperator = None
@@ -1083,79 +1120,243 @@ class NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec extends CoreSpec
                             ))
                         ),
                         StatementPattern(
-                            subj = QueryVariable(variableName = "thing"),
+                            subj = QueryVariable(variableName = "decimal"),
                             pred = IriRef(
-                                iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                                iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
                                 propertyPathOperator = None
                             ),
-                            obj = IriRef(
-                                iri = "http://www.knora.org/ontology/0001/anything#Thing".toSmartIri,
+                            obj = QueryVariable(variableName = "decimal__valueHasDecimal"),
+                            namedGraph = Some(IriRef(
+                                iri = "http://www.knora.org/explicit".toSmartIri,
+                                propertyPathOperator = None
+                            ))
+                        ),
+                        StatementPattern(
+                            subj = QueryVariable(variableName = "decimal"),
+                            pred = IriRef(
+                                iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
                                 propertyPathOperator = None
                             ),
+                            obj = QueryVariable(variableName = "decimalVal"),
                             namedGraph = None
                         ),
-                        OptionalPattern(patterns = Vector(
-                            StatementPattern(
-                                subj = QueryVariable(variableName = "thing"),
-                                pred = IriRef(
-                                    iri = "http://www.knora.org/ontology/0001/anything#hasDecimal".toSmartIri,
-                                    propertyPathOperator = None
-                                ),
-                                obj = QueryVariable(variableName = "decimal"),
-                                namedGraph = None
-                            ),
-                            StatementPattern(
-                                subj = QueryVariable(variableName = "decimal"),
-                                pred = IriRef(
-                                    iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
-                                    propertyPathOperator = None
-                                ),
-                                obj = XsdLiteral(
-                                    value = "false",
-                                    datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
-                                ),
-                                namedGraph = Some(IriRef(
-                                    iri = "http://www.knora.org/explicit".toSmartIri,
-                                    propertyPathOperator = None
-                                ))
-                            ),
-                            StatementPattern(
-                                subj = QueryVariable(variableName = "decimal"),
-                                pred = IriRef(
-                                    iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
-                                    propertyPathOperator = None
-                                ),
-                                obj = QueryVariable(variableName = "decimal__valueHasDecimal"),
-                                namedGraph = Some(IriRef(
-                                    iri = "http://www.knora.org/explicit".toSmartIri,
-                                    propertyPathOperator = None
-                                ))
-                            ),
-                            StatementPattern(
-                                subj = QueryVariable(variableName = "decimal"),
-                                pred = IriRef(
-                                    iri = "http://www.knora.org/ontology/knora-base#valueHasDecimal".toSmartIri,
-                                    propertyPathOperator = None
-                                ),
-                                obj = QueryVariable(variableName = "decimalVal"),
-                                namedGraph = None
-                            ),
-                            FilterPattern(expression = CompareExpression(
-                                leftArg = QueryVariable(variableName = "decimalVal"),
-                                operator = CompareExpressionOperator.GREATER_THAN,
-                                rightArg = XsdLiteral(
-                                    value = "2",
-                                    datatype = "http://www.w3.org/2001/XMLSchema#decimal".toSmartIri
-                                )
-                            ))
+                        FilterPattern(expression = CompareExpression(
+                            leftArg = QueryVariable(variableName = "decimalVal"),
+                            operator = CompareExpressionOperator.GREATER_THAN,
+                            rightArg = XsdLiteral(
+                                value = "2",
+                                datatype = "http://www.w3.org/2001/XMLSchema#decimal".toSmartIri
+                            )
                         ))
-                    ),
-                    positiveEntities = Set(),
-                    querySchema = None
+                    ))
                 ),
-                limit = Some(25),
-                useDistinct = true
-            )
+                positiveEntities = Set(),
+                querySchema = None
+            ),
+            limit = Some(25),
+            useDistinct = true
+        )
+
+    val InputQueryWithRdfsLabelAndLiteralInSimpleSchema: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    ?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
+          |}
+        """.stripMargin
+
+    val InputQueryWithRdfsLabelAndLiteralInComplexSchema: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    ?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
+          |}
+        """.stripMargin
+
+    val TransformedQueryWithRdfsLabelAndLiteral: SelectQuery = SelectQuery(
+        variables = Vector(QueryVariable(variableName = "book")),
+        offset = 0,
+        groupBy = Vector(QueryVariable(variableName = "book")),
+        orderBy = Vector(OrderCriterion(
+            queryVariable = QueryVariable(variableName = "book"),
+            isAscending = true
+        )),
+        whereClause = WhereClause(
+            patterns = Vector(
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = IriRef(
+                        iri = "http://www.knora.org/ontology/knora-base#Resource".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    namedGraph = None
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = XsdLiteral(
+                        value = "false",
+                        datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                    ),
+                    namedGraph = Some(IriRef(
+                        iri = "http://www.knora.org/explicit".toSmartIri,
+                        propertyPathOperator = None
+                    ))
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = IriRef(
+                        iri = "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    namedGraph = None
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = XsdLiteral(
+                        value = "Zeitgl\u00F6cklein des Lebens und Leidens Christi",
+                        datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
+                    ),
+                    namedGraph = None
+                )
+            ),
+            positiveEntities = Set(),
+            querySchema = None
+        ),
+        limit = Some(25),
+        useDistinct = true
+    )
+
+    val InputQueryWithRdfsLabelAndVariableInSimpleSchema: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    ?book rdfs:label ?label .
+          |    FILTER(?label = "Zeitglöcklein des Lebens und Leidens Christi")
+          |}
+        """.stripMargin
+
+    val InputQueryWithRdfsLabelAndVariableInComplexSchema: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    ?book rdfs:label ?label .
+          |    FILTER(?label = "Zeitglöcklein des Lebens und Leidens Christi")
+          |}
+        """.stripMargin
+
+    val TransformedQueryWithRdfsLabelAndVariable: SelectQuery = SelectQuery(
+        variables = Vector(QueryVariable(variableName = "book")),
+        offset = 0,
+        groupBy = Vector(QueryVariable(variableName = "book")),
+        orderBy = Vector(OrderCriterion(
+            queryVariable = QueryVariable(variableName = "book"),
+            isAscending = true
+        )),
+        whereClause = WhereClause(
+            patterns = Vector(
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = IriRef(
+                        iri = "http://www.knora.org/ontology/knora-base#Resource".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    namedGraph = None
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.knora.org/ontology/knora-base#isDeleted".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = XsdLiteral(
+                        value = "false",
+                        datatype = "http://www.w3.org/2001/XMLSchema#boolean".toSmartIri
+                    ),
+                    namedGraph = Some(IriRef(
+                        iri = "http://www.knora.org/explicit".toSmartIri,
+                        propertyPathOperator = None
+                    ))
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = IriRef(
+                        iri = "http://www.knora.org/ontology/0803/incunabula#book".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    namedGraph = None
+                ),
+                StatementPattern(
+                    subj = QueryVariable(variableName = "book"),
+                    pred = IriRef(
+                        iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri,
+                        propertyPathOperator = None
+                    ),
+                    obj = QueryVariable(variableName = "label"),
+                    namedGraph = None
+                ),
+                FilterPattern(expression = CompareExpression(
+                    leftArg = QueryVariable(variableName = "label"),
+                    operator = CompareExpressionOperator.EQUALS,
+                    rightArg = XsdLiteral(
+                        value = "Zeitgl\u00F6cklein des Lebens und Leidens Christi",
+                        datatype = "http://www.w3.org/2001/XMLSchema#string".toSmartIri
+                    )
+                ))
+            ),
+            positiveEntities = Set(),
+            querySchema = None
+        ),
+        limit = Some(25),
+        useDistinct = true
+    )
 
     "The NonTriplestoreSpecificGravsearchToPrequeryGenerator object" should {
 
@@ -1253,5 +1454,28 @@ class NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec extends CoreSpec
             assert(transformedQuery === transformedQueryWithDecimalOptionalSortCriterionAndFilterComplex)
         }
 
+        "transform an input query using rdfs:label and a literal in the simple schema" in {
+            val transformedQuery = QueryHandler.transformQuery(InputQueryWithRdfsLabelAndLiteralInSimpleSchema, responderData, settings)
+
+            assert(transformedQuery === TransformedQueryWithRdfsLabelAndLiteral)
+        }
+
+        "transform an input query using rdfs:label and a literal in the complex schema" in {
+            val transformedQuery = QueryHandler.transformQuery(InputQueryWithRdfsLabelAndLiteralInComplexSchema, responderData, settings)
+
+            assert(transformedQuery === TransformedQueryWithRdfsLabelAndLiteral)
+        }
+
+        "transform an input query using rdfs:label and a variable in the simple schema" in {
+            val transformedQuery = QueryHandler.transformQuery(InputQueryWithRdfsLabelAndVariableInSimpleSchema, responderData, settings)
+
+            assert(transformedQuery === TransformedQueryWithRdfsLabelAndVariable)
+        }
+
+        "transform an input query using rdfs:label and a variable in the complex schema" in {
+            val transformedQuery = QueryHandler.transformQuery(InputQueryWithRdfsLabelAndVariableInComplexSchema, responderData, settings)
+
+            assert(transformedQuery === TransformedQueryWithRdfsLabelAndVariable)
+        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
@@ -30,153 +30,14 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 /**
-  * Tests Gravsearch type inspection.
-  */
+ * Tests Gravsearch type inspection.
+ */
 class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
-
-    private val searchParserV2Spec = new GravsearchParserSpec
-
     private val anythingAdminUser = SharedTestDataADM.anythingAdminUser
 
     private implicit val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
 
     private val timeout = 10.seconds
-
-    "The type inspection utility" should {
-        "remove the type annotations from a WHERE clause" in {
-            val parsedQuery = GravsearchParser.parseQuery(QueryWithExplicitTypeAnnotations)
-            val whereClauseWithoutAnnotations = GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
-            whereClauseWithoutAnnotations should ===(whereClauseWithoutAnnotations)
-        }
-    }
-
-    "The annotation-reading type inspector" should {
-        "get type information from a simple query" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = false)
-            val parsedQuery = GravsearchParser.parseQuery(QueryWithExplicitTypeAnnotations)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == SimpleTypeInspectionResult)
-        }
-    }
-
-    "The inferring type inspector" should {
-        "infer that an entity is a knora-api:Resource if there is an rdf:type statement about it and and the specified type is a Knora resource class" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryRdfTypeRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult1)
-        }
-
-        "infer a property's knora-api:objectType if the property's IRI is used as a predicate" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryPropertyIriObjectTypeRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult1)
-        }
-
-        "infer an entity's type if the entity is used as the object of a statement and the predicate's knora-api:objectType is known" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryTypeOfObjectFromPropertyRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult1)
-        }
-
-        "infer the knora-api:objectType of a property variable if it's used with an object whose type is known" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryPropertyTypeFromObjectRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult1)
-        }
-
-        "infer an entity's type if the entity is used as the subject of a statement, the predicate is an IRI, and the predicate's knora-api:subjectType is known" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryTypeOfSubjectFromPropertyRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult1)
-        }
-
-        "infer the knora-api:objectType of a property variable if it's compared to a known property IRI in a FILTER" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryPropertyVarTypeFromFilterRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult2)
-        }
-
-        "infer the type of a non-property variable if it's compared to an XSD literal in a FILTER" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryNonPropertyVarTypeFromFilterRule)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult4)
-        }
-
-        "infer the type of a non-property variable used as the argument of a function in a FILTER" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryVarTypeFromFunction)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult5)
-        }
-
-        "infer the type of a non-property IRI used as the argument of a function in a FILTER" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryIriTypeFromFunction)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult6)
-        }
-
-        "infer the types in a query that requires 6 iterations" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(PathologicalQuery)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == PathologicalTypeInferenceResult)
-        }
-
-        "reject a query with a non-Knora property whose type cannot be inferred" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryNonKnoraTypeWithoutAnnotation)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            assertThrows[GravsearchException] {
-                Await.result(resultFuture, timeout)
-            }
-        }
-
-        "accept a query with a non-Knora property whose type can be inferred" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryNonKnoraTypeWithAnnotation)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            val result = Await.result(resultFuture, timeout)
-            assert(result == TypeInferenceResult3)
-        }
-
-        "reject a query with inconsistent types inferred from statements" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryWithInconsistentTypes1)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            assertThrows[GravsearchException] {
-                Await.result(resultFuture, timeout)
-            }
-        }
-
-        "reject a query with inconsistent types inferred from a FILTER" in {
-            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(QueryWithInconsistentTypes2)
-            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-            assertThrows[GravsearchException] {
-                Await.result(resultFuture, timeout)
-            }
-        }
-    }
-
 
     val QueryWithExplicitTypeAnnotations: String =
         """
@@ -216,7 +77,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
           |}
         """.stripMargin
 
-    val SimpleTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
+    val SimpleTypeInspectionResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasRecipient".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "linkingProp1") -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableIri(iri = "http://rdfh.ch/beol/oU8fMNDJQ9SGblfBl5JamA".toSmartIri) -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
@@ -226,7 +87,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasAuthor".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri)
     ))
 
-    val WhereClauseWithoutAnnotations = WhereClause(patterns = Vector(
+    val WhereClauseWithoutAnnotations: WhereClause = WhereClause(patterns = Vector(
         StatementPattern(
             obj = IriRef(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri),
             pred = IriRef(iri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".toSmartIri),
@@ -594,7 +455,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
           |}
         """.stripMargin
 
-    val PathologicalTypeInferenceResult = GravsearchTypeInspectionResult(entities = Map(
+    val PathologicalTypeInferenceResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableVariable(variableName = "book4") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "titleProp1") -> PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
         TypeableVariable(variableName = "page1") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
@@ -625,7 +486,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
     ))
 
 
-    val TypeInferenceResult1 = GravsearchTypeInspectionResult(entities = Map(
+    val TypeInferenceResult1: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasRecipient".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "linkingProp1") -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "date") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Date".toSmartIri),
@@ -637,7 +498,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasAuthor".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri)
     ))
 
-    val TypeInferenceResult2 = GravsearchTypeInspectionResult(entities = Map(
+    val TypeInferenceResult2: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasRecipient".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "linkingProp1") -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "date") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Date".toSmartIri),
@@ -647,13 +508,13 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasAuthor".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri)
     ))
 
-    val TypeInferenceResult3 = GravsearchTypeInspectionResult(entities = Map(
+    val TypeInferenceResult3: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableVariable(variableName = "title") -> NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
         TypeableIri(iri = "http://purl.org/dc/terms/title".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
         TypeableVariable(variableName = "book") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri)
     ))
 
-    val TypeInferenceResult4 = GravsearchTypeInspectionResult(entities = Map(
+    val TypeInferenceResult4: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#title".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#pubdate".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Date".toSmartIri),
         TypeableVariable(variableName = "book") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
@@ -661,13 +522,13 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         TypeableVariable(variableName = "title") -> NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri)
     ))
 
-    val TypeInferenceResult5 = GravsearchTypeInspectionResult(entities = Map(
+    val TypeInferenceResult5: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableVariable(variableName = "mainRes") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
         TypeableVariable(variableName = "titleProp") -> PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri),
         TypeableVariable(variableName = "propVal0") -> NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri)
     ))
 
-    val TypeInferenceResult6 = GravsearchTypeInspectionResult(entities = Map(
+    val TypeInferenceResult6: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
         TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/v2#hasText".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/v2#TextValue".toSmartIri),
         TypeableVariable(variableName = "text") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/v2#TextValue".toSmartIri),
         TypeableVariable(variableName = "letter") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/v2#Resource".toSmartIri),
@@ -675,4 +536,166 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         TypeableIri(iri = "http://api.knora.org/ontology/knora-api/v2#textValueHasStandoff".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/v2#StandoffTag".toSmartIri),
         TypeableVariable(variableName = "standoffLinkTag") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/v2#StandoffTag".toSmartIri)
     ))
+
+    val QueryWithRdfsLabel: String =
+        """
+          |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?book knora-api:isMainResource true .
+          |
+          |} WHERE {
+          |    ?book rdf:type incunabula:book .
+          |    ?book rdfs:label "Zeitglöcklein des Lebens und Leidens Christi" .
+          |}
+        """.stripMargin
+
+    val RdfsLabelResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
+        TypeableVariable(variableName = "book") -> NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri),
+        TypeableIri(iri = "http://www.w3.org/2000/01/rdf-schema#label".toSmartIri) -> PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri)
+    ))
+
+    "The type inspection utility" should {
+        "remove the type annotations from a WHERE clause" in {
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithExplicitTypeAnnotations)
+            val whereClauseWithoutAnnotations = GravsearchTypeInspectionUtil.removeTypeAnnotations(parsedQuery.whereClause)
+            whereClauseWithoutAnnotations should ===(whereClauseWithoutAnnotations)
+        }
+    }
+
+    "The annotation-reading type inspector" should {
+        "get type information from a simple query" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = false)
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithExplicitTypeAnnotations)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == SimpleTypeInspectionResult)
+        }
+    }
+
+    "The inferring type inspector" should {
+        "infer that an entity is a knora-api:Resource if there is an rdf:type statement about it and and the specified type is a Knora resource class" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryRdfTypeRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult1)
+        }
+
+        "infer a property's knora-api:objectType if the property's IRI is used as a predicate" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryPropertyIriObjectTypeRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult1)
+        }
+
+        "infer an entity's type if the entity is used as the object of a statement and the predicate's knora-api:objectType is known" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryTypeOfObjectFromPropertyRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult1)
+        }
+
+        "infer the knora-api:objectType of a property variable if it's used with an object whose type is known" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryPropertyTypeFromObjectRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult1)
+        }
+
+        "infer an entity's type if the entity is used as the subject of a statement, the predicate is an IRI, and the predicate's knora-api:subjectType is known" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryTypeOfSubjectFromPropertyRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult1)
+        }
+
+        "infer the knora-api:objectType of a property variable if it's compared to a known property IRI in a FILTER" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryPropertyVarTypeFromFilterRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult2)
+        }
+
+        "infer the type of a non-property variable if it's compared to an XSD literal in a FILTER" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryNonPropertyVarTypeFromFilterRule)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult4)
+        }
+
+        "infer the type of a non-property variable used as the argument of a function in a FILTER" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryVarTypeFromFunction)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult5)
+        }
+
+        "infer the type of a non-property IRI used as the argument of a function in a FILTER" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryIriTypeFromFunction)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult6)
+        }
+
+        "infer the types in a query that requires 6 iterations" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(PathologicalQuery)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == PathologicalTypeInferenceResult)
+        }
+
+        "know the object type of rdfs:label" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithRdfsLabel)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == RdfsLabelResult)
+        }
+
+        "reject a query with a non-Knora property whose type cannot be inferred" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryNonKnoraTypeWithoutAnnotation)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            assertThrows[GravsearchException] {
+                Await.result(resultFuture, timeout)
+            }
+        }
+
+        "accept a query with a non-Knora property whose type can be inferred" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryNonKnoraTypeWithAnnotation)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result == TypeInferenceResult3)
+        }
+
+        "reject a query with inconsistent types inferred from statements" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithInconsistentTypes1)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            assertThrows[GravsearchException] {
+                Await.result(resultFuture, timeout)
+            }
+        }
+
+        "reject a query with inconsistent types inferred from a FILTER" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithInconsistentTypes2)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            assertThrows[GravsearchException] {
+                Await.result(resultFuture, timeout)
+            }
+        }
+    }
 }


### PR DESCRIPTION
User story: https://dasch.myjetbrains.com/youtrack/issue/DSP-271

- [x] Add `OntologyConstants.ResourceMetadataPropertyAxioms` specifying the object type of `rdfs:label`, so the type inspection mechanism knows it (by reading it in `IntermediateTypeInspectionResult.newInstance`).
- [x] Change `AbstractPrequeryGenerator` so it doesn't generate any extra statements for a variable that is the object of `rdfs:label`.
- [x] Add a `knora-api:matchLabel` function to `AbstractPrequeryGenerator`, so you can do Lucene full-text searches in labels.
  - [x] In `InferringGravsearchTypeInspector`, infer that the first argument of `knora-api:matchLabel` is a resource.
- [x] Support the `regex` function with `rdfs:label` in `AbstractPrequeryGenerator`.
- [x] Add tests:
  - [x] In `GravsearchTypeInspectorSpec` for type inspection
  - [x] In `NonTriplestoreSpecificGravsearchToPrequeryTransformerSpec` for generating the prequery
  - [x] In `SearchRouteV2R2RSpec` for searching for a resource by label:
    - [x] Using a literal in the simple schema
    - [x] Using a literal in the complex schema
    - [x] Using a variable and a `FILTER` in the simple schema
    - [x] Using a variable and a `FILTER` in the complex schema
    - [x] Using `knora-api:matchLabel` in the simple schema
    - [x] Using `knora-api:matchLabel` in the complex schema
    - [x] Using `regex` in the simple schema
    - [x] Using `regex` in the complex schema
- [x] Update docs (`query-language.md`).