### PR TITLE
dummy response for create resource + getClass with allLanguages=true 

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/SharedTestDataADM.scala
@@ -2261,6 +2261,7 @@ object SharedTestDataADM {
             """.stripMargin
     }
 
+
     def createClassWithoutCardinalities(anythinOntologyIri: IRI, anythingLastModDate: Instant): String = {
         s"""
            |{
@@ -2295,6 +2296,187 @@ object SharedTestDataADM {
            |  }
            |}
             """.stripMargin
+    }
+
+    val createClassWithoutCardinalitiesResponse: String = {
+        """{
+          |    "@graph": [
+          |        {
+          |            "@id": "anything:Nothing",
+          |            "@type": "owl:Class",
+          |            "knora-api:canBeInstantiated": true,
+          |            "knora-api:isResourceClass": true,
+          |            "rdfs:comment": {
+          |                "@language": "en",
+          |                "@value": "Represents nothing"
+          |            },
+          |            "rdfs:label": {
+          |                "@language": "en",
+          |                "@value": "nothing"
+          |            },
+          |            "rdfs:subClassOf": [
+          |                {
+          |                    "@id": "knora-api:Resource"
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:arkUrl"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:attachedToProject"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:attachedToUser"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:creationDate"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:maxCardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:deleteComment"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:maxCardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:deleteDate"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:maxCardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:deletedBy"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:minCardinality": 0,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:hasIncomingLinkValue"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:hasPermissions"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:minCardinality": 0,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:hasStandoffLinkTo"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:minCardinality": 0,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:hasStandoffLinkToValue"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:maxCardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:isDeleted"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:maxCardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:lastModificationDate"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:userHasPermission"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:versionArkUrl"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:maxCardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "knora-api:versionDate"
+          |                    }
+          |                },
+          |                {
+          |                    "@type": "owl:Restriction",
+          |                    "knora-api:isInherited": true,
+          |                    "owl:cardinality": 1,
+          |                    "owl:onProperty": {
+          |                        "@id": "rdfs:label"
+          |                    }
+          |                }
+          |            ]
+          |        }
+          |    ],
+          |    "@id": "http://0.0.0.0:3333/ontology/0001/anything/v2",
+          |    "@type": "owl:Ontology",
+          |    "knora-api:attachedToProject": {
+          |        "@id": "http://rdfh.ch/projects/0001"
+          |    },
+          |    "knora-api:lastModificationDate": {
+          |        "@type": "xsd:dateTimeStamp",
+          |        "@value": "2020-07-24T11:24:29.824Z"
+          |    },
+          |    "rdfs:label": "The anything ontology",
+          |    "@context": {
+          |        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |        "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
+          |        "owl": "http://www.w3.org/2002/07/owl#",
+          |        "salsah-gui": "http://api.knora.org/ontology/salsah-gui/v2#",
+          |        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+          |        "xsd": "http://www.w3.org/2001/XMLSchema#",
+          |        "anything": "http://0.0.0.0:3333/ontology/0001/anything/v2#"
+          |    }
+          |}""".stripMargin
     }
 
     def addCardinality(anythinOntologyIri: IRI, anythingLastModDate: Instant): String = {

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -356,6 +356,15 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
         )
     }
 
+    private def createClassTestResponse: Future[TestDataFileContent] = {
+        FastFuture.successful(
+            TestDataFileContent(
+                filePath = TestDataFilePath.makeJsonPath("create-class-without-cardinalities-response"),
+                text = SharedTestDataADM.createClassWithoutCardinalitiesResponse
+            )
+        )
+    }
+
     private def updateClass: Route = path(OntologiesBasePath / "classes") {
         put {
             // Change the labels or comments of a class.
@@ -570,7 +579,7 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
 
     // Classes to return in test data.
     private val testClasses: Map[String, IRI] = Map(
-        "get-class-anything-thing-response" -> SharedOntologyTestDataADM.ANYTHING_THING_RESOURCE_CLASS_LocalHost,
+        "get-class-anything-thing-with-allLanguages-response" -> SharedOntologyTestDataADM.ANYTHING_THING_RESOURCE_CLASS_LocalHost,
         "get-class-image-bild-response" -> SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS_LocalHost,
         "get-class-incunabula-book-response" -> SharedOntologyTestDataADM.INCUNABULA_BOOK_RESOURCE_CLASS_LocalHost,
         "get-class-incunabula-page-response" -> SharedOntologyTestDataADM.INCUNABULA_PAGE_RESOURCE_CLASS_LocalHost
@@ -583,9 +592,13 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
         val responseFutures: Iterable[Future[TestDataFileContent]] = testClasses.map {
             case (filename, classIri) =>
                 val encodedClassIri = URLEncoder.encode(classIri, "UTF-8")
-
+                val segment = if (filename.endsWith("-with-allLanguages-response"))
+                        encodedClassIri + "?allLanguages=true"
+                        else  encodedClassIri
                 for {
-                    responseStr <- doTestDataRequest(Get(s"$baseApiUrl$OntologiesBasePathString/classes/$encodedClassIri"))
+
+                    responseStr <- doTestDataRequest(Get(s"$baseApiUrl$OntologiesBasePathString/classes/$segment"))
+
                 } yield TestDataFileContent(
                     filePath = TestDataFilePath.makeJsonPath(filename),
                     text = responseStr
@@ -967,6 +980,7 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
             createOntologyResponse: TestDataFileContent <- createOntologyTestResponse
             updateOntologyMetadataRequest: TestDataFileContent <- updateOntologyMetadataTestRequest
             createClassRequest: Set[TestDataFileContent] <- createClassTestRequest
+            createClassResponse: TestDataFileContent<- createClassTestResponse
             addCardinalitiesRequest: TestDataFileContent <- addCardinalitiesTestRequest
             createPropertyRequest: TestDataFileContent <- createPropertyTestRequest
             updateClassRequest: Set[TestDataFileContent] <- updateClassTestRequest
@@ -975,7 +989,7 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
             deleteOntologyResponse: TestDataFileContent <- deleteOntologyTestResponse
         } yield ontologyResponses + ontologyMetadataResponses ++ projectOntologiesResponses ++ ontologyClassResponses ++
             ontologyPropertyResponses + createOntologyRequest + createOntologyResponse + updateOntologyMetadataRequest ++
-            createClassRequest + addCardinalitiesRequest + createPropertyRequest ++
+            createClassRequest + createClassResponse + addCardinalitiesRequest + createPropertyRequest ++
             updateClassRequest ++ replaceCardinalitiesRequest ++ updatePropertyRequest + deleteOntologyResponse
     }
 }


### PR DESCRIPTION
This PR resolves [DSP-510](https://dasch.myjetbrains.com/youtrack/agiles/110-4/111-42?issue=DSP-510)

- [x] add dummy test data for createClass response -> stored as `create-class-without-cardinalities-response.json`
- [x] add test data for getClass when `?allLanguages=true` -> stored as `get-class-anything-thing-with-allLanguages-response.json`