### PR TITLE
Create a group with a custom IRI

### DIFF
--- a/docs/src/paradox/03-apis/api-admin/groups.md
+++ b/docs/src/paradox/03-apis/api-admin/groups.md
@@ -48,26 +48,27 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 - POST: `/admin/groups`
 - BODY:
 
-```
-{
-  "name": "NewGroup",
-  "description": "NewGroupDescription",
-  "project": "http://rdfh.ch/projects/00FF",
-  "status": true,
-  "selfjoin": false
-}
-```
-Additionally, each group can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form)
-specified by the `id` in the request body as below:
-```
-{ "id": "http://rdfh.ch/groups/00FF/group-with-custom-Iri",  
-  "name": "GroupWithCustomIRI",
-  "description": "A new group with a custom IRI",
-  "project": "http://rdfh.ch/projects/00FF",
-  "status": true,
-  "selfjoin": false
-}
-```
+    ```JSON
+    {
+      "name": "NewGroup",
+      "description": "NewGroupDescription",
+      "project": "http://rdfh.ch/projects/00FF",
+      "status": true,
+      "selfjoin": false
+    }
+    ```
+    Additionally, each group can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form)
+    specified by the `id` in the request body as below:
+    ```JSON
+    { 
+      "id": "http://rdfh.ch/groups/00FF/group-with-custom-Iri",  
+      "name": "GroupWithCustomIRI",
+      "description": "A new group with a custom IRI",
+      "project": "http://rdfh.ch/projects/00FF",
+      "status": true,
+      "selfjoin": false
+    }
+    ```
 
 ### Update group information
 

--- a/docs/src/paradox/03-apis/api-admin/groups.md
+++ b/docs/src/paradox/03-apis/api-admin/groups.md
@@ -57,6 +57,17 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
   "selfjoin": false
 }
 ```
+Additionally, each group can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form)
+specified by the `id` in the request body as below:
+```
+{ "id": "http://rdfh.ch/groups/00FF/group-with-custom-Iri",  
+  "name": "GroupWithCustomIRI",
+  "description": "A new group with a custom IRI",
+  "project": "http://rdfh.ch/projects/00FF",
+  "status": true,
+  "selfjoin": false
+}
+```
 
 ### Update group information
 

--- a/docs/src/paradox/03-apis/api-admin/lists.md
+++ b/docs/src/paradox/03-apis/api-admin/lists.md
@@ -57,22 +57,22 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
   - Required permission: SystemAdmin / ProjectAdmin
   - POST: `/admin/lists`
   - BODY:
-    ```
+    ```JSON
     {
         "projectIri": "someprojectiri",
         "labels": [{ "value": "Neue Liste", "language": "de"}],
         "comments": []
     } 
     ```
-  Each list can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form) specified by the `listIri` in the request body as below:
-  ```jsonld
+    Additionally, each list can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form) specified by the `id` in the request body as below:
+    ```JSON
     {
+        "id": "http://rdfh.ch/lists/0001/a-list-with-IRI",
         "projectIri": "http://rdfh.ch/projects/0001",
-        "listIri": "http://rdfh.ch/lists/0001/a-list-with-IRI",
         "labels": [{ "value": "Neue Liste mit IRI", "language": "de"}],
         "comments": []
     }
-  ```
+    ```
 
 ### Create new child node
 

--- a/docs/src/paradox/03-apis/api-admin/projects.md
+++ b/docs/src/paradox/03-apis/api-admin/projects.md
@@ -80,10 +80,10 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
       "selfjoin": false
     }
     ```
-    Each project can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form) specified by the `projectIri` in the request body as below:
+    Additionally, each project can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form) specified by the `id` in the request body as below:
     ```JSON
     {
-        "projectIri": "http://rdfh.ch/projects/3333",
+        "id": "http://rdfh.ch/projects/3333",
         "shortname": "newprojectWithIri",
         "shortcode": "3333",
         "longname": "new project with a custom IRI",

--- a/docs/src/paradox/03-apis/api-admin/users.md
+++ b/docs/src/paradox/03-apis/api-admin/users.md
@@ -77,7 +77,7 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
   - TypeScript Docs: userFormats - `CreateUserApiRequestV1`
   - POST: `/admin/users`
   - BODY:
-    ```
+    ```JSON
     {
       "email": "donald.duck@example.org",
       "givenName": "Donald",
@@ -92,8 +92,9 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
     
     Additionally, each user can have an optional custom IRI (of @ref:[Knora IRI](../api-v2/knora-iris.md#iris-for-data) form)
     specified by the `id` in the request body as below:
-    ```
-    { "id" : "http://rdfh.ch/users/donaldDuck",
+    ```JSON
+    { 
+      "id" : "http://rdfh.ch/users/donaldDuck",
       "email": "donald.duck@example.org",
       "givenName": "Donald",
       "familyName": "Duck",

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -573,6 +573,15 @@ object SharedTestDataADM {
            |    "selfjoin": false
            |}""".stripMargin
 
+    val createGroupWithCustomIriRequest: String =
+        s"""{   "id": "http://rdfh.ch/groups/00FF/group-with-customIri",
+           |    "name": "NewGroupWithCustomIri",
+           |    "description": "A new group with a custom Iri",
+           |    "project": "$IMAGES_PROJECT_IRI",
+           |    "status": true,
+           |    "selfjoin": false
+           |}""".stripMargin
+
     val updateGroupRequest: String =
         s"""{
            |    "name": "UpdatedGroupName",

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -688,8 +688,8 @@ object SharedTestDataADM {
 
     val createListWithCustomIriRequest: String =
         s"""{
+           |    "id": "${SharedTestDataADM.customListIRI}",
            |    "projectIri": "${SharedTestDataADM.ANYTHING_PROJECT_IRI}",
-           |    "listIri": "${SharedTestDataADM.customListIRI}",
            |    "labels": [{ "value": "New list with a custom IRI", "language": "en"}],
            |    "comments": []
            |}""".stripMargin

--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -607,7 +607,7 @@ object SharedTestDataADM {
 
     val createProjectWithCustomIRIRequest: String =
         s"""{
-           |    "projectIri": "$customProjectIri",
+           |    "id": "$customProjectIri",
            |    "shortname": "newprojectWithIri",
            |    "shortcode": "3333",
            |    "longname": "new project with a custom IRI",

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/groupsmessages/GroupsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/groupsmessages/GroupsMessagesADM.scala
@@ -26,6 +26,7 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.{ProjectADM, P
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.admin.responder.{KnoraRequestADM, KnoraResponseADM}
 import org.knora.webapi.responders.admin.GroupsResponderADM
+import org.knora.webapi.util.StringFormatter
 import org.knora.webapi.{BadRequestException, IRI}
 import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, RootJsonFormat}
 
@@ -35,19 +36,25 @@ import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, RootJsonFormat}
 /**
   * Represents an API request payload that asks the Knora API server to create a new group.
   *
+  * @param id          the optional IRI of the group to be created (unique).
   * @param name        the name of the group to be created (unique).
   * @param description the description of the group to be created.
   * @param project     the project inside which the group will be created.
   * @param status      the status of the group to be created (active = true, inactive = false).
   * @param selfjoin    the status of self-join of the group to be created.
   */
-case class CreateGroupApiRequestADM(name: String,
+case class CreateGroupApiRequestADM(id: Option[IRI] = None,
+                                    name: String,
                                     description: Option[String],
                                     project: IRI,
                                     status: Boolean,
                                     selfjoin: Boolean) extends GroupsADMJsonProtocol {
 
+    implicit protected val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
     def toJsValue: JsValue = createGroupApiRequestADMFormat.write(this)
+
+    //check the custom Iri
+    stringFormatter.validateOptionalGroupIri(id, throw BadRequestException(s"Invalid group IRI"))
 }
 
 /**
@@ -320,7 +327,7 @@ trait GroupsADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol wi
     implicit val groupsGetResponseADMFormat: RootJsonFormat[GroupsGetResponseADM] = jsonFormat(GroupsGetResponseADM, "groups")
     implicit val groupResponseADMFormat: RootJsonFormat[GroupGetResponseADM] = jsonFormat(GroupGetResponseADM, "group")
     implicit val groupMembersResponseADMFormat: RootJsonFormat[GroupMembersGetResponseADM] = jsonFormat(GroupMembersGetResponseADM, "members")
-    implicit val createGroupApiRequestADMFormat: RootJsonFormat[CreateGroupApiRequestADM] = jsonFormat(CreateGroupApiRequestADM, "name", "description", "project", "status", "selfjoin")
+    implicit val createGroupApiRequestADMFormat: RootJsonFormat[CreateGroupApiRequestADM] = jsonFormat(CreateGroupApiRequestADM, "id", "name", "description", "project", "status", "selfjoin")
     implicit val changeGroupApiRequestADMFormat: RootJsonFormat[ChangeGroupApiRequestADM] = jsonFormat(ChangeGroupApiRequestADM, "name", "description", "status", "selfjoin")
     implicit val groupOperationResponseADMFormat: RootJsonFormat[GroupOperationResponseADM] = jsonFormat(GroupOperationResponseADM, "group")
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/listsmessages/ListsMessagesADM.scala
@@ -39,21 +39,21 @@ import spray.json.{DefaultJsonProtocol, JsArray, JsObject, JsValue, JsonFormat, 
   * Represents an API request payload that asks the Knora API server to create a new list. At least one
   * label needs to be supplied.
   *
+  * @param id    the optional custom list IRI.
   * @param projectIri the IRI of the project the list belongs to.
-  * @param listIri    the optional custom list IRI.
   * @param name       the optional name of the list.
   * @param labels     the list's labels.
   * @param comments   the list's comments.
   */
-case class CreateListApiRequestADM(projectIri: IRI,
-                                   listIri: Option[IRI] = None,
+case class CreateListApiRequestADM(id: Option[IRI] = None,
+                                   projectIri: IRI,
                                    name: Option[String] = None,
                                    labels: Seq[StringLiteralV2],
                                    comments: Seq[StringLiteralV2]) extends ListADMJsonProtocol {
 
     private val stringFormatter = StringFormatter.getInstanceForConstantOntologies
 
-    stringFormatter.validateOptionalListIri(listIri, throw BadRequestException(s"Invalid list IRI"))
+    stringFormatter.validateOptionalListIri(id, throw BadRequestException(s"Invalid list IRI"))
 
     if (projectIri.isEmpty) {
         // println(this)
@@ -961,7 +961,7 @@ trait ListADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol with
     }
 
 
-    implicit val createListApiRequestADMFormat: RootJsonFormat[CreateListApiRequestADM] = jsonFormat(CreateListApiRequestADM, "projectIri", "listIri", "name", "labels", "comments")
+    implicit val createListApiRequestADMFormat: RootJsonFormat[CreateListApiRequestADM] = jsonFormat(CreateListApiRequestADM, "id", "projectIri", "name", "labels", "comments")
     implicit val createListNodeApiRequestADMFormat: RootJsonFormat[CreateChildNodeApiRequestADM] = jsonFormat(CreateChildNodeApiRequestADM, "parentNodeIri", "projectIri", "name", "labels", "comments")
     implicit val changeListInfoApiRequestADMFormat: RootJsonFormat[ChangeListInfoApiRequestADM] = jsonFormat(ChangeListInfoApiRequestADM, "listIri", "projectIri", "labels", "comments")
     implicit val nodePathGetResponseADMFormat: RootJsonFormat[NodePathGetResponseADM] = jsonFormat(NodePathGetResponseADM, "elements")

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/projectsmessages/ProjectsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/projectsmessages/ProjectsMessagesADM.scala
@@ -40,7 +40,7 @@ import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, RootJsonFormat}
 /**
   * Represents an API request payload that asks the Knora API server to create a new project.
   *
-  * @param projectIri  the optional IRI of the project to be created.
+  * @param id  the optional IRI of the project to be created.
   * @param shortname   the shortname of the project to be created (unique).
   * @param shortcode   the shortcode of the project to be creates (unique)
   * @param longname    the longname of the project to be created.
@@ -50,7 +50,7 @@ import spray.json.{DefaultJsonProtocol, JsValue, JsonFormat, RootJsonFormat}
   * @param status      the status of the project to be created (active = true, inactive = false).
   * @param selfjoin    the status of self-join of the project to be created.
   */
-case class CreateProjectApiRequestADM(projectIri: Option[IRI] = None,
+case class CreateProjectApiRequestADM(id: Option[IRI] = None,
                                       shortname: String,
                                       shortcode: String,
                                       longname: Option[String],
@@ -65,7 +65,7 @@ case class CreateProjectApiRequestADM(projectIri: Option[IRI] = None,
     if (description.isEmpty) {
         throw BadRequestException("Project description needs to be supplied.")
     }
-    stringFormatter.validateOptionalProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+    stringFormatter.validateOptionalProjectIri(id, throw BadRequestException(s"Invalid project IRI"))
 }
 
 /**
@@ -593,7 +593,7 @@ trait ProjectsADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol 
 
     implicit val projectAdminMembersGetResponseADMFormat: RootJsonFormat[ProjectAdminMembersGetResponseADM] = rootFormat(lazyFormat(jsonFormat(ProjectAdminMembersGetResponseADM, "members")))
     implicit val projectMembersGetResponseADMFormat: RootJsonFormat[ProjectMembersGetResponseADM] = rootFormat(lazyFormat(jsonFormat(ProjectMembersGetResponseADM, "members")))
-    implicit val createProjectApiRequestADMFormat: RootJsonFormat[CreateProjectApiRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateProjectApiRequestADM, "projectIri","shortname", "shortcode", "longname", "description", "keywords", "logo", "status", "selfjoin")))
+    implicit val createProjectApiRequestADMFormat: RootJsonFormat[CreateProjectApiRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateProjectApiRequestADM, "id","shortname", "shortcode", "longname", "description", "keywords", "logo", "status", "selfjoin")))
     implicit val changeProjectApiRequestADMFormat: RootJsonFormat[ChangeProjectApiRequestADM] = rootFormat(lazyFormat(jsonFormat(ChangeProjectApiRequestADM, "shortname", "longname", "description", "keywords", "logo", "status", "selfjoin")))
     implicit val projectsKeywordsGetResponseADMFormat: RootJsonFormat[ProjectsKeywordsGetResponseADM] = jsonFormat(ProjectsKeywordsGetResponseADM, "keywords")
     implicit val projectKeywordsGetResponseADMFormat: RootJsonFormat[ProjectKeywordsGetResponseADM] = jsonFormat(ProjectKeywordsGetResponseADM, "keywords")

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/usersmessages/UsersMessagesADM.scala
@@ -59,6 +59,7 @@ case class CreateUserApiRequestADM(id: Option[IRI] = None,
                                    status: Boolean,
                                    lang: String,
                                    systemAdmin: Boolean) {
+
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getGeneralInstance
     def toJsValue: JsValue = UsersADMJsonProtocol.createUserApiRequestADMFormat.write(this)
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/Responder.scala
@@ -148,8 +148,8 @@ abstract class Responder(responderData: ResponderData) extends LazyLogging {
      * @param iriFormatter the stringFormatter method that must be used to create a random Iri.
      * @return IRI of the entity.
      */
-    protected def checkEntityIri(entityIri: Option[SmartIri],
-                                 iriFormatter: => IRI): Future[IRI] = {
+    protected def checkOrCreateEntityIri(entityIri: Option[SmartIri],
+                                         iriFormatter: => IRI): Future[IRI] = {
         entityIri match {
             case Some(customResourceIri) =>
                 for {

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -301,7 +301,7 @@ class GroupsResponderADM(responderData: ResponderData) extends Responder(respond
 
             // check the custom IRI; if not given, create an unused IRI
             customGroupIri: Option[SmartIri] = createRequest.id.map(iri => iri.toSmartIri)
-            groupIri: IRI <- checkEntityIri(customGroupIri, stringFormatter.makeRandomGroupIri(projectADM.shortcode))
+            groupIri: IRI <- checkOrCreateEntityIri(customGroupIri, stringFormatter.makeRandomGroupIri(projectADM.shortcode))
 
 
             /* create the group */

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -299,8 +299,10 @@ class GroupsResponderADM(responderData: ResponderData) extends Responder(respond
                 case None => throw NotFoundException(s"Cannot create group inside project <${createRequest.project}>. The project was not found.")
             }
 
-            /* generate a new random group IRI */
-            groupIri = stringFormatter.makeRandomGroupIri(projectADM.shortcode)
+            // check group Iri
+            customGroupIri: Option[SmartIri] = createRequest.id.map(iri => iri.toSmartIri)
+            groupIri: IRI <- checkEntityIri(customGroupIri, stringFormatter.makeRandomGroupIri(projectADM.shortcode))
+
 
             /* create the group */
             createNewGroupSparqlString = queries.sparql.admin.txt.createNewGroup(

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/GroupsResponderADM.scala
@@ -299,7 +299,7 @@ class GroupsResponderADM(responderData: ResponderData) extends Responder(respond
                 case None => throw NotFoundException(s"Cannot create group inside project <${createRequest.project}>. The project was not found.")
             }
 
-            // check group Iri
+            // check the custom IRI; if not given, create an unused IRI
             customGroupIri: Option[SmartIri] = createRequest.id.map(iri => iri.toSmartIri)
             groupIri: IRI <- checkEntityIri(customGroupIri, stringFormatter.makeRandomGroupIri(projectADM.shortcode))
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -632,7 +632,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             maybeShortcode = project.shortcode
             dataNamedGraph = stringFormatter.projectDataNamedGraphV2(project)
 
-            customListIri: Option[SmartIri] = createListRequest.listIri.map(iri => iri.toSmartIri)
+            customListIri: Option[SmartIri] = createListRequest.id.map(iri => iri.toSmartIri)
             listIri: IRI <- checkEntityIri(customListIri, stringFormatter.makeRandomListIri(maybeShortcode))
 
             // Create the new list

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -632,6 +632,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
             maybeShortcode = project.shortcode
             dataNamedGraph = stringFormatter.projectDataNamedGraphV2(project)
 
+            // check the custom IRI; if not given, create an unused IRI
             customListIri: Option[SmartIri] = createListRequest.id.map(iri => iri.toSmartIri)
             listIri: IRI <- checkEntityIri(customListIri, stringFormatter.makeRandomListIri(maybeShortcode))
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ListsResponderADM.scala
@@ -634,7 +634,7 @@ class ListsResponderADM(responderData: ResponderData) extends Responder(responde
 
             // check the custom IRI; if not given, create an unused IRI
             customListIri: Option[SmartIri] = createListRequest.id.map(iri => iri.toSmartIri)
-            listIri: IRI <- checkEntityIri(customListIri, stringFormatter.makeRandomListIri(maybeShortcode))
+            listIri: IRI <- checkOrCreateEntityIri(customListIri, stringFormatter.makeRandomListIri(maybeShortcode))
 
             // Create the new list
             createNewListSparqlString = queries.sparql.admin.txt.createNewList(

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -777,8 +777,9 @@ class ProjectsResponderADM(responderData: ResponderData) extends Responder(respo
             _ = if (shortcodeExists) {
                 throw DuplicateValueException(s"Project with the shortcode: '${createProjectRequest.shortcode}' already exists")
             }
-            customProjectIri: Option[SmartIri] = createProjectRequest.projectIri.map(iri => iri.toSmartIri)
 
+            //check custom Iri
+            customProjectIri: Option[SmartIri] = createProjectRequest.id.map(iri => iri.toSmartIri)
             newProjectIRI: IRI <- checkEntityIri(customProjectIri, stringFormatter.makeRandomProjectIri(validatedShortcode))
 
             createNewProjectSparqlString = queries.sparql.admin.txt.createNewProject(

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -780,7 +780,7 @@ class ProjectsResponderADM(responderData: ResponderData) extends Responder(respo
 
             // check the custom IRI; if not given, create an unused IRI
             customProjectIri: Option[SmartIri] = createProjectRequest.id.map(iri => iri.toSmartIri)
-            newProjectIRI: IRI <- checkEntityIri(customProjectIri, stringFormatter.makeRandomProjectIri(validatedShortcode))
+            newProjectIRI: IRI <- checkOrCreateEntityIri(customProjectIri, stringFormatter.makeRandomProjectIri(validatedShortcode))
 
             createNewProjectSparqlString = queries.sparql.admin.txt.createNewProject(
                 adminNamedGraphIri = OntologyConstants.NamedGraphs.AdminNamedGraph,

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/ProjectsResponderADM.scala
@@ -778,7 +778,7 @@ class ProjectsResponderADM(responderData: ResponderData) extends Responder(respo
                 throw DuplicateValueException(s"Project with the shortcode: '${createProjectRequest.shortcode}' already exists")
             }
 
-            //check custom Iri
+            // check the custom IRI; if not given, create an unused IRI
             customProjectIri: Option[SmartIri] = createProjectRequest.id.map(iri => iri.toSmartIri)
             newProjectIRI: IRI <- checkEntityIri(customProjectIri, stringFormatter.makeRandomProjectIri(validatedShortcode))
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -1180,7 +1180,7 @@ class UsersResponderADM(responderData: ResponderData) extends Responder(responde
 
             // check the custom IRI; if not given, create an unused IRI
             customUserIri: Option[SmartIri] = createRequest.id.map(iri => iri.toSmartIri)
-            userIri: IRI <- checkEntityIri(customUserIri, stringFormatter.makeRandomPersonIri)
+            userIri: IRI <- checkOrCreateEntityIri(customUserIri, stringFormatter.makeRandomPersonIri)
 
             encoder = new BCryptPasswordEncoder(settings.bcryptPasswordStrength)
             hashedPassword = encoder.encode(createRequest.password)

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/UsersResponderADM.scala
@@ -1178,7 +1178,7 @@ class UsersResponderADM(responderData: ResponderData) extends Responder(responde
                 throw DuplicateValueException(s"User with the email '${createRequest.email}' already exists")
             }
 
-            // check user Iri
+            // check the custom IRI; if not given, create an unused IRI
             customUserIri: Option[SmartIri] = createRequest.id.map(iri => iri.toSmartIri)
             userIri: IRI <- checkEntityIri(customUserIri, stringFormatter.makeRandomPersonIri)
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -233,7 +233,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 throw ForbiddenException(s"User ${createResourceRequestV2.requestingUser.username} does not have permission to create a resource of class <${createResourceRequestV2.createResource.resourceClassIri}> in project <$projectIri>")
             }
 
-            resourceIri: IRI <- checkEntityIri(createResourceRequestV2.createResource.resourceIri, stringFormatter.makeRandomResourceIri(createResourceRequestV2.createResource.projectADM.shortcode))
+            resourceIri: IRI <- checkOrCreateEntityIri(createResourceRequestV2.createResource.resourceIri, stringFormatter.makeRandomResourceIri(createResourceRequestV2.createResource.projectADM.shortcode))
 
             // Do the remaining pre-update checks and the update while holding an update lock on the resource to be created.
             taskResult <- IriLocker.runWithIriLock(

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ValuesResponderV2.scala
@@ -397,7 +397,7 @@ class ValuesResponderV2(responderData: ResponderData) extends Responder(responde
         for {
 
             // Make an IRI for the new value.
-            newValueIri: IRI <- checkEntityIri(maybeValueIri, stringFormatter.makeRandomValueIri(resourceInfo.resourceIri))
+            newValueIri: IRI <- checkOrCreateEntityIri(maybeValueIri, stringFormatter.makeRandomValueIri(resourceInfo.resourceIri))
 
             // Make a UUID for the new value
             newValueUUID: UUID = maybeValueUUID match {
@@ -610,7 +610,7 @@ class ValuesResponderV2(responderData: ResponderData) extends Responder(responde
                                                         resourceCreationDate: Instant,
                                                         requestingUser: UserADM): Future[InsertSparqlWithUnverifiedValue] = {
         for {
-            newValueIri: IRI <- checkEntityIri(valueToCreate.customValueIri, stringFormatter.makeRandomValueIri(resourceIri))
+            newValueIri: IRI <- checkOrCreateEntityIri(valueToCreate.customValueIri, stringFormatter.makeRandomValueIri(resourceIri))
 
             // Make a UUID for the new value.
             newValueUUID: UUID = valueToCreate.customValueUUID match {
@@ -2018,7 +2018,7 @@ class ValuesResponderV2(responderData: ResponderData) extends Responder(responde
 
         for {
             // Make an IRI for the new LinkValue.
-            newLinkValueIri: IRI <- checkEntityIri(customNewLinkValueIri, stringFormatter.makeRandomValueIri(sourceResourceInfo.resourceIri))
+            newLinkValueIri: IRI <- checkOrCreateEntityIri(customNewLinkValueIri, stringFormatter.makeRandomValueIri(sourceResourceInfo.resourceIri))
 
             linkUpdate = maybeLinkValueInfo match {
                 case Some(linkValueInfo) =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/GroupsRouteADM.scala
@@ -118,11 +118,17 @@ class GroupsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
         }
     }
 
-    private def createGroupTestRequest: Future[TestDataFileContent] = {
+    private def createGroupTestRequest: Future[Set[TestDataFileContent]] = {
         FastFuture.successful(
-            TestDataFileContent(
-                filePath = TestDataFilePath.makeJsonPath("create-group-request"),
-                text = SharedTestDataADM.createGroupRequest
+            Set(
+                TestDataFileContent(
+                    filePath = TestDataFilePath.makeJsonPath("create-group-request"),
+                    text = SharedTestDataADM.createGroupRequest
+                ),
+                TestDataFileContent(
+                    filePath = TestDataFilePath.makeJsonPath("create-group-with-custom-Iri-request"),
+                    text = SharedTestDataADM.createGroupWithCustomIriRequest
+                )
             )
         )
     }
@@ -332,15 +338,14 @@ class GroupsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) wi
     override def getTestData(implicit executionContext: ExecutionContext,
                              actorSystem: ActorSystem,
                              materializer: Materializer): Future[Set[TestDataFileContent]] = {
-        Future.sequence {
-            Set(
-                getGroupsTestResponse,
-                createGroupTestRequest,
-                getGroupByIriTestResponse,
-                updateGroupTestRequest,
-                changeGroupStatusTestRequest,
-                getGroupMembersTestResponse
-            )
+        for {
+            getGroupsResponse <- getGroupsTestResponse
+            createGroupRequest <- createGroupTestRequest
+            getGroupByIriResponse <- getGroupByIriTestResponse
+            updateGroupRequest <- updateGroupTestRequest
+            changeGroupStatusRequest <- changeGroupStatusTestRequest
+            getGroupMembersResponse <- getGroupMembersTestResponse
+        } yield createGroupRequest + getGroupsResponse + getGroupByIriResponse + updateGroupRequest +
+                changeGroupStatusRequest + getGroupMembersResponse
         }
-    }
 }

--- a/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/util/StringFormatter.scala
@@ -1714,6 +1714,15 @@ class StringFormatter private(val maybeSettings: Option[KnoraSettingsImpl] = Non
     }
 
     /**
+      * Returns `true` if an IRI string looks like a Knora group IRI.
+      *
+      * @param iri the IRI to be checked.
+      */
+    def isKnoraGroupIriStr(iri: IRI): Boolean = {
+        isIri(iri) && iri.startsWith("http://" + IriDomain + "/groups/")
+    }
+
+    /**
      * Checks that a string represents a valid resource identifier in a standoff link.
      *
      * @param s               the string to be checked.
@@ -2557,6 +2566,33 @@ class StringFormatter private(val maybeSettings: Option[KnoraSettingsImpl] = Non
     def validateOptionalListIri(maybeIri: Option[IRI], errorFun: => Nothing): Option[IRI] = {
         maybeIri match {
             case Some(iri) => Some(validateListIri(iri, errorFun))
+            case None => None
+        }
+    }
+
+    /**
+      * Given the group IRI, checks if it is in a valid format.
+      *
+      * @param iri the group's IRI.
+      * @return the IRI of the list.
+      */
+    def validateGroupIri(iri: IRI, errorFun: => Nothing): IRI = {
+        if (isKnoraGroupIriStr(iri)) {
+            iri
+        } else {
+            errorFun
+        }
+    }
+
+    /**
+      * Given the optional group IRI, checks if it is in a valid format.
+      *
+      * @param maybeIri the optional group's IRI to be checked.
+      * @return the same optional IRI.
+      */
+    def validateOptionalGroupIri(maybeIri: Option[IRI], errorFun: => Nothing): Option[IRI] = {
+        maybeIri match {
+            case Some(iri) => Some(validateGroupIri(iri, errorFun))
             case None => None
         }
     }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/GroupsADME2ESpec.scala
@@ -23,6 +23,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.testkit.RouteTestTimeout
+import akka.http.scaladsl.unmarshalling.Unmarshal
 import com.typesafe.config.{Config, ConfigFactory}
 import org.knora.webapi.messages.admin.responder.groupsmessages.{GroupADM, GroupsADMJsonProtocol}
 import org.knora.webapi.messages.v1.responder.sessionmessages.SessionJsonProtocol
@@ -30,6 +31,7 @@ import org.knora.webapi.testing.tags.E2ETest
 import org.knora.webapi.util.{AkkaHttpUtils, MutableTestIri}
 import org.knora.webapi.{E2ESpec, SharedTestDataADM}
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 
@@ -71,6 +73,60 @@ class GroupsADME2ESpec extends E2ESpec(GroupsADME2ESpec.config) with GroupsADMJs
                 val response: HttpResponse = singleAwaitingRequest(request)
                 // log.debug(s"response: {}", response)
                 assert(response.status === StatusCodes.OK)
+            }
+        }
+
+        "given a custom Iri" should {
+            "create a group with the provided custom IRI " in {
+
+                val request = Post(baseApiUrl + s"/admin/groups", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createGroupWithCustomIriRequest)) ~> addCredentials(BasicHttpCredentials(imagesUser01Email, testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+
+                response.status should be(StatusCodes.OK)
+
+                val result: GroupADM = AkkaHttpUtils.httpResponseToJson(response).fields("group").convertTo[GroupADM]
+
+                //check that the custom IRI is correctly assigned
+                result.id should be ("http://rdfh.ch/groups/00FF/group-with-customIri")
+            }
+
+            "return 'BadRequest' if the supplied 'id' is not a valid IRI" in {
+                val params =
+                    s"""{   "id": "invalid-group-IRI",
+                       |    "name": "NewGroupWithInvalidCustomIri",
+                       |    "description": "A new group with an invalid custom Iri",
+                       |    "project": "${SharedTestDataADM.IMAGES_PROJECT_IRI}",
+                       |    "status": true,
+                       |    "selfjoin": false
+                       |}""".stripMargin
+
+
+                val request = Post(baseApiUrl + s"/admin/groups", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(imagesUser01Email, testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be (StatusCodes.BadRequest)
+                val errorMessage : String = Await.result(Unmarshal(response.entity).to[String], 1.second)
+                val invalidIri: Boolean = errorMessage.contains(s"Invalid group IRI")
+                invalidIri should be(true)
+            }
+
+            "return 'BadRequest' if the supplied IRI for the group is not unique" in {
+                val params =
+                    s"""{   "id": "http://rdfh.ch/groups/00FF/group-with-customIri",
+                       |    "name": "NewGroupWithDuplicateCustomIri",
+                       |    "description": "A new group with a duplicate custom Iri",
+                       |    "project": "${SharedTestDataADM.IMAGES_PROJECT_IRI}",
+                       |    "status": true,
+                       |    "selfjoin": false
+                       |}""".stripMargin
+
+
+                val request = Post(baseApiUrl + s"/admin/groups", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(imagesUser01Email, testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be (StatusCodes.BadRequest)
+
+                val errorMessage : String = Await.result(Unmarshal(response.entity).to[String], 1.second)
+                val invalidIri: Boolean = errorMessage.contains(s"IRI: 'http://rdfh.ch/groups/00FF/group-with-customIri' already exists, try another one.")
+                invalidIri should be(true)
             }
         }
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ListsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ListsADME2ESpec.scala
@@ -157,7 +157,7 @@ class ListsADME2ESpec extends E2ESpec(ListsADME2ESpec.config) with SessionJsonPr
 
         "given a custom Iri" should {
 
-            "create a list with a custom Iri" in {
+            "create a list with the provided custom Iri" in {
 
                 val request = Post(baseApiUrl + s"/admin/lists", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createListWithCustomIriRequest)) ~> addCredentials(anythingAdminUserCreds.basicHttpCredentials)
                 val response: HttpResponse = singleAwaitingRequest(request)
@@ -194,7 +194,7 @@ class ListsADME2ESpec extends E2ESpec(ListsADME2ESpec.config) with SessionJsonPr
                 invalidIri should be(true)
             }
 
-            "return a DuplicateValueException during list creation when the supplied listIri is not unique" in {
+            "return a DuplicateValueException during list creation when the supplied list IRI is not unique" in {
 
                 // duplicate list IRI
                 val params =

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/ProjectsADME2ESpec.scala
@@ -120,6 +120,76 @@ class ProjectsADME2ESpec extends E2ESpec(ProjectsADME2ESpec.config) with Session
             }
         }
 
+        "given a custom Iri" should {
+
+            "CREATE a new project with the provided custom Iri" in {
+
+                val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createProjectWithCustomIRIRequest)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be (StatusCodes.OK)
+
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("project").convertTo[ProjectADM]
+
+                //check that the custom IRI is correctly assigned
+                result.id should be (SharedTestDataADM.customProjectIri)
+
+                //check the rest of project info
+                result.shortcode should be ("3333")
+                result.shortname should be ("newprojectWithIri")
+                result.longname should be (Some("new project with a custom IRI"))
+                result.keywords should be (Seq("projectIRI"))
+                result.description should be (Seq(StringLiteralV2(value = "a project created with a custom IRI", language = Some("en"))))
+
+            }
+
+            "return 'BadRequest' if the supplied project IRI is not a valid IRI" in {
+                val params =
+                    s"""{
+                       |    "id": "invalid-project-IRI",
+                       |    "shortname": "newprojectWithInvalidIri",
+                       |    "shortcode": "2222",
+                       |    "longname": "new project with a custom invalid IRI",
+                       |    "description": [{"value": "a project created with an invalid custom IRI", "language": "en"}],
+                       |    "keywords": ["projectInvalidIRI"],
+                       |    "logo": "/fu/bar/baz.jpg",
+                       |    "status": true,
+                       |    "selfjoin": false
+                       |}""".stripMargin
+
+
+                val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be (StatusCodes.BadRequest)
+                val errorMessage : String = Await.result(Unmarshal(response.entity).to[String], 1.second)
+                val invalidIri: Boolean = errorMessage.contains("Invalid project IRI")
+                invalidIri should be(true)
+            }
+
+            "return 'BadRequest' if the supplied project IRI is not unique" in {
+                val params =
+                    s"""{
+                       |    "id": "${SharedTestDataADM.customProjectIri}",
+                       |    "shortname": "newprojectWithDuplicateIri",
+                       |    "shortcode": "2222",
+                       |    "longname": "new project with a duplicate custom invalid IRI",
+                       |    "description": [{"value": "a project created with a duplicate custom IRI", "language": "en"}],
+                       |    "keywords": ["projectDuplicateIRI"],
+                       |    "logo": "/fu/bar/baz.jpg",
+                       |    "status": true,
+                       |    "selfjoin": false
+                       |}""".stripMargin
+
+
+                val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                response.status should be (StatusCodes.BadRequest)
+
+                val errorMessage : String = Await.result(Unmarshal(response.entity).to[String], 1.second)
+                val invalidIri: Boolean = errorMessage.contains(s"IRI: '${SharedTestDataADM.customProjectIri}' already exists, try another one.")
+                invalidIri should be(true)
+            }
+        }
+
         "used to modify project information" should {
 
             val newProjectIri = new MutableTestIri
@@ -144,74 +214,6 @@ class ProjectsADME2ESpec extends E2ESpec(ProjectsADME2ESpec.config) with Session
                 newProjectIri.set(result.id)
                 // log.debug("newProjectIri: {}", newProjectIri.get)
 
-            }
-
-
-            "CREATE a new project with custom Iri" in {
-
-                val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createProjectWithCustomIRIRequest)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
-                val response: HttpResponse = singleAwaitingRequest(request)
-                response.status should be (StatusCodes.OK)
-
-                val result = AkkaHttpUtils.httpResponseToJson(response).fields("project").convertTo[ProjectADM]
-
-                //check that the custom IRI is correctly assigned
-                result.id should be (SharedTestDataADM.customProjectIri)
-
-                //check the rest of project info
-                result.shortcode should be ("3333")
-                result.shortname should be ("newprojectWithIri")
-                result.longname should be (Some("new project with a custom IRI"))
-                result.keywords should be (Seq("projectIRI"))
-                result.description should be (Seq(StringLiteralV2(value = "a project created with a custom IRI", language = Some("en"))))
-
-            }
-
-            "return 'BadRequest' if the supplied 'projectIri' is not a valid IRI" in {
-                val params =
-                    s"""{
-                       |    "projectIri": "invalid-project-IRI",
-                       |    "shortname": "newprojectWithInvalidIri",
-                       |    "shortcode": "2222",
-                       |    "longname": "new project with a custom invalid IRI",
-                       |    "description": [{"value": "a project created with an invalid custom IRI", "language": "en"}],
-                       |    "keywords": ["projectInvalidIRI"],
-                       |    "logo": "/fu/bar/baz.jpg",
-                       |    "status": true,
-                       |    "selfjoin": false
-                       |}""".stripMargin
-
-
-                val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
-                val response: HttpResponse = singleAwaitingRequest(request)
-                response.status should be (StatusCodes.BadRequest)
-                val errorMessage : String = Await.result(Unmarshal(response.entity).to[String], 1.second)
-                val invalidIri: Boolean = errorMessage.contains("Invalid project IRI")
-                invalidIri should be(true)
-            }
-
-            "return 'BadRequest' if the supplied 'projectIri' is not unique" in {
-                val params =
-                    s"""{
-                       |    "projectIri": "${SharedTestDataADM.customProjectIri}",
-                       |    "shortname": "newprojectWithDuplicateIri",
-                       |    "shortcode": "2222",
-                       |    "longname": "new project with a duplicate custom invalid IRI",
-                       |    "description": [{"value": "a project created with a duplicate custom IRI", "language": "en"}],
-                       |    "keywords": ["projectDuplicateIRI"],
-                       |    "logo": "/fu/bar/baz.jpg",
-                       |    "status": true,
-                       |    "selfjoin": false
-                       |}""".stripMargin
-
-
-                val request = Post(baseApiUrl + s"/admin/projects", HttpEntity(ContentTypes.`application/json`, params)) ~> addCredentials(BasicHttpCredentials(rootEmail, testPass))
-                val response: HttpResponse = singleAwaitingRequest(request)
-                response.status should be (StatusCodes.BadRequest)
-
-                val errorMessage : String = Await.result(Unmarshal(response.entity).to[String], 1.second)
-                val invalidIri: Boolean = errorMessage.contains(s"IRI: '${SharedTestDataADM.customProjectIri}' already exists, try another one.")
-                invalidIri should be(true)
             }
 
             "return a 'BadRequest' if the supplied project shortname during creation is not unique" in {

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/GroupsResponderADMSpec.scala
@@ -91,7 +91,12 @@ class GroupsResponderADMSpec extends CoreSpec(GroupsResponderADMSpec.config) wit
 
             "CREATE the group and return the group's info if the supplied group name is unique" in {
                 responderManager ! GroupCreateRequestADM(
-                    CreateGroupApiRequestADM("NewGroup", Some("""NewGroupDescription with "quotes" and <html tag>"""), SharedTestDataADM.IMAGES_PROJECT_IRI, status = true, selfjoin = false),
+                    createRequest = CreateGroupApiRequestADM(
+                        name= "NewGroup",
+                        description = Some("""NewGroupDescription with "quotes" and <html tag>"""),
+                        project = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        status = true,
+                        selfjoin = false),
                     SharedTestDataADM.imagesUser01,
                     UUID.randomUUID
                 )
@@ -111,7 +116,12 @@ class GroupsResponderADMSpec extends CoreSpec(GroupsResponderADMSpec.config) wit
 
             "return a 'DuplicateValueException' if the supplied group name is not unique" in {
                 responderManager ! GroupCreateRequestADM(
-                    CreateGroupApiRequestADM("NewGroup", Some("NewGroupDescription"), SharedTestDataADM.IMAGES_PROJECT_IRI, status = true, selfjoin = false),
+                    createRequest = CreateGroupApiRequestADM(
+                        name = "NewGroup",
+                        description = Some("NewGroupDescription"),
+                        project = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        status = true,
+                        selfjoin = false),
                     SharedTestDataADM.imagesUser01,
                     UUID.randomUUID
                 )
@@ -125,7 +135,12 @@ class GroupsResponderADMSpec extends CoreSpec(GroupsResponderADMSpec.config) wit
 
                 /* missing group name */
                 responderManager ! GroupCreateRequestADM(
-                    CreateGroupApiRequestADM("", Some("NoNameGroupDescription"), SharedTestDataADM.IMAGES_PROJECT_IRI, status = true, selfjoin = false),
+                    createRequest = CreateGroupApiRequestADM(
+                        name = "",
+                        description = Some("NoNameGroupDescription"),
+                        project = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        status = true,
+                        selfjoin = false),
                     SharedTestDataADM.imagesUser01,
                     UUID.randomUUID
                 )
@@ -133,7 +148,12 @@ class GroupsResponderADMSpec extends CoreSpec(GroupsResponderADMSpec.config) wit
 
                 /* missing project */
                 responderManager ! GroupCreateRequestADM(
-                    CreateGroupApiRequestADM("OtherNewGroup", Some("OtherNewGroupDescription"), "", status = true, selfjoin = false),
+                    createRequest = CreateGroupApiRequestADM(
+                        name = "OtherNewGroup",
+                        description = Some("OtherNewGroupDescription"),
+                        project = "",
+                        status = true,
+                        selfjoin = false),
                     SharedTestDataADM.imagesUser01,
                     UUID.randomUUID
                 )


### PR DESCRIPTION
This PR makes creation of groups with custom IRIs possible:
**Todo:**
- [x] accept custom IRI for a group

- [x] create a group with the provided custom Iri

- [x] add tests

- [x] add test data

- [x] update documentation

- [x] for sake of consistency, refactor list, and project creation to accept custom IRIs as an `id`.

Resolves [DSP-244](https://dasch.myjetbrains.com/youtrack/agiles/110-4/111-35?issue=DSP-244)