### PR TITLE
test: Fix typo

### DIFF
--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -81,7 +81,7 @@ class SearchRouteV2R2RSpec extends R2RSpec {
     private val timeTagResourceIri = new MutableTestIri
 
     // If true, writes all API responses to test data files. If false, compares the API responses to the existing test data files.
-    private val writeTestDataFiles = true
+    private val writeTestDataFiles = false
 
     override lazy val rdfDataObjects: List[RdfDataObject] = List(
         RdfDataObject(path = "_test_data/demo_data/images-demo-data.ttl", name = "http://www.knora.org/data/00FF/images"),


### PR DESCRIPTION
In `SearchRouteV2R2RSpec`, `private val writeTestDataFiles = true` should be `false` so the test is actually run.