### PR TITLE
Create Permissions

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -493,6 +493,12 @@ object OntologyConstants {
 
         /* Permissions */
         val Permission: IRI = KnoraAdminPrefixExpansion + "Permission"
+        val AdministrativePermission: IRI = KnoraAdminPrefixExpansion + "AdministrativePermission"
+        val DefaultObjectAccessPermission: IRI = KnoraAdminPrefixExpansion + "DefaultObjectAccessPermission"
+        val ForProject: IRI = KnoraAdminPrefixExpansion + "forProject"
+        val ForGroup: IRI = KnoraAdminPrefixExpansion + "forGroup"
+        val ForResourceClass: IRI = KnoraAdminPrefixExpansion + "forResourceClass"
+        val ForProperty: IRI = KnoraAdminPrefixExpansion + "forProperty"
 
         val ProjectResourceCreateAllPermission: String = "ProjectResourceCreateAllPermission"
         val ProjectResourceCreateRestrictedPermission: String = "ProjectResourceCreateRestrictedPermission"
@@ -523,13 +529,6 @@ object OntologyConstants {
             HasDefaultDeletePermission,
             HasDefaultChangeRightsPermission
         )
-
-        val AdministrativePermission: IRI = KnoraAdminPrefixExpansion + "AdministrativePermission"
-        val DefaultObjectAccessPermission: IRI = KnoraAdminPrefixExpansion + "DefaultObjectAccessPermission"
-        val ForProject: IRI = KnoraAdminPrefixExpansion + "forProject"
-        val ForGroup: IRI = KnoraAdminPrefixExpansion + "forGroup"
-        val ForResourceClass: IRI = KnoraAdminPrefixExpansion + "forResourceClass"
-        val ForProperty: IRI = KnoraAdminPrefixExpansion + "forProperty"
 
         val SystemProject: IRI = KnoraAdminPrefixExpansion + "SystemProject"
         val DefaultSharedOntologiesProject: IRI = KnoraAdminPrefixExpansion + "DefaultSharedOntologiesProject"
@@ -1136,6 +1135,7 @@ object OntologyConstants {
         val PersistentMapNamedGraph: IRI = "http://www.knora.org/data/maps"
         val KnoraExplicitNamedGraph: IRI = "http://www.knora.org/explicit"
         val GraphDBExplicitNamedGraph: IRI = "http://www.ontotext.com/explicit"
+        val PermissionsNamedGraph: IRI = "http://www.knora.org/data/permissions"
     }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -1135,7 +1135,6 @@ object OntologyConstants {
         val PersistentMapNamedGraph: IRI = "http://www.knora.org/data/maps"
         val KnoraExplicitNamedGraph: IRI = "http://www.knora.org/explicit"
         val GraphDBExplicitNamedGraph: IRI = "http://www.ontotext.com/explicit"
-        val PermissionsNamedGraph: IRI = "http://www.knora.org/data/permissions"
     }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/StringFormatter.scala
@@ -1726,6 +1726,16 @@ class StringFormatter private(val maybeSettings: Option[KnoraSettingsImpl] = Non
     }
 
     /**
+     * Returns `true` if an IRI string looks like a Knora permission IRI.
+     *
+     * @param iri the IRI to be checked.
+     */
+    def isKnoraPermissionIriStr(iri: IRI): Boolean = {
+        isIri(iri) && iri.startsWith("http://" + IriDomain + "/permissions/")
+    }
+
+
+    /**
      * Checks that a string represents a valid resource identifier in a standoff link.
      *
      * @param s               the string to be checked.
@@ -2596,6 +2606,33 @@ class StringFormatter private(val maybeSettings: Option[KnoraSettingsImpl] = Non
     def validateOptionalGroupIri(maybeIri: Option[IRI], errorFun: => Nothing): Option[IRI] = {
         maybeIri match {
             case Some(iri) => Some(validateGroupIri(iri, errorFun))
+            case None => None
+        }
+    }
+
+    /**
+     * Given the permission IRI, checks if it is in a valid format.
+     *
+     * @param iri the permission's IRI.
+     * @return the IRI of the list.
+     */
+    def validatePermissionIri(iri: IRI, errorFun: => Nothing): IRI = {
+        if (isKnoraPermissionIriStr(iri)) {
+            iri
+        } else {
+            errorFun
+        }
+    }
+
+    /**
+     * Given the optional permission IRI, checks if it is in a valid format.
+     *
+     * @param maybeIri the optional permission's IRI to be checked.
+     * @return the same optional IRI.
+     */
+    def validateOptionalPermissionIri(maybeIri: Option[IRI], errorFun: => Nothing): Option[IRI] = {
+        maybeIri match {
+            case Some(iri) => Some(validatePermissionIri(iri, errorFun))
             case None => None
         }
     }

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -82,7 +82,7 @@ case class CreateDefaultObjectAccessPermissionAPIRequestADM(id: Option[IRI] = No
     forGroup match {
         case Some(iri:IRI) =>
             if(forResourceClass.isDefined)
-                throw throw BadRequestException("Not allowed to supply groupIri and resourceClassIri together.")
+                throw BadRequestException("Not allowed to supply groupIri and resourceClassIri together.")
             else if (forProperty.isDefined)
                 throw BadRequestException("Not allowed to supply groupIri and propertyIri together.")
             else Some(iri)
@@ -144,17 +144,18 @@ case class AdministrativePermissionsForProjectGetRequestADM(projectIri: IRI,
                                                             requestingUser: UserADM,
                                                             apiRequestID: UUID
                                                            ) extends PermissionsResponderRequestADM {
+
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
+    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-                && !requestingUser.permissions.isProjectAdminInAnyProject()
+                && !requestingUser.permissions.isProjectAdmin(projectIri)
                 && !requestingUser.isSystemUser
         ) {
             // not a system admin
             throw ForbiddenException("Administrative permission can only be queried by system and project admin.")
         }
-
-    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
 }
 
 /**
@@ -170,6 +171,7 @@ case class AdministrativePermissionForIriGetRequestADM(administrativePermissionI
                                                        apiRequestID: UUID
                                                       ) extends PermissionsResponderRequestADM {
     // Check user's permission for the operation
+    //TODO: should get the project the permission is assigned to and check if the requesting user is the project admin
     if (!requestingUser.isSystemAdmin
         && !requestingUser.permissions.isProjectAdminInAnyProject()
         && !requestingUser.isSystemUser
@@ -194,17 +196,18 @@ case class AdministrativePermissionForProjectGroupGetADM(projectIri: IRI,
                                                          groupIri: IRI,
                                                          requestingUser: UserADM
                                                         ) extends PermissionsResponderRequestADM {
+
+    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
+    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-        && !requestingUser.permissions.isProjectAdminInAnyProject()
+        && !requestingUser.permissions.isProjectAdmin(projectIri)
         && !requestingUser.isSystemUser
     ) {
         // not a system admin
         throw ForbiddenException("Administrative permission can only be queried by system and project admin.")
     }
-
-    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
-    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
 }
 
 /**
@@ -254,6 +257,7 @@ case class ObjectAccessPermissionsForResourceGetADM(resourceIri: IRI,
                                                     requestingUser: UserADM
                                                    ) extends PermissionsResponderRequestADM {
     // Check user's permission for the operation
+    //TODO: should get the project the resource belongs to and check if the requestingUser is the project admin
     if (!requestingUser.isSystemAdmin
         && !requestingUser.permissions.isProjectAdminInAnyProject()
         && !requestingUser.isSystemUser
@@ -280,6 +284,8 @@ case class ObjectAccessPermissionsForValueGetADM(valueIri: IRI,
                                                 ) extends PermissionsResponderRequestADM {
 
     // Check user's permission for the operation
+    //TODO: should get the project the value belongs to and check if the requestingUser is the project admin
+
     if (!requestingUser.isSystemAdmin
         && !requestingUser.permissions.isProjectAdminInAnyProject()
         && !requestingUser.isSystemUser
@@ -309,7 +315,20 @@ case class ObjectAccessPermissionsForValueGetADM(valueIri: IRI,
 case class DefaultObjectAccessPermissionsForProjectGetRequestADM(projectIri: IRI,
                                                                  requestingUser: UserADM,
                                                                  apiRequestID: UUID
-                                                                ) extends PermissionsResponderRequestADM
+                                                                ) extends PermissionsResponderRequestADM {
+
+    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
+    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+
+    // Check user's permission for the operation
+    if (!requestingUser.isSystemAdmin
+        && !requestingUser.permissions.isProjectAdmin(projectIri)
+        && !requestingUser.isSystemUser
+    ) {
+        // not a system admin
+        throw ForbiddenException("Default object access permissions can only be queried by system and project admin.")
+    }
+}
 
 /**
  * A message that requests an object access permission identified by project and either group / resource class / property.
@@ -325,22 +344,23 @@ case class DefaultObjectAccessPermissionGetADM(projectIri: IRI,
                                                resourceClassIri: Option[IRI] = None,
                                                propertyIri: Option[IRI] = None,
                                                requestingUser: UserADM) extends PermissionsResponderRequestADM {
+
+    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
+    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-        && !requestingUser.permissions.isProjectAdminInAnyProject()
+        && !requestingUser.permissions.isProjectAdmin(projectIri)
         && !requestingUser.isSystemUser
     ) {
         // not a system admin
         throw ForbiddenException("Default object access permissions can only be queried by system and project admin.")
     }
 
-    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
-    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
-
     groupIri match {
         case Some(iri:IRI) =>
             if(resourceClassIri.isDefined)
-                throw throw BadRequestException("Not allowed to supply groupIri and resourceClassIri together.")
+                throw BadRequestException("Not allowed to supply groupIri and resourceClassIri together.")
             else if (propertyIri.isDefined)
                 throw BadRequestException("Not allowed to supply groupIri and propertyIri together.")
             else Some(iri)
@@ -421,17 +441,18 @@ case class DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri
                                                                       targetUser: UserADM,
                                                                       requestingUser: UserADM
                                                                      ) extends PermissionsResponderRequestADM {
+
+    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
+    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-        && !requestingUser.permissions.isProjectAdminInAnyProject()
+        && !requestingUser.permissions.isProjectAdmin(projectIri)
         && !requestingUser.isSystemUser
     ) {
         // not a system admin
         throw ForbiddenException("Default object access permissions can only be queried by system and project admin.")
     }
-
-    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
-    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
 
     if (!stringFormatter.toSmartIri(resourceClassIri).isKnoraEntityIri) {
             throw BadRequestException(s"Invalid resource class IRI: $resourceClassIri")
@@ -461,17 +482,18 @@ case class DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri: IRI
                                                                  targetUser: UserADM,
                                                                  requestingUser: UserADM
                                                                 ) extends PermissionsResponderRequestADM {
+
+    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
+    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
+
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-        && !requestingUser.permissions.isProjectAdminInAnyProject()
+        && !requestingUser.permissions.isProjectAdmin(projectIri)
         && !requestingUser.isSystemUser
     ) {
         // not a system admin
         throw ForbiddenException("Default object access permissions can only be queried by system and project admin.")
     }
-
-    implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
-    stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
 
     if (!stringFormatter.toSmartIri(resourceClassIri).isKnoraEntityIri) {
         throw BadRequestException(s"Invalid resource class IRI: $resourceClassIri")

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -30,8 +30,9 @@ import org.knora.webapi.messages.admin.responder.projectsmessages.ProjectsADMJso
 import org.knora.webapi.messages.admin.responder.usersmessages.UserADM
 import org.knora.webapi.messages.admin.responder.{KnoraRequestADM, KnoraResponseADM}
 import org.knora.webapi.messages.traits.Jsonable
-import spray.json.{DefaultJsonProtocol, JsObject, JsValue, JsonFormat, RootJsonFormat, _}
+import spray.json._
 import org.knora.webapi.messages.StringFormatter
+import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // API requests
@@ -802,11 +803,12 @@ case class DefaultObjectAccessPermissionADM(iri: IRI,
  * @param additionalInformation an optional IRI (e.g., group IRI, resource class IRI).
  */
 case class PermissionADM(name: String,
-                         additionalInformation: Option[IRI],
-                         permissionCode: Option[Int]
+                         additionalInformation: Option[IRI] = None,
+                         permissionCode: Option[Int] = None
                         ) extends Jsonable with PermissionsADMJsonProtocol {
 
     def toJsValue = permissionADMFormat.write(this)
+    override def toString: String = name
 }
 
 
@@ -971,7 +973,7 @@ object PermissionType extends Enumeration {
 // JSON formatting
 
 
-trait PermissionsADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol with ProjectsADMJsonProtocol {
+trait PermissionsADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtocol with ProjectsADMJsonProtocol with TriplestoreJsonProtocol {
 
     implicit object PermissionProfileTypeFormat extends JsonFormat[PermissionProfileType] {
         /**
@@ -990,20 +992,20 @@ trait PermissionsADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtoc
         }
     }
 
-    implicit val createAdministrativePermissionAPIRequestADMFormat: RootJsonFormat[CreateAdministrativePermissionAPIRequestADM] = jsonFormat(CreateAdministrativePermissionAPIRequestADM, "forProject", "forGroup", "hasPermissions")
+    implicit val createAdministrativePermissionAPIRequestADMFormat: RootJsonFormat[CreateAdministrativePermissionAPIRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateAdministrativePermissionAPIRequestADM, "forProject", "forGroup", "hasPermissions")))
 //    implicit val changeAdministrativePermissionAPIRequestADMFormat: RootJsonFormat[ChangeAdministrativePermissionAPIRequestADM] = jsonFormat(ChangeAdministrativePermissionAPIRequestADM, "iri", "forProject", "forGroup","hasOldPermissions", "hasNewPermissions")
-    implicit val createDefaultObjectAccessPermissionAPIRequestADMFormat: RootJsonFormat[CreateDefaultObjectAccessPermissionAPIRequestADM] = jsonFormat(CreateDefaultObjectAccessPermissionAPIRequestADM, "forProject", "forGroup", "forResourceClass", "forProperty", "hasPermissions")
+    implicit val createDefaultObjectAccessPermissionAPIRequestADMFormat: RootJsonFormat[CreateDefaultObjectAccessPermissionAPIRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateDefaultObjectAccessPermissionAPIRequestADM, "forProject", "forGroup", "forResourceClass", "forProperty", "hasPermissions")))
 //    implicit val changeDefaultObjectAccessPermissionAPIRequestADMFormat: RootJsonFormat[ChangeDefaultObjectAccessPermissionAPIRequestADM] = jsonFormat(ChangeDefaultObjectAccessPermissionAPIRequestADM, "iri", "forProject", "forGroup", "forResourceClass", "forProperty", "hasPermissions")
     implicit val permissionADMFormat: JsonFormat[PermissionADM] = jsonFormat(PermissionADM.apply, "name", "additionalInformation", "permissionCode")
     // apply needed because we have an companion object of a case class
-    implicit val administrativePermissionADMFormat: JsonFormat[AdministrativePermissionADM] = jsonFormat(AdministrativePermissionADM, "iri", "forProject", "forGroup", "hasPermissions")
+    implicit val administrativePermissionADMFormat: JsonFormat[AdministrativePermissionADM] = lazyFormat(jsonFormat(AdministrativePermissionADM, "iri", "forProject", "forGroup", "hasPermissions"))
     implicit val objectAccessPermissionADMFormat: JsonFormat[ObjectAccessPermissionADM] = jsonFormat(ObjectAccessPermissionADM, "forResource", "forValue", "hasPermissions")
-    implicit val defaultObjectAccessPermissionADMFormat: JsonFormat[DefaultObjectAccessPermissionADM] = jsonFormat6(DefaultObjectAccessPermissionADM)
+    implicit val defaultObjectAccessPermissionADMFormat: JsonFormat[DefaultObjectAccessPermissionADM] = lazyFormat(jsonFormat6(DefaultObjectAccessPermissionADM))
     implicit val permissionsDataADMFormat: JsonFormat[PermissionsDataADM] = jsonFormat2(PermissionsDataADM)
     implicit val administrativePermissionsForProjectGetResponseADMFormat: RootJsonFormat[AdministrativePermissionsForProjectGetResponseADM] = jsonFormat(AdministrativePermissionsForProjectGetResponseADM, "administrativePermissions")
     implicit val administrativePermissionForIriGetResponseADMFormat: RootJsonFormat[AdministrativePermissionForIriGetResponseADM] = jsonFormat(AdministrativePermissionForIriGetResponseADM, "administrativePermission")
     implicit val administrativePermissionForProjectGroupGetResponseADMFormat: RootJsonFormat[AdministrativePermissionForProjectGroupGetResponseADM] = jsonFormat(AdministrativePermissionForProjectGroupGetResponseADM, "administrativePermission")
-    implicit val administrativePermissionCreateResponseADMFormat: RootJsonFormat[AdministrativePermissionCreateResponseADM] = jsonFormat(AdministrativePermissionCreateResponseADM, "administrative_permission")
+    implicit val administrativePermissionCreateResponseADMFormat: RootJsonFormat[AdministrativePermissionCreateResponseADM] = rootFormat(lazyFormat(jsonFormat(AdministrativePermissionCreateResponseADM, "administrativePermission")))
     implicit val defaultObjectAccessPermissionsForProjectGetResponseADMFormat: RootJsonFormat[DefaultObjectAccessPermissionsForProjectGetResponseADM] = jsonFormat(DefaultObjectAccessPermissionsForProjectGetResponseADM, "defaultObjectAccessPermission")
     implicit val defaultObjectAccessPermissionForIriGetResponseADMFormat: RootJsonFormat[DefaultObjectAccessPermissionForIriGetResponseADM] = jsonFormat(DefaultObjectAccessPermissionForIriGetResponseADM, "defaultObjectAccessPermission")
     implicit val defaultObjectAccessPermissionForProjectGroupGetResponseADMFormat: RootJsonFormat[DefaultObjectAccessPermissionGetResponseADM] = jsonFormat(DefaultObjectAccessPermissionGetResponseADM, "defaultObjectAccessPermission")

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -45,7 +45,8 @@ import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtoc
  * @param forGroup       the group for which this permission is created.
  * @param hasPermissions the set of permissions.
  */
-case class CreateAdministrativePermissionAPIRequestADM(forProject: IRI,
+case class CreateAdministrativePermissionAPIRequestADM(id: Option[IRI] = None,
+                                                       forProject: IRI,
                                                        forGroup: IRI,
                                                        hasPermissions: Set[PermissionADM]) extends PermissionsADMJsonProtocol{
 
@@ -53,7 +54,7 @@ case class CreateAdministrativePermissionAPIRequestADM(forProject: IRI,
 
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
     stringFormatter.validateProjectIri(forProject, throw BadRequestException(s"Invalid project IRI"))
-
+    stringFormatter.validateOptionalPermissionIri(id, throw BadRequestException(s"Invalid permission IRI"))
     if (hasPermissions.isEmpty) throw BadRequestException("Permissions needs to be supplied.")
 }
 
@@ -67,7 +68,8 @@ case class CreateAdministrativePermissionAPIRequestADM(forProject: IRI,
  * @param forProperty      the property
  * @param hasPermissions   the permissions
  */
-case class CreateDefaultObjectAccessPermissionAPIRequestADM(forProject: IRI,
+case class CreateDefaultObjectAccessPermissionAPIRequestADM(id: Option[IRI] = None,
+                                                            forProject: IRI,
                                                             forGroup: Option[IRI] = None,
                                                             forResourceClass: Option[IRI] = None,
                                                             forProperty: Option[IRI] = None,
@@ -76,7 +78,7 @@ case class CreateDefaultObjectAccessPermissionAPIRequestADM(forProject: IRI,
 
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
     stringFormatter.validateProjectIri(forProject, throw BadRequestException(s"Invalid project IRI"))
-
+    stringFormatter.validateOptionalPermissionIri(id, throw BadRequestException(s"Invalid permission IRI"))
     forGroup match {
         case Some(iri:IRI) =>
             if(forResourceClass.isDefined)
@@ -992,9 +994,9 @@ trait PermissionsADMJsonProtocol extends SprayJsonSupport with DefaultJsonProtoc
         }
     }
 
-    implicit val createAdministrativePermissionAPIRequestADMFormat: RootJsonFormat[CreateAdministrativePermissionAPIRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateAdministrativePermissionAPIRequestADM, "forProject", "forGroup", "hasPermissions")))
+    implicit val createAdministrativePermissionAPIRequestADMFormat: RootJsonFormat[CreateAdministrativePermissionAPIRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateAdministrativePermissionAPIRequestADM, "id", "forProject", "forGroup", "hasPermissions")))
 //    implicit val changeAdministrativePermissionAPIRequestADMFormat: RootJsonFormat[ChangeAdministrativePermissionAPIRequestADM] = jsonFormat(ChangeAdministrativePermissionAPIRequestADM, "iri", "forProject", "forGroup","hasOldPermissions", "hasNewPermissions")
-    implicit val createDefaultObjectAccessPermissionAPIRequestADMFormat: RootJsonFormat[CreateDefaultObjectAccessPermissionAPIRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateDefaultObjectAccessPermissionAPIRequestADM, "forProject", "forGroup", "forResourceClass", "forProperty", "hasPermissions")))
+    implicit val createDefaultObjectAccessPermissionAPIRequestADMFormat: RootJsonFormat[CreateDefaultObjectAccessPermissionAPIRequestADM] = rootFormat(lazyFormat(jsonFormat(CreateDefaultObjectAccessPermissionAPIRequestADM, "id", "forProject", "forGroup", "forResourceClass", "forProperty", "hasPermissions")))
 //    implicit val changeDefaultObjectAccessPermissionAPIRequestADMFormat: RootJsonFormat[ChangeDefaultObjectAccessPermissionAPIRequestADM] = jsonFormat(ChangeDefaultObjectAccessPermissionAPIRequestADM, "iri", "forProject", "forGroup", "forResourceClass", "forProperty", "hasPermissions")
     implicit val permissionADMFormat: JsonFormat[PermissionADM] = jsonFormat(PermissionADM.apply, "name", "additionalInformation", "permissionCode")
     // apply needed because we have an companion object of a case class

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -99,10 +99,10 @@ case class PermissionDataGetADM(projectIris: Seq[IRI],
                                 isInSystemAdminGroup: Boolean,
                                 requestingUser: UserADM
                                ) extends PermissionsResponderRequestADM {
-    if (projectIris.isEmpty) throw ("No project IRI is given.")
-    if (groupIris.isEmpty) throw ("No group IRI is given.")
-    if (isInProjectAdminGroups.isEmpty) throw ("No project admin group is specified.")
-    if (!requestingUser.isSystemUser) throw ForbiddenException("Request only allowed for SystemUser."))
+    if (projectIris.isEmpty) throw BadRequestException("No project IRI is given.")
+    if (groupIris.isEmpty) throw BadRequestException("No group IRI is given.")
+    if (isInProjectAdminGroups.isEmpty) throw BadRequestException("No project admin group is specified.")
+    if (!requestingUser.isSystemUser) throw ForbiddenException("Request only allowed for SystemUser.")
 }
 
 // Administrative Permissions
@@ -222,7 +222,7 @@ case class AdministrativePermissionCreateADM(createRequest: CreateAdministrative
                                             ) extends PermissionsResponderRequestADM {
     // check if the requesting user is allowed to add the administrative permission
     // Allowed are SystemAdmin, ProjectAdmin and SystemUser
-    _ = if (
+    if (
         !requestingUser.isSystemAdmin
             && !requestingUser.permissions.isProjectAdmin(createRequest.forProject)
             && !requestingUser.isSystemUser
@@ -374,14 +374,6 @@ case class DefaultObjectAccessPermissionCreateRequestADM(createRequest: CreateDe
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Responses
-
-/**
- * Represents an answer to [[PermissionDeleteRequestADM]].
- */
-case class PermissionDeleteResponseADM(result: String = "permission deleted"
-                                      ) extends KnoraResponseADM with PermissionsADMJsonProtocol {
-    def toJsValue = permissionDeleteResponseADMFormat.write(this)
-}
 
 // Administrative Permissions
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -409,9 +409,9 @@ case class DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri
             throw BadRequestException(s"Invalid resource class IRI: $resourceClassIri")
     }
 
-    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
-        throw ForbiddenException(s"Target user is not a member of the same project as the requesting user.")
-    }
+//    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
+//        throw ForbiddenException(s"Target user is not a member of the same project as the requesting user.")
+//    }
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -764,8 +764,8 @@ case class AdministrativePermissionADM(iri: IRI,
  * @param forValue       the IRI of the value.
  * @param hasPermissions the permissions.
  */
-case class ObjectAccessPermissionADM(forResource: Option[IRI],
-                                     forValue: Option[IRI],
+case class ObjectAccessPermissionADM(forResource: Option[IRI] = None,
+                                     forValue: Option[IRI] = None,
                                      hasPermissions: Set[PermissionADM]
                                     ) extends Jsonable with PermissionsADMJsonProtocol {
 
@@ -784,9 +784,9 @@ case class ObjectAccessPermissionADM(forResource: Option[IRI],
  */
 case class DefaultObjectAccessPermissionADM(iri: IRI,
                                             forProject: IRI,
-                                            forGroup: Option[IRI],
-                                            forResourceClass: Option[IRI],
-                                            forProperty: Option[IRI],
+                                            forGroup: Option[IRI] = None,
+                                            forResourceClass: Option[IRI] = None,
+                                            forProperty: Option[IRI] = None,
                                             hasPermissions: Set[PermissionADM]) {
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -451,9 +451,9 @@ case class DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri: IRI
         throw BadRequestException(s"Invalid property IRI: $propertyIri")
     }
 
-    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
-        throw ForbiddenException(s"Target user is not a member of the same project as the requesting user.")
-    }
+//    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
+//        throw ForbiddenException(s"Target user is not a member of the same project as the requesting user.")
+//    }
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -52,7 +52,6 @@ case class CreateAdministrativePermissionAPIRequestADM(forProject: IRI,
 
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
     stringFormatter.validateProjectIri(forProject, throw BadRequestException(s"Invalid project IRI"))
-    stringFormatter.validateGroupIri(forGroup, throw BadRequestException(s"Invalid group IRI"))
 
     if (hasPermissions.isEmpty) throw BadRequestException("Permissions needs to be supplied.")
 }
@@ -177,7 +176,6 @@ case class AdministrativePermissionForProjectGroupGetADM(projectIri: IRI,
 
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
     stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
-    stringFormatter.validateGroupIri(groupIri, throw BadRequestException(s"Invalid group IRI"))
 }
 
 /**
@@ -192,18 +190,17 @@ case class AdministrativePermissionForProjectGroupGetRequestADM(projectIri: IRI,
                                                                 groupIri: IRI,
                                                                 requestingUser: UserADM
                                                                ) extends PermissionsResponderRequestADM
-
 /**
- * Create a single [[AdministrativePermissionADM]] (internal use).
+ * Create a single [[AdministrativePermissionADM]].
  *
  * @param createRequest  the API create request payload.
  * @param requestingUser the requesting user.
  * @param apiRequestID   the API request ID.
  */
-case class AdministrativePermissionCreateADM(createRequest: CreateAdministrativePermissionAPIRequestADM,
-                                             requestingUser: UserADM,
-                                             apiRequestID: UUID
-                                            ) extends PermissionsResponderRequestADM {
+case class AdministrativePermissionCreateRequestADM(createRequest: CreateAdministrativePermissionAPIRequestADM,
+                                                    requestingUser: UserADM,
+                                                    apiRequestID: UUID
+                                                   ) extends PermissionsResponderRequestADM {
     // check if the requesting user is allowed to add the administrative permission
     // Allowed are SystemAdmin, ProjectAdmin and SystemUser
     if (
@@ -215,18 +212,6 @@ case class AdministrativePermissionCreateADM(createRequest: CreateAdministrative
         throw ForbiddenException("A new administrative permission can only be added by a system admin.")
     }
 }
-
-/**
- * Create a single [[AdministrativePermissionADM]].
- *
- * @param createRequest  the API create request payload.
- * @param requestingUser the requesting user.
- * @param apiRequestID   the API request ID.
- */
-case class AdministrativePermissionCreateRequestADM(createRequest: CreateAdministrativePermissionAPIRequestADM,
-                                                    requestingUser: UserADM,
-                                                    apiRequestID: UUID
-                                                   ) extends PermissionsResponderRequestADM
 
 
 // Object Access Permissions
@@ -322,7 +307,6 @@ case class DefaultObjectAccessPermissionGetADM(projectIri: IRI,
 
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
     stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
-    stringFormatter.validateOptionalGroupIri(groupIri, throw BadRequestException(s"Invalid group IRI"))
     resourceClassIri match {
         case Some(iri) => if (!stringFormatter.toSmartIri(iri).isKnoraEntityIri) {
             throw BadRequestException(s"Invalid resource class IRI: $iri")

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -99,10 +99,7 @@ case class PermissionDataGetADM(projectIris: Seq[IRI],
                                 isInSystemAdminGroup: Boolean,
                                 requestingUser: UserADM
                                ) extends PermissionsResponderRequestADM {
-    if (projectIris.isEmpty) throw BadRequestException("No project IRI is given.")
-    if (groupIris.isEmpty) throw BadRequestException("No group IRI is given.")
-    if (isInProjectAdminGroups.isEmpty) throw BadRequestException("No project admin group is specified.")
-    if (!requestingUser.isSystemUser) throw ForbiddenException("Request only allowed for SystemUser.")
+    if (!requestingUser.isSystemUser) throw ForbiddenException("Permission data can only by queried by a SystemUser.")
 }
 
 // Administrative Permissions

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -395,9 +395,12 @@ case class DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri
 
     implicit protected val stringFormatter: StringFormatter = StringFormatter.getInstanceForConstantOntologies
     stringFormatter.validateProjectIri(projectIri, throw BadRequestException(s"Invalid project IRI"))
-   if (!stringFormatter.toSmartIri(resourceClassIri).isKnoraEntityIri) {
+
+    if (!stringFormatter.toSmartIri(resourceClassIri).isKnoraEntityIri) {
             throw BadRequestException(s"Invalid resource class IRI: $resourceClassIri")
     }
+
+    if (targetUser.isAnonymousUser) throw BadRequestException("Anonymous Users are not allowed.")
 
 //    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
 //        throw ForbiddenException(s"Target user is not a member of the same project as the requesting user.")
@@ -441,7 +444,10 @@ case class DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri: IRI
         throw BadRequestException(s"Invalid property IRI: $propertyIri")
     }
 
-//    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
+    if (targetUser.isAnonymousUser) throw BadRequestException("Anonymous Users are not allowed.")
+
+
+    //    if (!requestingUser.projects.containsSlice(targetUser.projects)) {
 //        throw ForbiddenException(s"Target user is not a member of the same project as the requesting user.")
 //    }
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/PermissionUtilADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/PermissionUtilADM.scala
@@ -637,18 +637,36 @@ object PermissionUtilADM extends LazyLogging {
                     }
 
                     /* Sort permissions in descending order */
-                    val sortedPermissions = groupedPermissions.toArray.sortWith {
+                    val sortedPermissions: Array[(String, String)] = groupedPermissions.toArray.sortWith {
                         (left, right) => permissionStringsToPermissionLevels(left._1) > permissionStringsToPermissionLevels(right._1)
                     }
 
                     /* create the permissions string */
-                    sortedPermissions.foldLeft("") { (acc, perm) =>
+                    sortedPermissions.foldLeft("") { (acc, perm: (String, String)) =>
                         if (acc.isEmpty) {
                             acc + perm._1 + " " + perm._2
                         } else {
                             acc + OntologyConstants.KnoraBase.PermissionListDelimiter + perm._1 + " " + perm._2
                         }
                     }
+                } else {
+                    throw InconsistentTriplestoreDataException("Permissions cannot be empty")
+                }
+            case PermissionType.AP =>
+
+                if (permissions.nonEmpty) {
+
+                    val permNames: Set[String] = permissions.map(_.name)
+
+                    /* creates the permissions string. something like "ProjectResourceCreateAllPermission|ProjectAdminAllPermission" */
+                    permNames.foldLeft("") { (acc, perm: String) =>
+                        if (acc.isEmpty) {
+                            acc + perm
+                        } else {
+                            acc + OntologyConstants.KnoraBase.PermissionListDelimiter + perm
+                        }
+                    }
+
                 } else {
                     throw InconsistentTriplestoreDataException("Permissions cannot be empty")
                 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -46,7 +46,8 @@ import scala.concurrent.Future
  * Provides information about permissions to other responders.
  */
 class PermissionsResponderADM(responderData: ResponderData) extends Responder(responderData) {
-
+    
+    private val PERMISSIONS_GLOBAL_LOCK_IRI = "http://rdfh.ch/permissions"
     /* Entity types used to more clearly distinguish what kind of entity is meant */
     private val ResourceEntityType = "resource"
     private val PropertyEntityType = "property"

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -69,7 +69,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         case DefaultObjectAccessPermissionGetRequestADM(projectIri, groupIri, resourceClassIri, propertyIri, requestingUser) => defaultObjectAccessPermissionGetRequestADM(projectIri, groupIri, resourceClassIri, propertyIri, requestingUser)
         case DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri, resourceClassIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, None, ResourceEntityType, targetUser, requestingUser)
         case DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri, resourceClassIri, propertyTypeIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, Some(propertyTypeIri), PropertyEntityType, targetUser, requestingUser)
-//        case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => createDefaultObjectAccessPermissionADM(createRequest, requestingUser, apiRequestID)
+//        case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => defaultObjectAccessPermissionCreateADM(createRequest, requestingUser, apiRequestID)
         case other => handleUnexpectedMessage(other, log, this.getClass.getName)
     }
 
@@ -997,16 +997,8 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
                                                                    ): Future[DefaultObjectAccessPermissionsStringResponseADM] = {
         // logger.debug(s"defaultObjectAccessPermissionsStringForEntityGetADM (input) - projectIRI: $projectIri, resourceClassIRI: $resourceClassIri, propertyIRI: $propertyIri, entityType: $entityType, targetUser: $targetUser")
         for {
-            // check if necessary field are defined.
-            _ <- Future(if (projectIri.isEmpty) throw BadRequestException("Project cannot be empty"))
-            _ = if (entityType == PropertyEntityType && propertyIri.isEmpty) {
-                throw BadRequestException("PropertyTypeIri needs to be supplied")
-            }
-            _ = if (targetUser.isAnonymousUser) throw BadRequestException("Anonymous Users are not allowed.")
-
-
             /* Get the groups the user is member of. */
-            userGroupsOption: Option[Seq[IRI]] = targetUser.permissions.groupsPerProject.get(projectIri)
+            userGroupsOption: Option[Seq[IRI]] <- Future(targetUser.permissions.groupsPerProject.get(projectIri))
             userGroups: Seq[IRI] = userGroupsOption match {
                 case Some(groups) => groups
                 case None => Seq.empty[IRI]
@@ -1208,9 +1200,10 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
             _ = logger.debug(s"defaultObjectAccessPermissionsStringForEntityGetADM (result) - project: $projectIri, precedence: ${permissionsListBuffer.head._1}, defaultObjectAccessPermissions: $result")
         } yield permissionsmessages.DefaultObjectAccessPermissionsStringResponseADM(result)
     }
-    
-//    private def createDefaultObjectAccessPermissionADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
-//        // FIXME: Needs implementation
+//
+//    private def defaultObjectAccessPermissionCreateADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
+//
+//
 //    }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -62,7 +62,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         case AdministrativePermissionForIriGetRequestADM(administrativePermissionIri, requestingUser, apiRequestID) => administrativePermissionForIriGetRequestADM(administrativePermissionIri, requestingUser, apiRequestID)
         case AdministrativePermissionForProjectGroupGetADM(projectIri, groupIri, requestingUser) => administrativePermissionForProjectGroupGetADM(projectIri, groupIri, requestingUser)
         case AdministrativePermissionForProjectGroupGetRequestADM(projectIri, groupIri, requestingUser) => administrativePermissionForProjectGroupGetRequestADM(projectIri, groupIri, requestingUser)
-        case AdministrativePermissionCreateRequestADM(newAdministrativePermission, requestingUser, apiRequestID) => administrativePermissionCreateADM(newAdministrativePermission, requestingUser, apiRequestID)
+        case AdministrativePermissionCreateRequestADM(newAdministrativePermission, requestingUser, apiRequestID) => administrativePermissionCreateRequestADM(newAdministrativePermission, requestingUser, apiRequestID)
         case ObjectAccessPermissionsForResourceGetADM(resourceIri, requestingUser) => objectAccessPermissionsForResourceGetADM(resourceIri, requestingUser)
         case ObjectAccessPermissionsForValueGetADM(valueIri, requestingUser) => objectAccessPermissionsForValueGetADM(valueIri, requestingUser)
         case DefaultObjectAccessPermissionsForProjectGetRequestADM(projectIri, requestingUser, apiRequestID) => defaultObjectAccessPermissionsForProjectGetRequestADM(projectIri, requestingUser, apiRequestID)
@@ -70,7 +70,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         case DefaultObjectAccessPermissionGetRequestADM(projectIri, groupIri, resourceClassIri, propertyIri, requestingUser) => defaultObjectAccessPermissionGetRequestADM(projectIri, groupIri, resourceClassIri, propertyIri, requestingUser)
         case DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri, resourceClassIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, None, ResourceEntityType, targetUser, requestingUser)
         case DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri, resourceClassIri, propertyTypeIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, Some(propertyTypeIri), PropertyEntityType, targetUser, requestingUser)
-        case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => defaultObjectAccessPermissionCreateADM(createRequest, requestingUser, apiRequestID)
+        case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => defaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID)
         case other => handleUnexpectedMessage(other, log, this.getClass.getName)
     }
 
@@ -492,7 +492,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
      * @param apiRequestID      the API request ID.
      * @return an optional [[AdministrativePermissionADM]]
      */
-    private def administrativePermissionCreateADM(createRequest: CreateAdministrativePermissionAPIRequestADM,
+    private def administrativePermissionCreateRequestADM(createRequest: CreateAdministrativePermissionAPIRequestADM,
                                                   requestingUser: UserADM,
                                                   apiRequestID: UUID
                                                  ): Future[AdministrativePermissionCreateResponseADM] = {
@@ -1195,7 +1195,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         } yield permissionsmessages.DefaultObjectAccessPermissionsStringResponseADM(result)
     }
 
-    private def defaultObjectAccessPermissionCreateADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
+    private def defaultObjectAccessPermissionCreateRequestADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
 
             /**
              * The actual change project task run with an IRI lock.

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -46,7 +46,7 @@ import scala.concurrent.Future
  * Provides information about permissions to other responders.
  */
 class PermissionsResponderADM(responderData: ResponderData) extends Responder(responderData) {
-    
+
     private val PERMISSIONS_GLOBAL_LOCK_IRI = "http://rdfh.ch/permissions"
     /* Entity types used to more clearly distinguish what kind of entity is meant */
     private val ResourceEntityType = "resource"
@@ -70,7 +70,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         case DefaultObjectAccessPermissionGetRequestADM(projectIri, groupIri, resourceClassIri, propertyIri, requestingUser) => defaultObjectAccessPermissionGetRequestADM(projectIri, groupIri, resourceClassIri, propertyIri, requestingUser)
         case DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri, resourceClassIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, None, ResourceEntityType, targetUser, requestingUser)
         case DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri, resourceClassIri, propertyTypeIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, Some(propertyTypeIri), PropertyEntityType, targetUser, requestingUser)
-        case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => createDefaultObjectAccessPermissionADM(createRequest, requestingUser, apiRequestID)
+//        case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => createDefaultObjectAccessPermissionADM(createRequest, requestingUser, apiRequestID)
         case other => handleUnexpectedMessage(other, log, this.getClass.getName)
     }
 
@@ -544,7 +544,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
 
             // FIXME: Need to finish implementation
             // Create the administrative permission.
-            createAdministrativePermissionSparqlString = queries.sparql.admin.txt.createNewAdministrativePermission(
+            createAdministrativePermissionSparqlString = org.knora.webapi.messages.twirl.queries.sparql.admin.txt.createNewAdministrativePermission(
                 permissionsNamedGraphIri = OntologyConstants.NamedGraphs.PermissionsNamedGraph,
                 triplestore = settings.triplestoreType,
                 permissionClassIri = OntologyConstants.KnoraAdmin.Permission,
@@ -1243,9 +1243,9 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         } yield permissionsmessages.DefaultObjectAccessPermissionsStringResponseADM(result)
     }
     
-    private def createDefaultObjectAccessPermissionADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
-        // FIXME: Needs implementation
-    }
+//    private def createDefaultObjectAccessPermissionADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
+//        // FIXME: Needs implementation
+//    }
 
 }
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -779,20 +779,14 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
                 // not found permission in the cache
 
                 for {
-                    // check if necessary field are not empty.
-                    _ <- Future(if (projectIri.isEmpty) throw BadRequestException("Project cannot be empty"))
 
-                    /* check supplied parameters */
-                    _ = if (groupIri.isDefined && resourceClassIri.isDefined) throw BadRequestException("Not allowed to supply groupIri and resourceClassIri together")
-                    _ = if (groupIri.isDefined && propertyIri.isDefined) throw BadRequestException("Not allowed to supply groupIri and propertyIri together")
-
-                    sparqlQueryString = org.knora.webapi.messages.twirl.queries.sparql.v1.txt.getDefaultObjectAccessPermission(
+                    sparqlQueryString <- Future(org.knora.webapi.messages.twirl.queries.sparql.v1.txt.getDefaultObjectAccessPermission(
                         triplestore = settings.triplestoreType,
                         projectIri = projectIri,
                         maybeGroupIri = groupIri,
                         maybeResourceClassIri = resourceClassIri,
                         maybePropertyIri = propertyIri
-                    ).toString()
+                    ).toString())
 
                     // _ = logger.debug(s"defaultObjectAccessPermissionGetADM - query: $sparqlQueryString")
 
@@ -1200,10 +1194,9 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
             _ = logger.debug(s"defaultObjectAccessPermissionsStringForEntityGetADM (result) - project: $projectIri, precedence: ${permissionsListBuffer.head._1}, defaultObjectAccessPermissions: $result")
         } yield permissionsmessages.DefaultObjectAccessPermissionsStringResponseADM(result)
     }
-//
+
 //    private def defaultObjectAccessPermissionCreateADM(createRequest: CreateDefaultObjectAccessPermissionAPIRequestADM, requestingUser: UserADM, apiRequestID: UUID): Future[DefaultObjectAccessPermissionCreateResponseADM] = {
-//
-//
+
 //    }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -62,9 +62,6 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
      */
     override def knoraApiPath: Route =
         getAdministrativePermission ~
-        getPermissionsForProject ~
-        getPermission ~
-        deletePermission ~
         createAdministrativePermission ~
         createDefaultObjectAccessPermission
 
@@ -97,54 +94,6 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
             text = responseStr
         )
     }
-
-
-    /**
-     * Get all permissions for a project.
-     */
-    private def getPermissionsForProject: Route = path(PermissionsBasePath / Segment) { projectIri =>
-        get {
-            requestContext =>
-                val requestMessage = for {
-                    requestingUser <- getUserADM(requestContext)
-                } yield PermissionsForProjectGetRequestADM(projectIri, requestingUser, UUID.randomUUID())
-
-                RouteUtilADM.runJsonRoute(
-                    requestMessage,
-                    requestContext,
-                    settings,
-                    responderManager,
-                    log
-                )
-        }
-    }
-
-    //todo: add test data for get all permissions for a project
-
-    /**
-     * Get permission by IRI
-     */
-    private def getPermission: Route = path(PermissionsBasePath / Segment) { permissionIri =>
-        get {
-            requestContext =>
-                val requestMessage = for {
-                    requestingUser <- getUserADM(requestContext)
-                } yield PermissionForIriGetRequestADM(
-                    permissionIri = permissionIri,
-                    requestingUser = requestingUser,
-                    apiRequestID = UUID.randomUUID()
-                )
-
-                RouteUtilADM.runJsonRoute(
-                    requestMessage,
-                    requestContext,
-                    settings,
-                    responderManager,
-                    log
-                )
-        }
-    }
-    // todo add test data for get permissions with iri
 
     /**
      * Create a new administrative permission

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -126,6 +126,10 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
                 TestDataFileContent(
                     filePath = TestDataFilePath.makeJsonPath("create-administrative-permission-request"),
                     text = SharedTestDataADM.createAdministrativePermissionRequest
+                ),
+                TestDataFileContent(
+                    filePath = TestDataFilePath.makeJsonPath("create-administrative-permission-withCustomIRI-request"),
+                    text = SharedTestDataADM.createAdministrativePermissionWithCustomIriRequest
                 )
             )
         )
@@ -163,6 +167,10 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
                 TestDataFileContent(
                     filePath = TestDataFilePath.makeJsonPath("create-defaultObjectAccess-permission-request"),
                     text = SharedTestDataADM.createDefaultObjectAccessPermissionRequest
+                ),
+                TestDataFileContent(
+                    filePath = TestDataFilePath.makeJsonPath("create-defaultObjectAccess-permission-withCustomIRI-request"),
+                    text = SharedTestDataADM.createDefaultObjectAccessPermissionWithCustomIriRequest
                 )
             )
         )

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -26,6 +26,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{PathMatcher, Route}
+import akka.http.scaladsl.util.FastFuture
 import akka.stream.Materializer
 import io.swagger.annotations._
 import javax.ws.rs.Path
@@ -118,7 +119,17 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
                 }
         }
     }
-    //todo: add test data createAdministrativePermission
+
+    private def createAdminPermissionTestRequest: Future[Set[TestDataFileContent]] = {
+        FastFuture.successful(
+            Set(
+                TestDataFileContent(
+                    filePath = TestDataFilePath.makeJsonPath("create-administrative-permission-request"),
+                    text = SharedTestDataADM.createAdministrativePermissionRequest
+                )
+            )
+        )
+    }
 
     /**
      * Create default object access permission
@@ -146,7 +157,17 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
             }
         }
     }
-    //todo add test data for createDefaultObjectAccessPermission
+    private def createDOAPermissionTestRequest: Future[Set[TestDataFileContent]] = {
+        FastFuture.successful(
+            Set(
+                TestDataFileContent(
+                    filePath = TestDataFilePath.makeJsonPath("create-defaultObjectAccess-permission-request"),
+                    text = SharedTestDataADM.createDefaultObjectAccessPermissionRequest
+                )
+            )
+        )
+    }
+
 
     /**
      * Returns test data for this endpoint.
@@ -155,11 +176,12 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
      */
     override def getTestData(implicit executionContext: ExecutionContext,
                              actorSystem: ActorSystem, materializer: Materializer
-                            ): Future[Set[TestDataFileContent]] = {
-        Future.sequence {
-            Set(
-                getAdministrativePermissionTestResponse
-            )
-        }
+                            ): Future[Set[TestDataFileContent]] =  {
+        for {
+                getAdminPermissions <- getAdministrativePermissionTestResponse
+                createAPrequest <- createAdminPermissionTestRequest
+                createDOAPrequest <- createDOAPermissionTestRequest
+
+        } yield createAPrequest ++ createDOAPrequest + getAdminPermissions
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -23,11 +23,11 @@ import java.net.URLEncoder
 import java.util.UUID
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.client.RequestBuilding.Get
+import akka.http.scaladsl.client.RequestBuilding._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{PathMatcher, Route}
 import akka.stream.Materializer
-import io.swagger.annotations.Api
+import io.swagger.annotations._
 import javax.ws.rs.Path
 import org.knora.webapi.messages.admin.responder.permissionsmessages._
 import org.knora.webapi.routing.{Authenticator, KnoraRoute, KnoraRouteData, RouteUtilADM}
@@ -37,15 +37,16 @@ import org.knora.webapi.sharedtestdata.SharedTestDataADM
 
 import scala.concurrent.{ExecutionContext, Future}
 
+
 object PermissionsRouteADM {
     val PermissionsBasePath: PathMatcher[Unit] = PathMatcher("admin" / "permissions")
     val PermissionsBasePathString: String = "/admin/permissions"
 }
 
+
 @Api(value = "permissions", produces = "application/json")
 @Path("/admin/permissions")
-class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) with PermissionsADMJsonProtocol with
-    Authenticator with ClientEndpoint {
+class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeData) with Authenticator with PermissionsADMJsonProtocol with ClientEndpoint {
 
     import PermissionsRouteADM._
 
@@ -95,26 +96,26 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
      * Create a new administrative permission
      */
     private def createAdministrativePermission: Route = path(PermissionsBasePath / "ap") {
-
         post {
-            entity(as[CreateAdministrativePermissionAPIRequestADM]) { apiRequest =>
-                requestContext =>
-                    val requestMessage: Future[AdministrativePermissionCreateRequestADM] = for {
-                        requestingUser <- getUserADM(requestContext)
-                    } yield AdministrativePermissionCreateRequestADM(
-                        createRequest = apiRequest,
-                        requestingUser = requestingUser,
-                        apiRequestID = UUID.randomUUID()
-                    )
+            /* create a new administrative permission */
+                entity(as[CreateAdministrativePermissionAPIRequestADM]) { apiRequest =>
+                    requestContext =>
+                        val requestMessage = for {
+                            requestingUser <- getUserADM(requestContext)
+                        } yield AdministrativePermissionCreateRequestADM(
+                            createRequest = apiRequest,
+                            requestingUser = requestingUser,
+                            apiRequestID = UUID.randomUUID()
+                        )
 
-                    RouteUtilADM.runJsonRoute(
-                        requestMessage,
-                        requestContext,
-                        settings,
-                        responderManager,
-                        log
-                    )
-            }
+                        RouteUtilADM.runJsonRoute(
+                            requestMessage,
+                            requestContext,
+                            settings,
+                            responderManager,
+                            log
+                        )
+                }
         }
     }
     //todo: add test data createAdministrativePermission
@@ -124,6 +125,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
      */
     private def createDefaultObjectAccessPermission: Route = path(PermissionsBasePath / "doap") {
         post {
+            /* create a new default object access permission */
             entity(as[CreateDefaultObjectAccessPermissionAPIRequestADM]) { apiRequest =>
                 requestContext =>
                     val requestMessage: Future[DefaultObjectAccessPermissionCreateRequestADM] = for {

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -68,13 +68,9 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
     private def getAdministrativePermission: Route = path(PermissionsBasePath / Segment / Segment) { (projectIri, groupIri) =>
         get {
             requestContext =>
-                val params = requestContext.request.uri.query().toMap
-                val permissionType = params.getOrElse("permissionType", PermissionType.AP)
                 val requestMessage = for {
                     requestingUser <- getUserADM(requestContext)
-                } yield permissionType match {
-                    case _ => AdministrativePermissionForProjectGroupGetRequestADM(projectIri, groupIri, requestingUser)
-                }
+                } yield AdministrativePermissionForProjectGroupGetRequestADM(projectIri, groupIri, requestingUser)
 
                 RouteUtilADM.runJsonRoute(
                     requestMessage,

--- a/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -723,6 +723,24 @@ object SharedTestDataADM {
            |    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
            |}""".stripMargin
 
+    val createAdministrativePermissionWithCustomIriRequest: String =
+        s"""{
+           |    "id": "http://rdfh.ch/permissions/0001/AP-with-customIri",
+           |    "forGroup":"${SharedTestDataADM.thingSearcherGroup.id}",
+           |    "forProject":"${SharedTestDataADM.ANYTHING_PROJECT_IRI}",
+           |	"hasPermissions":[{"additionalInformation":null,"name":"ProjectAdminGroupAllPermission","permissionCode":null}]
+           |}""".stripMargin
+
+    val createDefaultObjectAccessPermissionWithCustomIriRequest: String =
+        s"""{
+           |    "id": "http://rdfh.ch/permissions/0001/DOAP-with-customIri",
+           |    "forGroup":"${SharedTestDataADM.thingSearcherGroup.id}",
+           |    "forProject":"${SharedTestDataADM.ANYTHING_PROJECT_IRI}",
+           |    "forProperty":null,
+           |    "forResourceClass":null,
+           |    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
+           |}""".stripMargin
+
     def updateListInfoRequest(listIri: IRI): String = {
         s"""{
            |    "listIri": "$listIri",

--- a/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -505,6 +505,15 @@ object SharedTestDataADM {
         selfjoin = false
     )
 
+    /* represents the full GroupInfoV1 of the Thing searcher group */
+    def thingSearcherGroup: GroupADM = GroupADM(
+        id = "http://rdfh.ch/groups/0001/thing-searcher",
+        name = "Thing searcher",
+        description = "A group for thing searchers.",
+        project = anythingProject,
+        status = true,
+        selfjoin = true
+    )
 
     /** **********************************/
     /** BEOL                           **/

--- a/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -733,11 +733,11 @@ object SharedTestDataADM {
 
     val createDefaultObjectAccessPermissionWithCustomIriRequest: String =
         s"""{
-           |    "id": "http://rdfh.ch/permissions/0001/DOAP-with-customIri",
-           |    "forGroup":"${SharedTestDataADM.thingSearcherGroup.id}",
-           |    "forProject":"${SharedTestDataADM.ANYTHING_PROJECT_IRI}",
+           |    "id": "http://rdfh.ch/permissions/00FF/DOAP-with-customIri",
+           |    "forGroup":null,
+           |    "forProject":"${SharedTestDataADM.IMAGES_PROJECT_IRI}",
            |    "forProperty":null,
-           |    "forResourceClass":null,
+           |    "forResourceClass":"${SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS}",
            |    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
            |}""".stripMargin
 

--- a/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -706,6 +706,23 @@ object SharedTestDataADM {
            |    "comments": []
            |}""".stripMargin
 
+
+    val createAdministrativePermissionRequest: String =
+        s"""{
+           |    "forGroup":"${SharedTestDataADM.thingSearcherGroup.id}",
+           |    "forProject":"${SharedTestDataADM.ANYTHING_PROJECT_IRI}",
+           |	"hasPermissions":[{"additionalInformation":null,"name":"ProjectAdminGroupAllPermission","permissionCode":null}]
+           |}""".stripMargin
+
+    val createDefaultObjectAccessPermissionRequest: String =
+        s"""{
+           |    "forGroup":"${SharedTestDataADM.thingSearcherGroup.id}",
+           |    "forProject":"${SharedTestDataADM.ANYTHING_PROJECT_IRI}",
+           |    "forProperty":null,
+           |    "forResourceClass":null,
+           |    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
+           |}""".stripMargin
+
     def updateListInfoRequest(listIri: IRI): String = {
         s"""{
            |    "listIri": "$listIri",

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewAdministrativePermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewAdministrativePermission.scala.txt
@@ -21,25 +21,25 @@
 
 @*
  * Creates a new administrative permission.
- *
+ * @param adminNamedGraphIri the name of the graph into which the new project will be created.
  * @param triplestore the name of the triplestore being used. The template uses this value to exclude inferred
                       results from the WHERE clause of the update.
  * @param permissionIri the Iri of the new administrative permission.
  * @param permissionClassIri the IRI of the OWL class that the new administrative permission should belong to.
- * @param forProject the project.
- * @param forGroup the group.
+ * @param projectIri the project.
+ * @param groupIri the group.
  * @param permission the permission.
  *
  *@
-@(permissionsNamedGraphIri: IRI,
+@(adminNamedGraphIri: IRI,
   triplestore: String,
   permissionIri: IRI,
   permissionClassIri: IRI,
-  forProject: IRI,
-  forGroup: IRI,
+  projectIri: IRI,
+  groupIri: IRI,
   permissions: String)
 
-prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
@@ -71,9 +71,9 @@ explicit statements in the WHERE clause here.
     case other => {}
 }
 WHERE {
-    BIND(IRI("@permissionsNamedGraphIri") AS ?permissionsNamedGraphIri)
+    BIND(IRI("@adminNamedGraphIri") AS ?adminNamedGraphIri)
     BIND(IRI("@permissionIri") AS ?permissionIri)
     BIND(IRI("@permissionClassIri") AS ?permissionClassIri)
-    BIND(IRI("@forProject") AS ?projectIri)
-    BIND(IRI("@forGroup") AS ?groupIri)
+    BIND(IRI("@projectIri") AS ?projectIri)
+    BIND(IRI("@groupIri") AS ?groupIri)
 }

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewAdministrativePermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewAdministrativePermission.scala.txt
@@ -1,0 +1,79 @@
+@*
+ * Copyright © 2015-2019 the contributors (see Contributors.md).
+ *
+ * This file is part of Knora.
+ *
+ * Knora is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Knora is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
+ *@
+
+@import org.knora.webapi.IRI
+
+@*
+ * Creates a new administrative permission.
+ *
+ * @param triplestore the name of the triplestore being used. The template uses this value to exclude inferred
+                      results from the WHERE clause of the update.
+ * @param permissionIri the Iri of the new administrative permission.
+ * @param permissionClassIri the IRI of the OWL class that the new administrative permission should belong to.
+ * @param forProject the project.
+ * @param forGroup the group.
+ * @param permission the permission.
+ *
+ *@
+@(permissionsNamedGraphIri: IRI,
+  triplestore: String,
+  permissionIri: IRI,
+  permissionClassIri: IRI,
+  forProject: IRI,
+  forGroup: IRI,
+  permissions: String)
+
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX knora-admin: <http://www.knora.org/ontology/knora-admin#>
+
+INSERT {
+    GRAPH ?adminNamedGraphIri {
+        ?permissionIri rdf:type ?permissionClassIri .
+
+        ?permissionIri knora-admin:forProject ?projectIri .
+
+        ?permissionIri knora-admin:forGroup ?groupIri .
+
+        ?permissionIri knora-admin:hasPermissions "@permissions"^^xsd:string .
+    }
+}
+@*
+
+GraphDB's consistency checking requires reasoning, but reasoning interferes with certain things
+in the WHERE clauses of our SPARQL updates, so we set a GraphDB-specific flag to return only
+explicit statements in the WHERE clause here.
+
+*@
+@triplestore match {
+    case "graphdb" | "graphdb-free" => {
+        USING <http://www.ontotext.com/explicit>
+    }
+
+    case other => {}
+}
+WHERE {
+    BIND(IRI("@permissionsNamedGraphIri") AS ?permissionsNamedGraphIri)
+    BIND(IRI("@permissionIri") AS ?permissionIri)
+    BIND(IRI("@permissionClassIri") AS ?permissionClassIri)
+    BIND(IRI("@forProject") AS ?projectIri)
+    BIND(IRI("@forGroup") AS ?groupIri)
+}

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewDefaultObjectAccessPermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/admin/createNewDefaultObjectAccessPermission.scala.txt
@@ -20,15 +20,17 @@
 @import org.knora.webapi.IRI
 
 @*
- * Creates a new administrative permission.
+ * Creates a new default object access permission.
  * @param adminNamedGraphIri the name of the graph into which the new project will be created.
  * @param triplestore the name of the triplestore being used. The template uses this value to exclude inferred
                       results from the WHERE clause of the update.
  * @param permissionIri the Iri of the new administrative permission.
  * @param permissionClassIri the IRI of the OWL class that the new administrative permission should belong to.
  * @param projectIri the project.
- * @param groupIri the group.
- * @param permission the permission.
+ * @param maybeGroupIri the group's IRI.
+ * @param maybeResourceClassIri the resource's class IRI.
+ * @param maybePropertyIri the property's IRI.
+ * @param permissions the permission.
  *
  *@
 @(adminNamedGraphIri: IRI,
@@ -36,7 +38,9 @@
   permissionIri: IRI,
   permissionClassIri: IRI,
   projectIri: IRI,
-  groupIri: IRI,
+  maybeGroupIri: Option[IRI],
+  maybeResourceClassIri: Option[IRI],
+  maybePropertyIri: Option[IRI],
   permissions: String)
 
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
@@ -51,9 +55,15 @@ INSERT {
         ?permissionIri rdf:type ?permissionClassIri .
 
         ?permissionIri knora-admin:forProject ?projectIri .
-
-        ?permissionIri knora-admin:forGroup ?groupIri .
-
+        @if(maybeGroupIri.nonEmpty) {
+            ?permissionIri knora-admin:forGroup <@maybeGroupIri.get> .
+        }
+        @if(maybeResourceClassIri.nonEmpty) {
+            ?permissionIri knora-admin:forResourceClass <@maybeResourceClassIri.get> .
+        }
+        @if(maybePropertyIri.nonEmpty) {
+            ?permissionIri knora-admin:forProperty <@maybePropertyIri.get> .
+        }
         ?permissionIri knora-base:hasPermissions "@permissions"^^xsd:string .
     }
 }
@@ -76,5 +86,4 @@ WHERE {
     BIND(IRI("@permissionIri") AS ?permissionIri)
     BIND(IRI("@permissionClassIri") AS ?permissionClassIri)
     BIND(IRI("@projectIri") AS ?projectIri)
-    BIND(IRI("@groupIri") AS ?groupIri)
 }

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermission.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v1/getDefaultObjectAccessPermission.scala.txt
@@ -24,9 +24,9 @@
  *
  * @param triplestore the name of the triplestore being used.
  * @param projectIri the project's IRI.
- * @param groupIri the group's IRI.
- * @param resourceClassIri the resource's class IRI.
- * @param propertyIri the property's IRI.
+ * @param maybeGroupIri the group's IRI.
+ * @param maybeResourceClassIri the resource's class IRI.
+ * @param maybePropertyIri the property's IRI.
  *@
 @(triplestore: String,
   projectIri: IRI,

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -46,9 +46,9 @@ object PermissionsADME2ESpec {
   */
 class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with TriplestoreJsonProtocol {
 
-    "The Permissions Route ('admin/permissions/projectIri')" should {
+    "The Permissions Route ('admin/permissions/projectIri/groupIri')" should {
 
-        "return administrative permissions" in {
+        "return group's administrative permissions" in {
 
             val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
             val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -20,11 +20,11 @@
 package org.knora.webapi.e2e.admin
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.E2ESpec
-import org.knora.webapi.messages.OntologyConstants
-import org.knora.webapi.sharedtestdata.SharedTestDataV1
+import org.knora.webapi.sharedtestdata.SharedTestDataADM
 
 import scala.concurrent.duration._
 
@@ -46,11 +46,10 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
     "The Permissions Route ('admin/permissions/projectIri/groupIri')" should {
 
         "return administrative permissions" in {
-            val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
-            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
-
-            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri")
-            val response = singleAwaitingRequest(request, 1.seconds)
+            val projectIri = java.net.URLEncoder.encode(SharedTestDataADM.IMAGES_PROJECT_IRI, "utf-8")
+            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri") ~> addCredentials(BasicHttpCredentials(
+                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+            val response = singleAwaitingRequest(request, 3.seconds)
             logger.debug("==>> " + response.toString)
             assert(response.status === StatusCodes.OK)
         }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -19,13 +19,15 @@
 
 package org.knora.webapi.e2e.admin
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.sharedtestdata.{SharedTestDataADM, SharedTestDataV1}
+import org.knora.webapi.util.AkkaHttpUtils
+import spray.json._
 
 import scala.concurrent.duration._
 
@@ -55,6 +57,39 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
             val response = singleAwaitingRequest(request, 1.seconds)
             logger.debug("==>> " + response.toString)
             assert(response.status === StatusCodes.OK)
+        }
+    }
+    "The Permissions Route ('admin/permissions')" should {
+        "create an administrative access permission" in {
+
+            val request = Post(baseApiUrl + s"/admin/permissions/ap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createAdministrativePermissionRequest)) ~> addCredentials(BasicHttpCredentials(
+                            SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+            val response: HttpResponse = singleAwaitingRequest(request)
+            assert(response.status === StatusCodes.OK)
+
+            val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrativePermission").asJsObject.fields
+            val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
+            assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
+            val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+            assert(projectIri == "http://rdfh.ch/projects/0001")
+            val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+            assert(permissions.contains("ProjectAdminGroupAllPermission"))
+        }
+
+        "create a default object access permission" in {
+
+            val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createDefaultObjectAccessPermissionRequest)) ~> addCredentials(BasicHttpCredentials(
+                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+            val response: HttpResponse = singleAwaitingRequest(request)
+            assert(response.status === StatusCodes.OK)
+
+            val result = AkkaHttpUtils.httpResponseToJson(response).fields("defaultObjectAccessPermission").asJsObject.fields
+            val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
+            assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
+            val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+            assert(projectIri == "http://rdfh.ch/projects/0001")
+            val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+            assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
         }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -48,13 +48,13 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
 
         "return administrative permissions" in {
 
-//            val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
-//            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
-//            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
-//                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-//            val response = singleAwaitingRequest(request, 1.seconds)
-//            logger.debug("==>> " + response.toString)
-//            assert(response.status === StatusCodes.OK)
+            val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
+            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
+                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+            val response = singleAwaitingRequest(request, 1.seconds)
+            logger.debug("==>> " + response.toString)
+            assert(response.status === StatusCodes.OK)
         }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -24,7 +24,8 @@ import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import com.typesafe.config.ConfigFactory
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.E2ESpec
-import org.knora.webapi.sharedtestdata.SharedTestDataADM
+import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.sharedtestdata.{SharedTestDataADM, SharedTestDataV1}
 
 import scala.concurrent.duration._
 
@@ -43,15 +44,17 @@ object PermissionsADME2ESpec {
   */
 class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with TriplestoreJsonProtocol {
 
-    "The Permissions Route ('admin/permissions/projectIri/groupIri')" should {
+    "The Permissions Route ('admin/permissions/projectIri')" should {
 
         "return administrative permissions" in {
-            val projectIri = java.net.URLEncoder.encode(SharedTestDataADM.IMAGES_PROJECT_IRI, "utf-8")
-            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri") ~> addCredentials(BasicHttpCredentials(
-                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-            val response = singleAwaitingRequest(request, 3.seconds)
-            logger.debug("==>> " + response.toString)
-            assert(response.status === StatusCodes.OK)
+
+//            val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+//            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
+//            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
+//                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+//            val response = singleAwaitingRequest(request, 1.seconds)
+//            logger.debug("==>> " + response.toString)
+//            assert(response.status === StatusCodes.OK)
         }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/BUILD.bazel
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
-load("//third_party:dependencies.bzl", "ALL_WEBAPI_MAIN_DEPENDENCIES")
+load("//third_party:dependencies.bzl", "ALL_WEBAPI_MAIN_DEPENDENCIES", "BASE_TEST_DEPENDENCIES_WITH_JSON")
 
 scala_test(
     name = "PermissionsMessagesADMSpec",
@@ -18,7 +18,5 @@ scala_test(
     deps = ALL_WEBAPI_MAIN_DEPENDENCIES + [
         "//webapi:main_library",
         "//webapi:test_library",
-        "@maven//:org_scalatest_scalatest_2_12",
-        "@maven//:org_scalactic_scalactic_2_12",
-    ],
+      ] + BASE_TEST_DEPENDENCIES_WITH_JSON,
 )

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -19,9 +19,11 @@
 
 package org.knora.webapi.messages.admin.responder.permissionsmessages
 
-import org.knora.webapi.messages.v1.responder.usermessages.UsersResponderRequestV1
+import java.util.UUID
+
+import org.knora.webapi.exceptions.{BadRequestException, ForbiddenException}
 import org.knora.webapi.sharedtestdata.SharedOntologyTestDataADM._
-import org.knora.webapi.sharedtestdata.SharedTestDataADM
+import org.knora.webapi.sharedtestdata._
 import org.knora.webapi.sharedtestdata.SharedTestDataV1._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -31,8 +33,387 @@ import org.scalatest.wordspec.AnyWordSpecLike
   */
 class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
 
-    "querying the user's 'PermissionsDataADM' with 'hasPermissionFor'" should {
+    "Administrative Permission Get Requests" should {
+        "return 'BadRequest' if the supplied project IRI for AdministrativePermissionsForProjectGetRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionsForProjectGetRequestADM(
+                    projectIri = "invalid-project-IRI",
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
 
+        "return 'ForbiddenException' if the user requesting AdministrativePermissionsForProjectGetRequestADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                AdministrativePermissionsForProjectGetRequestADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    requestingUser = SharedTestDataADM.imagesUser02,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Administrative permission can only be queried by system and project admin.")
+        }
+
+        "return 'BadRequest' if the supplied permission IRI for AdministrativePermissionForIriGetRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionForIriGetRequestADM(
+                    administrativePermissionIri = "invalid-permission-IRI",
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid permission IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting AdministrativePermissionForIriGetRequestADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                AdministrativePermissionForIriGetRequestADM(
+                    administrativePermissionIri = "http://rdfh.ch/permissions/permissionIRI",
+                    requestingUser = SharedTestDataADM.imagesUser02,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Administrative permission can only be queried by system and project admin.")
+        }
+
+
+        "return 'BadRequest' if the supplied project IRI for AdministrativePermissionForProjectGroupGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionForProjectGroupGetADM(
+                    projectIri = "invalid-project-IRI",
+                    groupIri = SharedTestDataADM.imagesReviewerGroup.id,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionForProjectGroupGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionForProjectGroupGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = "invalid-group-iri",
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Invalid group IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting AdministrativePermissionForProjectGroupGetADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                AdministrativePermissionForProjectGroupGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = SharedTestDataADM.imagesReviewerGroup.id,
+                    requestingUser = SharedTestDataADM.imagesUser02
+                )
+            )
+            assert(caught.getMessage === "Administrative permission can only be queried by system and project admin.")
+        }
+    }
+
+    "Administrative Permission Create Requests" should {
+        "return 'BadRequest' if the supplied project IRI for AdministrativePermissionCreateADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionCreateADM(
+                    createRequest = CreateAdministrativePermissionAPIRequestADM(
+                        forProject = "invalid-project-IRI",
+                        forGroup = SharedTestDataADM.imagesReviewerGroup.id,
+                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionCreateADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionCreateADM(
+                    createRequest = CreateAdministrativePermissionAPIRequestADM(
+                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        forGroup = "invalid-group-IRI",
+                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid group IRI")
+        }
+
+        "return 'BadRequest' if the no permissions supplied for AdministrativePermissionCreateADM" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionCreateADM(
+                    createRequest = CreateAdministrativePermissionAPIRequestADM(
+                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        forGroup = SharedTestDataADM.imagesReviewerGroup.id,
+                        hasPermissions = Set.empty[PermissionADM]
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Permissions needs to be supplied.")
+        }
+
+        "return 'ForbiddenException' if the user requesting AdministrativePermissionCreateADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                AdministrativePermissionCreateADM(
+                    createRequest = CreateAdministrativePermissionAPIRequestADM(
+                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        forGroup = SharedTestDataADM.imagesReviewerGroup.id,
+                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
+                    ),
+                    requestingUser = SharedTestDataADM.imagesReviewerUser,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "A new administrative permission can only be added by a system admin.")
+        }
+
+    }
+
+    "Object Access Permission Get Requests" should {
+        "return 'BadRequest' if the supplied resource IRI for ObjectAccessPermissionsForResourceGetADM is not a valid KnoraResourceIri" in {
+            val caught = intercept[BadRequestException](
+                ObjectAccessPermissionsForResourceGetADM(
+                    resourceIri = SharedTestDataADM.customValueIRI,
+                    requestingUser = SharedTestDataADM.anythingAdminUser
+                )
+            )
+            // a value IRI is given instead of a resource IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid resource IRI: ${SharedTestDataADM.customValueIRI}")
+        }
+        "return 'ForbiddenException' if the user requesting ObjectAccessPermissionsForResourceGetADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                ObjectAccessPermissionsForResourceGetADM(
+                    resourceIri = SharedTestDataADM.customResourceIRI,
+                    requestingUser = SharedTestDataADM.anythingUser1
+                )
+            )
+            assert(caught.getMessage === "Object access permissions can only be queried by system and project admin.")
+        }
+        "return 'BadRequest' if the supplied resource IRI for ObjectAccessPermissionsForValueGetADM is not a valid KnoraValueIri" in {
+            val caught = intercept[BadRequestException](
+                ObjectAccessPermissionsForValueGetADM(
+                    valueIri = SharedTestDataADM.customResourceIRI,
+                    requestingUser = SharedTestDataADM.anythingAdminUser
+                )
+            )
+            // a resource IRI is given instead of a value IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid value IRI: ${SharedTestDataADM.customResourceIRI}")
+        }
+        "return 'ForbiddenException' if the user requesting ObjectAccessPermissionsForValueGetADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                ObjectAccessPermissionsForValueGetADM(
+                    valueIri = SharedTestDataADM.customValueIRI,
+                    requestingUser = SharedTestDataADM.anythingUser1
+                )
+            )
+            assert(caught.getMessage === "Object access permissions can only be queried by system and project admin.")
+        }
+    }
+
+    "Default Object Access Permission Get Requests" should {
+
+        "return 'BadRequest' if the supplied project IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = "invalid-project-IRI",
+                    groupIri = Some(SharedTestDataADM.imagesReviewerGroup.id),
+                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'BadRequest' if the supplied optional group IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = Some(SharedTestDataADM.imagesUser01.id),
+                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // user IRI is given instead of group IRI, exception should be thrown.
+            assert(caught.getMessage === "Invalid group IRI")
+        }
+
+        "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = Some(SharedTestDataADM.imagesReviewerGroup.id),
+                    resourceClassIri = Some(SharedTestDataADM.customResourceIRI),
+                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // a resource IRI is given instead of a resource class IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
+        }
+
+        "return 'BadRequest' if the supplied property IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = Some(SharedTestDataADM.imagesReviewerGroup.id),
+                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+                    propertyIri = Some(SharedTestDataADM.customValueIRI),
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // a value IRI is given instead of a property IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+        }
+
+        "return 'BadRequest' if the supplied permission IRI for DefaultObjectAccessPermissionForIriGetRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionForIriGetRequestADM(
+                    defaultObjectAccessPermissionIri = "invalid-permission-IRI",
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid permission IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionForIriGetRequestADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionForIriGetRequestADM(
+                    defaultObjectAccessPermissionIri = "http://rdfh.ch/permissions/permissionIRI",
+                    requestingUser = SharedTestDataADM.imagesUser02,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Default object access permissions can only be queried by system and project admin.")
+        }
+
+        "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionsStringForResourceClassGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedTestDataADM.customResourceIRI,
+                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // a resource IRI is given instead of a resource class IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForResourceClassGetADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    requestingUser = SharedTestDataADM.imagesUser02
+                )
+            )
+            assert(caught.getMessage === "Default object access permissions can only be queried by system and project admin.")
+        }
+
+        "return 'BadRequest' if the supplied project IRI DefaultObjectAccessPermissionsStringForResourceClassGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
+                    projectIri = "invalid-project-IRI",
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    targetUser = SharedTestDataADM.imagesUser02,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForResourceClassGetADM is not in the same project as the target user" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    targetUser = SharedTestDataADM.anythingUser1,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
+        }
+
+        "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedTestDataADM.customResourceIRI,
+                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // a resource IRI is given instead of a resource class IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    requestingUser = SharedTestDataADM.imagesUser02
+                )
+            )
+            assert(caught.getMessage === "Default object access permissions can only be queried by system and project admin.")
+        }
+
+        "return 'BadRequest' if the supplied project IRI DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = "invalid-project-IRI",
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+                    targetUser = SharedTestDataADM.imagesUser02,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+                    targetUser = SharedTestDataADM.anythingUser1,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
+        }
+
+        "return 'BadRequest' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    propertyIri = SharedTestDataADM.customValueIRI,
+                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // a value IRI is given instead of a property IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+        }
+    }
+
+    "querying the user's 'PermissionsDataADM' with 'hasPermissionFor'" should {
         "return true if the user is allowed to create a resource (root user)" in {
 
             val projectIri = INCUNABULA_PROJECT_IRI

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -345,6 +345,30 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
 //            )
 //            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
 //        }
+        "return 'BadRequest' if the target user of DefaultObjectAccessPermissionsStringForResourceClassGetADM is an Anonymous user" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    targetUser = SharedTestDataADM.anonymousUser,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === s"Anonymous Users are not allowed.")
+        }
+
+        "return 'BadRequest' if the supplied project IRI DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = "",
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+                    targetUser = SharedTestDataADM.imagesUser02,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
 
         "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
             val caught = intercept[BadRequestException](
@@ -360,6 +384,20 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
         }
 
+        "return 'BadRequest' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+                    propertyIri = SharedTestDataADM.customValueIRI,
+                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            // a value IRI is given instead of a property IRI, exception should be thrown.
+            assert(caught.getMessage === s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+        }
+
         "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not SystemAdmin" in {
             val caught = intercept[ForbiddenException](
                 DefaultObjectAccessPermissionsStringForPropertyGetADM(
@@ -373,18 +411,7 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Default object access permissions can only be queried by system and project admin.")
         }
 
-        "return 'BadRequest' if the supplied project IRI DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
-            val caught = intercept[BadRequestException](
-                DefaultObjectAccessPermissionsStringForPropertyGetADM(
-                    projectIri = "invalid-project-IRI",
-                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
-                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
-                    targetUser = SharedTestDataADM.imagesUser02,
-                    requestingUser = SharedTestDataADM.imagesUser01
-                )
-            )
-            assert(caught.getMessage === "Invalid project IRI")
-        }
+
 
 //        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
 //            val caught = intercept[ForbiddenException](
@@ -399,19 +426,21 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
 //            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
 //        }
 
-        "return 'BadRequest' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
+
+
+        "return 'BadRequest' if the target user of DefaultObjectAccessPermissionsStringForPropertyGetADM is an Anonymous user" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionsStringForPropertyGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
                     resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
-                    propertyIri = SharedTestDataADM.customValueIRI,
-                    targetUser = SharedTestDataADM.imagesReviewerUser,
+                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+                    targetUser = SharedTestDataADM.anonymousUser,
                     requestingUser = SharedTestDataADM.imagesUser01
                 )
             )
-            // a value IRI is given instead of a property IRI, exception should be thrown.
-            assert(caught.getMessage === s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+            assert(caught.getMessage === s"Anonymous Users are not allowed.")
         }
+
     }
 
     "Default Object Access Permission Create Requests" should {

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -279,6 +279,28 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === s"Either a group, a resource class, a property, or a combination of resource class and property must be given.")
         }
 
+        "return 'BadRequest' if the supplied project IRI for DefaultObjectAccessPermissionsForProjectGetRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionsForProjectGetRequestADM(
+                    projectIri = "invalid-project-IRI",
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsForProjectGetRequestADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionsForProjectGetRequestADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    requestingUser = SharedTestDataADM.imagesUser02,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Default object access permissions can only be queried by system and project admin.")
+        }
+
         "return 'BadRequest' if the supplied permission IRI for DefaultObjectAccessPermissionForIriGetRequestADM is not valid" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionForIriGetRequestADM(
@@ -377,7 +399,7 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
         }
 
-        "return 'BadRequest' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
+        "return 'BadRequest' if the supplied property IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionsStringForPropertyGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -414,6 +414,84 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
         }
     }
 
+    "Default Object Access Permission Create Requests" should {
+        "return 'BadRequest' if the supplied project IRI for DefaultObjectAccessPermissionCreateRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = "invalid-project-IRI",
+                        forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+        "return 'BadRequest' if the no permissions supplied for DefaultObjectAccessPermissionCreateRequestADM" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = SharedTestDataADM.ANYTHING_PROJECT_IRI,
+                        forGroup = Some(SharedTestDataADM.thingSearcherGroup.id),
+                        hasPermissions = Set.empty[PermissionADM]
+                    ),
+                    requestingUser = SharedTestDataADM.anythingAdminUser,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Permissions needs to be supplied.")
+        }
+
+        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionCreateRequestADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = SharedTestDataADM.ANYTHING_PROJECT_IRI,
+                        forGroup = Some(SharedTestDataADM.thingSearcherGroup.id),
+                        hasPermissions = Set(PermissionADM.restrictedViewPermission(SharedTestDataADM.thingSearcherGroup.id))
+                    ),
+                    requestingUser = SharedTestDataADM.anythingUser2,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "A new default object access permission can only be added by a system admin.")
+        }
+
+        "return 'BadRequest' if the both group and resource class are supplied for DefaultObjectAccessPermissionCreateRequestADM" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = ANYTHING_PROJECT_IRI,
+                        forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                        forResourceClass = Some(ANYTHING_THING_RESOURCE_CLASS_LocalHost),
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "If a group is defined, a resource class or a property cannot also be specified.")
+        }
+
+        "return 'BadRequest' if the both group and property are supplied for DefaultObjectAccessPermissionCreateRequestADM" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = ANYTHING_PROJECT_IRI,
+                        forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                        forProperty = Some(ANYTHING_HasListItem_PROPERTY_LocalHost),
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "If a group is defined, a resource class or a property cannot also be specified.")
+        }
+    }
+
     "querying the user's 'PermissionsDataADM' with 'hasPermissionFor'" should {
         "return true if the user is allowed to create a resource (root user)" in {
 

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -91,17 +91,6 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-//        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionForProjectGroupGetADM is not valid" in {
-//            val caught = intercept[BadRequestException](
-//                AdministrativePermissionForProjectGroupGetADM(
-//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-//                    groupIri = "invalid-group-iri",
-//                    requestingUser = SharedTestDataADM.imagesUser01
-//                )
-//            )
-//            assert(caught.getMessage === "Invalid group IRI")
-//        }
-
         "return 'ForbiddenException' if the user requesting AdministrativePermissionForProjectGroupGetADM is not SystemAdmin" in {
             val caught = intercept[ForbiddenException](
                 AdministrativePermissionForProjectGroupGetADM(
@@ -130,20 +119,21 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-//        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionCreateRequestADM is not valid" in {
-//            val caught = intercept[BadRequestException](
-//                AdministrativePermissionCreateRequestADM(
-//                    createRequest = CreateAdministrativePermissionAPIRequestADM(
-//                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
-//                        forGroup = "invalid-group-IRI",
-//                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
-//                    ),
-//                    requestingUser = SharedTestDataADM.imagesUser01,
-//                    apiRequestID = UUID.randomUUID()
-//                )
-//            )
-//            assert(caught.getMessage === "Invalid group IRI")
-//        }
+        "return 'BadRequest' if the supplied permission IRI for AdministrativePermissionCreateRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                AdministrativePermissionCreateRequestADM(
+                    createRequest = CreateAdministrativePermissionAPIRequestADM(
+                        id = Some("invalid-permission-IRI"),
+                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                        forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
+                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid permission IRI")
+        }
 
         "return 'BadRequest' if the no permissions supplied for AdministrativePermissionCreateRequestADM" in {
             val caught = intercept[BadRequestException](
@@ -230,20 +220,6 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             )
             assert(caught.getMessage === "Invalid project IRI")
         }
-
-//        "return 'BadRequest' if the supplied optional group IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
-//            val caught = intercept[BadRequestException](
-//                DefaultObjectAccessPermissionGetADM(
-//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-//                    groupIri = Some(SharedTestDataADM.imagesUser01.id),
-//                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
-//                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
-//                    requestingUser = SharedTestDataADM.imagesUser01
-//                )
-//            )
-//            // user IRI is given instead of group IRI, exception should be thrown.
-//            assert(caught.getMessage === "Invalid group IRI")
-//        }
 
         "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
             val caught = intercept[BadRequestException](
@@ -362,17 +338,6 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-//        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForResourceClassGetADM is not in the same project as the target user" in {
-//            val caught = intercept[ForbiddenException](
-//                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
-//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-//                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
-//                    targetUser = SharedTestDataADM.anythingUser1,
-//                    requestingUser = SharedTestDataADM.imagesUser01
-//                )
-//            )
-//            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
-//        }
         "return 'BadRequest' if the target user of DefaultObjectAccessPermissionsStringForResourceClassGetADM is an Anonymous user" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionsStringForResourceClassGetADM(
@@ -439,23 +404,6 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Default object access permissions can only be queried by system and project admin.")
         }
 
-
-
-//        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
-//            val caught = intercept[ForbiddenException](
-//                DefaultObjectAccessPermissionsStringForPropertyGetADM(
-//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-//                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
-//                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
-//                    targetUser = SharedTestDataADM.anythingUser1,
-//                    requestingUser = SharedTestDataADM.imagesUser01
-//                )
-//            )
-//            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
-//        }
-
-
-
         "return 'BadRequest' if the target user of DefaultObjectAccessPermissionsStringForPropertyGetADM is an Anonymous user" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionsStringForPropertyGetADM(
@@ -486,6 +434,23 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             )
             assert(caught.getMessage === "Invalid project IRI")
         }
+
+        "return 'BadRequest' if the supplied custom permission IRI for DefaultObjectAccessPermissionCreateRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        id = Some("invalid-permission-IRI"),
+                        forProject = SharedTestDataADM.ANYTHING_PROJECT_IRI,
+                        forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid permission IRI")
+        }
+
         "return 'BadRequest' if the no permissions supplied for DefaultObjectAccessPermissionCreateRequestADM" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionCreateRequestADM(

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -568,14 +568,14 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
                 DefaultObjectAccessPermissionCreateRequestADM(
                     createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
                         forProject = ANYTHING_PROJECT_IRI,
-                        forResourceClass = Some(SharedTestDataADM.customResourceIRI),
+                        forResourceClass = Some(ANYTHING_THING_RESOURCE_CLASS_LocalHost),
                         hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
                     ),
                     requestingUser = SharedTestDataADM.imagesUser01,
                     apiRequestID = UUID.randomUUID()
                 )
             )
-            assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
+            assert(caught.getMessage === s"Invalid resource class IRI: ${ANYTHING_THING_RESOURCE_CLASS_LocalHost}")
         }
 
         "return 'BadRequest' if neither a group, nor a resource class, nor a property is supplied for DefaultObjectAccessPermissionCreateRequestADM" in {

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -22,6 +22,7 @@ package org.knora.webapi.messages.admin.responder.permissionsmessages
 import java.util.UUID
 
 import org.knora.webapi.exceptions.{BadRequestException, ForbiddenException}
+import org.knora.webapi.messages.OntologyConstants
 import org.knora.webapi.sharedtestdata.SharedOntologyTestDataADM._
 import org.knora.webapi.sharedtestdata._
 import org.knora.webapi.sharedtestdata.SharedTestDataV1._
@@ -83,29 +84,29 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             val caught = intercept[BadRequestException](
                 AdministrativePermissionForProjectGroupGetADM(
                     projectIri = "invalid-project-IRI",
-                    groupIri = SharedTestDataADM.imagesReviewerGroup.id,
+                    groupIri = OntologyConstants.KnoraAdmin.ProjectMember,
                     requestingUser = SharedTestDataADM.imagesUser01
                 )
             )
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionForProjectGroupGetADM is not valid" in {
-            val caught = intercept[BadRequestException](
-                AdministrativePermissionForProjectGroupGetADM(
-                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = "invalid-group-iri",
-                    requestingUser = SharedTestDataADM.imagesUser01
-                )
-            )
-            assert(caught.getMessage === "Invalid group IRI")
-        }
+//        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionForProjectGroupGetADM is not valid" in {
+//            val caught = intercept[BadRequestException](
+//                AdministrativePermissionForProjectGroupGetADM(
+//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+//                    groupIri = "invalid-group-iri",
+//                    requestingUser = SharedTestDataADM.imagesUser01
+//                )
+//            )
+//            assert(caught.getMessage === "Invalid group IRI")
+//        }
 
         "return 'ForbiddenException' if the user requesting AdministrativePermissionForProjectGroupGetADM is not SystemAdmin" in {
             val caught = intercept[ForbiddenException](
                 AdministrativePermissionForProjectGroupGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = SharedTestDataADM.imagesReviewerGroup.id,
+                    groupIri = OntologyConstants.KnoraAdmin.ProjectMember,
                     requestingUser = SharedTestDataADM.imagesUser02
                 )
             )
@@ -114,12 +115,12 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
     }
 
     "Administrative Permission Create Requests" should {
-        "return 'BadRequest' if the supplied project IRI for AdministrativePermissionCreateADM is not valid" in {
+        "return 'BadRequest' if the supplied project IRI for AdministrativePermissionCreateRequestADM is not valid" in {
             val caught = intercept[BadRequestException](
-                AdministrativePermissionCreateADM(
+                AdministrativePermissionCreateRequestADM(
                     createRequest = CreateAdministrativePermissionAPIRequestADM(
                         forProject = "invalid-project-IRI",
-                        forGroup = SharedTestDataADM.imagesReviewerGroup.id,
+                        forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
                         hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
                     ),
                     requestingUser = SharedTestDataADM.imagesUser01,
@@ -129,27 +130,27 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionCreateADM is not valid" in {
-            val caught = intercept[BadRequestException](
-                AdministrativePermissionCreateADM(
-                    createRequest = CreateAdministrativePermissionAPIRequestADM(
-                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                        forGroup = "invalid-group-IRI",
-                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
-                    ),
-                    requestingUser = SharedTestDataADM.imagesUser01,
-                    apiRequestID = UUID.randomUUID()
-                )
-            )
-            assert(caught.getMessage === "Invalid group IRI")
-        }
+//        "return 'BadRequest' if the supplied group IRI for AdministrativePermissionCreateRequestADM is not valid" in {
+//            val caught = intercept[BadRequestException](
+//                AdministrativePermissionCreateRequestADM(
+//                    createRequest = CreateAdministrativePermissionAPIRequestADM(
+//                        forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
+//                        forGroup = "invalid-group-IRI",
+//                        hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
+//                    ),
+//                    requestingUser = SharedTestDataADM.imagesUser01,
+//                    apiRequestID = UUID.randomUUID()
+//                )
+//            )
+//            assert(caught.getMessage === "Invalid group IRI")
+//        }
 
-        "return 'BadRequest' if the no permissions supplied for AdministrativePermissionCreateADM" in {
+        "return 'BadRequest' if the no permissions supplied for AdministrativePermissionCreateRequestADM" in {
             val caught = intercept[BadRequestException](
-                AdministrativePermissionCreateADM(
+                AdministrativePermissionCreateRequestADM(
                     createRequest = CreateAdministrativePermissionAPIRequestADM(
                         forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                        forGroup = SharedTestDataADM.imagesReviewerGroup.id,
+                        forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
                         hasPermissions = Set.empty[PermissionADM]
                     ),
                     requestingUser = SharedTestDataADM.imagesUser01,
@@ -159,12 +160,12 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Permissions needs to be supplied.")
         }
 
-        "return 'ForbiddenException' if the user requesting AdministrativePermissionCreateADM is not SystemAdmin" in {
+        "return 'ForbiddenException' if the user requesting AdministrativePermissionCreateRequestADM is not SystemAdmin" in {
             val caught = intercept[ForbiddenException](
-                AdministrativePermissionCreateADM(
+                AdministrativePermissionCreateRequestADM(
                     createRequest = CreateAdministrativePermissionAPIRequestADM(
                         forProject = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                        forGroup = SharedTestDataADM.imagesReviewerGroup.id,
+                        forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
                         hasPermissions = Set(PermissionADM.ProjectAdminAllPermission)
                     ),
                     requestingUser = SharedTestDataADM.imagesReviewerUser,
@@ -223,7 +224,7 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionGetADM(
                     projectIri = "invalid-project-IRI",
-                    groupIri = Some(SharedTestDataADM.imagesReviewerGroup.id),
+                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
                     resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                     propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
                     requestingUser = SharedTestDataADM.imagesUser01
@@ -232,25 +233,25 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-        "return 'BadRequest' if the supplied optional group IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
-            val caught = intercept[BadRequestException](
-                DefaultObjectAccessPermissionGetADM(
-                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = Some(SharedTestDataADM.imagesUser01.id),
-                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
-                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
-                    requestingUser = SharedTestDataADM.imagesUser01
-                )
-            )
-            // user IRI is given instead of group IRI, exception should be thrown.
-            assert(caught.getMessage === "Invalid group IRI")
-        }
+//        "return 'BadRequest' if the supplied optional group IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
+//            val caught = intercept[BadRequestException](
+//                DefaultObjectAccessPermissionGetADM(
+//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+//                    groupIri = Some(SharedTestDataADM.imagesUser01.id),
+//                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+//                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
+//                    requestingUser = SharedTestDataADM.imagesUser01
+//                )
+//            )
+//            // user IRI is given instead of group IRI, exception should be thrown.
+//            assert(caught.getMessage === "Invalid group IRI")
+//        }
 
         "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionGetADM is not valid" in {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = Some(SharedTestDataADM.imagesReviewerGroup.id),
+                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
                     resourceClassIri = Some(SharedTestDataADM.customResourceIRI),
                     propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
                     requestingUser = SharedTestDataADM.imagesUser01
@@ -264,7 +265,7 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = Some(SharedTestDataADM.imagesReviewerGroup.id),
+                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
                     resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                     propertyIri = Some(SharedTestDataADM.customValueIRI),
                     requestingUser = SharedTestDataADM.imagesUser01
@@ -333,17 +334,17 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForResourceClassGetADM is not in the same project as the target user" in {
-            val caught = intercept[ForbiddenException](
-                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
-                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
-                    targetUser = SharedTestDataADM.anythingUser1,
-                    requestingUser = SharedTestDataADM.imagesUser01
-                )
-            )
-            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
-        }
+//        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForResourceClassGetADM is not in the same project as the target user" in {
+//            val caught = intercept[ForbiddenException](
+//                DefaultObjectAccessPermissionsStringForResourceClassGetADM(
+//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+//                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+//                    targetUser = SharedTestDataADM.anythingUser1,
+//                    requestingUser = SharedTestDataADM.imagesUser01
+//                )
+//            )
+//            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
+//        }
 
         "return 'BadRequest' if the supplied resourceClass IRI for DefaultObjectAccessPermissionsStringForPropertyGetADM is not valid" in {
             val caught = intercept[BadRequestException](
@@ -385,18 +386,18 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             assert(caught.getMessage === "Invalid project IRI")
         }
 
-        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
-            val caught = intercept[ForbiddenException](
-                DefaultObjectAccessPermissionsStringForPropertyGetADM(
-                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
-                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
-                    targetUser = SharedTestDataADM.anythingUser1,
-                    requestingUser = SharedTestDataADM.imagesUser01
-                )
-            )
-            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
-        }
+//        "return 'ForbiddenException' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
+//            val caught = intercept[ForbiddenException](
+//                DefaultObjectAccessPermissionsStringForPropertyGetADM(
+//                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+//                    resourceClassIri = SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS,
+//                    propertyIri = SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY,
+//                    targetUser = SharedTestDataADM.anythingUser1,
+//                    requestingUser = SharedTestDataADM.imagesUser01
+//                )
+//            )
+//            assert(caught.getMessage === "Target user is not a member of the same project as the requesting user.")
+//        }
 
         "return 'BadRequest' if the user requesting DefaultObjectAccessPermissionsStringForPropertyGetADM is not in the same project as the target user" in {
             val caught = intercept[BadRequestException](

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -225,8 +225,6 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
                 DefaultObjectAccessPermissionGetADM(
                     projectIri = "invalid-project-IRI",
                     groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
-                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
                     requestingUser = SharedTestDataADM.imagesUser01
                 )
             )
@@ -251,9 +249,7 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
                     resourceClassIri = Some(SharedTestDataADM.customResourceIRI),
-                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY),
                     requestingUser = SharedTestDataADM.imagesUser01
                 )
             )
@@ -265,14 +261,46 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
             val caught = intercept[BadRequestException](
                 DefaultObjectAccessPermissionGetADM(
                     projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
-                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
                     propertyIri = Some(SharedTestDataADM.customValueIRI),
                     requestingUser = SharedTestDataADM.imagesUser01
                 )
             )
             // a value IRI is given instead of a property IRI, exception should be thrown.
             assert(caught.getMessage === s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+        }
+
+        "return 'BadRequest' if both group and resource class are supplied for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                    resourceClassIri = Some(SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS),
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === s"Not allowed to supply groupIri and resourceClassIri together.")
+        }
+
+        "return 'BadRequest' if both group and property are supplied for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                    propertyIri = Some(SharedOntologyTestDataADM.IMAGES_TITEL_PROPERTY_LocalHost),
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === s"Not allowed to supply groupIri and propertyIri together.")
+        }
+
+        "return 'BadRequest' if no group, resourceClassIri or propertyIri are supplied for DefaultObjectAccessPermissionGetADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionGetADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    requestingUser = SharedTestDataADM.imagesUser01
+                )
+            )
+            assert(caught.getMessage === s"Either a group, a resource class, a property, or a combination of resource class and property must be given.")
         }
 
         "return 'BadRequest' if the supplied permission IRI for DefaultObjectAccessPermissionForIriGetRequestADM is not valid" in {
@@ -501,7 +529,7 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
                     apiRequestID = UUID.randomUUID()
                 )
             )
-            assert(caught.getMessage === "If a group is defined, a resource class or a property cannot also be specified.")
+            assert(caught.getMessage === "Not allowed to supply groupIri and resourceClassIri together.")
         }
 
         "return 'BadRequest' if the both group and property are supplied for DefaultObjectAccessPermissionCreateRequestADM" in {
@@ -510,14 +538,58 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
                     createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
                         forProject = ANYTHING_PROJECT_IRI,
                         forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                        forProperty = Some(ANYTHING_HasListItem_PROPERTY_LocalHost),
+                        forProperty = Some(ANYTHING_HasDate_PROPERTY_LocalHost),
                         hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
                     ),
                     requestingUser = SharedTestDataADM.imagesUser01,
                     apiRequestID = UUID.randomUUID()
                 )
             )
-            assert(caught.getMessage === "If a group is defined, a resource class or a property cannot also be specified.")
+            assert(caught.getMessage === "Not allowed to supply groupIri and propertyIri together.")
+        }
+
+        "return 'BadRequest' if propertyIri supplied for DefaultObjectAccessPermissionCreateRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = ANYTHING_PROJECT_IRI,
+                        forProperty = Some(SharedTestDataADM.customValueIRI),
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === s"Invalid property IRI: ${SharedTestDataADM.customValueIRI}")
+        }
+
+        "return 'BadRequest' if resourceClassIri supplied for DefaultObjectAccessPermissionCreateRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = ANYTHING_PROJECT_IRI,
+                        forResourceClass = Some(SharedTestDataADM.customResourceIRI),
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === s"Invalid resource class IRI: ${SharedTestDataADM.customResourceIRI}")
+        }
+
+        "return 'BadRequest' if neither a group, nor a resource class, nor a property is supplied for DefaultObjectAccessPermissionCreateRequestADM" in {
+            val caught = intercept[BadRequestException](
+                DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        forProject = ANYTHING_PROJECT_IRI,
+                        hasPermissions = Set(PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.ProjectMember))
+                    ),
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Either a group, a resource class, a property, or a combination of resource class and property must be given.")
         }
     }
 

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
@@ -345,19 +345,6 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
 
             "create a DefaultObjectAccessPermission for project and property" ignore {}
 
-            "fail and return a 'BadRequestException' when project does not exist" ignore {}
-
-            "fail and return a  'BadRequestException' when resource class does not exist" ignore {}
-
-            "fail and return a  'BadRequestException' when property does not exist" ignore {}
-
-            "fail and return a 'NotAuthorizedException' whe the user's permission are not high enough (e.g., not member of ProjectAdmin group" ignore {
-
-                /* defining project level default object access permissions, so I need to be at least a member of the 'ProjectAdmin' group */
-
-                /* defining system level default object access permissions, so I need to be at least a member of the 'SystemAdmin' group */
-            }
-
             "fail and return a 'DuplicateValueException' when permission for project / group / resource class / property  combination already exists" ignore {}
         }
         "asked to delete a permission object " should {

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
@@ -275,10 +275,10 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
 
             "return DefaultObjectAccessPermission for project and group" in {
                 responderManager ! DefaultObjectAccessPermissionGetRequestADM(
-                    projectIRI = INCUNABULA_PROJECT_IRI,
-                    groupIRI = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                    resourceClassIRI = None,
-                    propertyIRI = None,
+                    projectIri = INCUNABULA_PROJECT_IRI,
+                    groupIri = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                    resourceClassIri = None,
+                    propertyIri = None,
                     requestingUser = rootUser
                 )
                 expectMsg(DefaultObjectAccessPermissionGetResponseADM(
@@ -288,10 +288,10 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
 
             "return DefaultObjectAccessPermission for project and resource class ('incunabula:Page')" in {
                 responderManager ! DefaultObjectAccessPermissionGetRequestADM(
-                    projectIRI = INCUNABULA_PROJECT_IRI,
-                    groupIRI = None,
-                    resourceClassIRI = Some(INCUNABULA_BOOK_RESOURCE_CLASS),
-                    propertyIRI = None,
+                    projectIri = INCUNABULA_PROJECT_IRI,
+                    groupIri = None,
+                    resourceClassIri = Some(INCUNABULA_BOOK_RESOURCE_CLASS),
+                    propertyIri = None,
                     requestingUser = rootUser
                 )
                 expectMsg(DefaultObjectAccessPermissionGetResponseADM(
@@ -301,10 +301,10 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
 
             "return DefaultObjectAccessPermission for project and property ('knora-base:hasStillImageFileValue') (system property)" in {
                 responderManager ! DefaultObjectAccessPermissionGetRequestADM(
-                    projectIRI = INCUNABULA_PROJECT_IRI,
-                    groupIRI = None,
-                    resourceClassIRI = None,
-                    propertyIRI = Some(OntologyConstants.KnoraBase.HasStillImageFileValue),
+                    projectIri = INCUNABULA_PROJECT_IRI,
+                    groupIri = None,
+                    resourceClassIri = None,
+                    propertyIri = Some(OntologyConstants.KnoraBase.HasStillImageFileValue),
                     requestingUser = rootUser
                 )
                 expectMsg(DefaultObjectAccessPermissionGetResponseADM(
@@ -314,10 +314,10 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
 
             "cache DefaultObjectAccessPermission" in {
                 responderManager ! DefaultObjectAccessPermissionGetRequestADM(
-                    projectIRI = INCUNABULA_PROJECT_IRI,
-                    groupIRI = None,
-                    resourceClassIRI = None,
-                    propertyIRI = Some(OntologyConstants.KnoraBase.HasStillImageFileValue),
+                    projectIri = INCUNABULA_PROJECT_IRI,
+                    groupIri = None,
+                    resourceClassIri = None,
+                    propertyIri = Some(OntologyConstants.KnoraBase.HasStillImageFileValue),
                     requestingUser = rootUser
                 )
                 expectMsg(DefaultObjectAccessPermissionGetResponseADM(

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
@@ -219,9 +219,10 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
                 expectMsg(Failure(DuplicateValueException(s"Permission for project: '$IMAGES_PROJECT_IRI' and group: '${OntologyConstants.KnoraAdmin.ProjectMember}' combination already exists.")))
             }
 
-            "create and return an administrative permission" in {
+            "create and return an administrative permission with a custom IRI" in {
                 responderManager ! AdministrativePermissionCreateRequestADM(
                     createRequest = CreateAdministrativePermissionAPIRequestADM(
+                        id = Some("http://rdfh.ch/permissions/0001/AP-with-customIri"),
                         forProject = ANYTHING_PROJECT_IRI,
                         forGroup = SharedTestDataADM.thingSearcherGroup.id,
                         hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission)
@@ -230,6 +231,7 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
                     apiRequestID = UUID.randomUUID()
                 )
                 val received: AdministrativePermissionCreateResponseADM = expectMsgType[AdministrativePermissionCreateResponseADM]
+                assert(received.administrativePermission.iri == "http://rdfh.ch/permissions/0001/AP-with-customIri")
                 assert(received.administrativePermission.forProject == ANYTHING_PROJECT_IRI)
                 assert(received.administrativePermission.forGroup == SharedTestDataADM.thingSearcherGroup.id)
             }
@@ -353,6 +355,24 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
                 assert(received.defaultObjectAccessPermission.forProject == ANYTHING_PROJECT_IRI)
                 assert(received.defaultObjectAccessPermission.forGroup.contains(SharedTestDataADM.thingSearcherGroup.id))
                 assert(received.defaultObjectAccessPermission.hasPermissions.contains(PermissionADM.restrictedViewPermission(SharedTestDataADM.thingSearcherGroup.id)))
+            }
+
+            "create a DefaultObjectAccessPermission for project and group with custom IRI" in {
+                responderManager ! DefaultObjectAccessPermissionCreateRequestADM(
+                    createRequest = CreateDefaultObjectAccessPermissionAPIRequestADM(
+                        id = Some("http://rdfh.ch/permissions/0001/DOAP-with-customIri"),
+                        forProject = ANYTHING_PROJECT_IRI,
+                        forGroup = Some(OntologyConstants.KnoraAdmin.UnknownUser),
+                        hasPermissions = Set(PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser))
+                    ),
+                    requestingUser = rootUser,
+                    apiRequestID = UUID.randomUUID()
+                )
+                val received: DefaultObjectAccessPermissionCreateResponseADM = expectMsgType[DefaultObjectAccessPermissionCreateResponseADM]
+                assert(received.defaultObjectAccessPermission.iri == "http://rdfh.ch/permissions/0001/DOAP-with-customIri")
+                assert(received.defaultObjectAccessPermission.forProject == ANYTHING_PROJECT_IRI)
+                assert(received.defaultObjectAccessPermission.forGroup.contains(OntologyConstants.KnoraAdmin.UnknownUser))
+                assert(received.defaultObjectAccessPermission.hasPermissions.contains(PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)))
             }
 
             "create a DefaultObjectAccessPermission for project and resource class" in {

--- a/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedPermissionsTestData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedPermissionsTestData.scala
@@ -41,7 +41,7 @@ object SharedPermissionsTestData {
     val perm001_d1: doap =
         doap(
             iri = "http://rdfh.ch/permissions/0000/001-d1",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0000/001-d1", forProject = OntologyConstants.KnoraAdmin.SystemProject, forGroup = None, forResourceClass = Some(OntologyConstants.KnoraBase.LinkObj), forProperty = None, hasPermissions = Set(
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0000/001-d1", forProject = OntologyConstants.KnoraAdmin.SystemProject, forResourceClass = Some(OntologyConstants.KnoraBase.LinkObj), hasPermissions = Set(
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
@@ -51,7 +51,7 @@ object SharedPermissionsTestData {
     val perm001_d2: doap =
         doap(
             iri = "http://rdfh.ch/permissions/0000/001-d2",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0000/001-d2", forProject = OntologyConstants.KnoraAdmin.SystemProject, forGroup = None, forResourceClass = Some(OntologyConstants.KnoraBase.Region), forProperty = None, hasPermissions = Set(
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0000/001-d2", forProject = OntologyConstants.KnoraAdmin.SystemProject, forResourceClass = Some(OntologyConstants.KnoraBase.Region), hasPermissions = Set(
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
@@ -61,7 +61,7 @@ object SharedPermissionsTestData {
     val perm001_d3: doap =
         doap(
             iri = "http://rdfh.ch/permissions/0000/001-d3",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0000/001-d3", forProject = OntologyConstants.KnoraAdmin.SystemProject, forGroup = None, forResourceClass = None, forProperty = Some(OntologyConstants.KnoraBase.HasStillImageFileValue), hasPermissions = Set(
+            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0000/001-d3", forProject = OntologyConstants.KnoraAdmin.SystemProject, forProperty = Some(OntologyConstants.KnoraBase.HasStillImageFileValue), hasPermissions = Set(
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
@@ -121,8 +121,6 @@ object SharedPermissionsTestData {
             iri = "http://rdfh.ch/permissions/00FF/a4",
             forProject = IMAGES_PROJECT_IRI,
             forGroup = Some("http://rdfh.ch/groups/00FF/images-reviewer"),
-            forResourceClass = None,
-            forProperty = None,
             hasPermissions = Set(PermissionADM.deletePermission(OntologyConstants.KnoraAdmin.Creator))
         )
     )
@@ -134,8 +132,6 @@ object SharedPermissionsTestData {
                 iri = "http://rdfh.ch/permissions/00FF/d1",
                 forProject = IMAGES_PROJECT_IRI,
                 forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                forResourceClass = None,
-                forProperty = None,
                 hasPermissions = Set(
                                 PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
@@ -151,7 +147,6 @@ object SharedPermissionsTestData {
                 iri = "http://rdfh.ch/permissions/00FF/d2",
                 forProject = IMAGES_PROJECT_IRI,
                 forGroup = Some(OntologyConstants.KnoraAdmin.KnownUser),
-                forResourceClass = None, forProperty = None,
                 hasPermissions = Set(
                     PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                     PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
@@ -193,7 +188,6 @@ object SharedPermissionsTestData {
             iri = "http://rdfh.ch/0803/00014b43f902", // incunabula:page
             p = ObjectAccessPermissionADM(
                 forResource = Some("http://rdfh.ch/0803/00014b43f902"),
-                forValue = None,
                 hasPermissions = Set(
                                 PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
@@ -207,7 +201,6 @@ object SharedPermissionsTestData {
         oap(
             iri = "http://rdfh.ch/0803/00014b43f902/values/1ad3999ad60b", // knora-base:TextValue
             p = ObjectAccessPermissionADM(
-                forResource = None,
                 forValue = Some("http://rdfh.ch/0803/00014b43f902/values/1ad3999ad60b"),
                 hasPermissions = Set(
                                     PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser),
@@ -225,8 +218,6 @@ object SharedPermissionsTestData {
                 iri = "http://rdfh.ch/permissions/0803/003-d1",
                 forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI,
                 forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                forResourceClass = None,
-                forProperty = None,
                 hasPermissions = Set(
                     PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                     PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
@@ -241,9 +232,7 @@ object SharedPermissionsTestData {
             p = DefaultObjectAccessPermissionADM(
                 iri = "http://rdfh.ch/permissions/0803/003-d2",
                 forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI,
-                forGroup = None,
                 forResourceClass = Some(INCUNABULA_BOOK_RESOURCE_CLASS),
-                forProperty = None,
                 hasPermissions = Set(
                     PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                     PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
@@ -258,9 +247,7 @@ object SharedPermissionsTestData {
             p = DefaultObjectAccessPermissionADM(
                 iri = "http://rdfh.ch/permissions/0803/003-d3",
                 forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI,
-                forGroup = None,
                 forResourceClass = Some(INCUNABULA_PAGE_RESOURCE_CLASS),
-                forProperty = None,
                 hasPermissions = Set(
                     PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                     PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
@@ -303,8 +290,6 @@ object SharedPermissionsTestData {
                 iri = "http://rdfh.ch/permissions/0001/005-d1",
                 forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI,
                 forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
-                forResourceClass = None,
-                forProperty = None,
                 hasPermissions = Set(
                                 PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),

--- a/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedPermissionsTestData.scala
+++ b/webapi/src/test/scala/org/knora/webapi/sharedtestdata/SharedPermissionsTestData.scala
@@ -77,25 +77,42 @@ object SharedPermissionsTestData {
     val perm002_a1: ap =
         ap(
             iri = "http://rdfh.ch/permissions/00FF/a1",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a1", forProject = IMAGES_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/00FF/a1",
+                forProject = IMAGES_PROJECT_IRI,
+                forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
+                hasPermissions = Set(
+                    PermissionADM.ProjectResourceCreateAllPermission
+                )
+            )
         )
 
     val perm002_a2: ap =
         ap(
             iri = "http://rdfh.ch/permissions/00FF/a2",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a2", forProject = IMAGES_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin, hasPermissions = Set(
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/00FF/a2",
+                forProject = IMAGES_PROJECT_IRI,
+                forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin,
+                hasPermissions = Set(
                                 PermissionADM.ProjectResourceCreateAllPermission,
                                 PermissionADM.ProjectAdminAllPermission
-                            ))
+                )
+            )
         )
 
     val perm002_a3: ap =
         ap(
             iri = "http://rdfh.ch/permissions/00FF/a3",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/00FF/a3", forProject = IMAGES_PROJECT_IRI, forGroup = "http://rdfh.ch/groups/00FF/images-reviewer", hasPermissions = Set(
-                PermissionADM.projectResourceCreateRestrictedPermission(s"$IMAGES_ONTOLOGY_IRI#bild"),
-                PermissionADM.projectResourceCreateRestrictedPermission(s"$IMAGES_ONTOLOGY_IRI#bildformat")
-            ))
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/00FF/a3",
+                forProject = IMAGES_PROJECT_IRI,
+                forGroup = "http://rdfh.ch/groups/00FF/images-reviewer",
+                hasPermissions = Set(
+                    PermissionADM.projectResourceCreateRestrictedPermission(s"$IMAGES_ONTOLOGY_IRI#bild"),
+                    PermissionADM.projectResourceCreateRestrictedPermission(s"$IMAGES_ONTOLOGY_IRI#bildformat")
+                )
+            )
         )
 
     val perm0003_a4: doap = doap(
@@ -113,21 +130,34 @@ object SharedPermissionsTestData {
     val perm002_d1: doap =
         doap(
             iri = "http://rdfh.ch/permissions/00FF/d1",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/00FF/d1", forProject = IMAGES_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember), forResourceClass = None, forProperty = None, hasPermissions = Set(
+            p = DefaultObjectAccessPermissionADM(
+                iri = "http://rdfh.ch/permissions/00FF/d1",
+                forProject = IMAGES_PROJECT_IRI,
+                forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                forResourceClass = None,
+                forProperty = None,
+                hasPermissions = Set(
                                 PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
-                            ))
+                )
+            )
         )
 
     val perm002_d2: doap =
         doap(
             iri = "http://rdfh.ch/permissions/00FF/d2",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/00FF/d2", forProject = IMAGES_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraAdmin.KnownUser), forResourceClass = None, forProperty = None, hasPermissions = Set(
-                PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
-                PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
-                PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
-            ))
+            p = DefaultObjectAccessPermissionADM(
+                iri = "http://rdfh.ch/permissions/00FF/d2",
+                forProject = IMAGES_PROJECT_IRI,
+                forGroup = Some(OntologyConstants.KnoraAdmin.KnownUser),
+                forResourceClass = None, forProperty = None,
+                hasPermissions = Set(
+                    PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
+                    PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
+                    PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser)
+                )
+            )
         )
 
     /*************************************/
@@ -137,38 +167,55 @@ object SharedPermissionsTestData {
     val perm003_a1: ap =
         ap(
             iri = "http://rdfh.ch/permissions/0803/003-a1",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/003-a1", forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/003-a1",
+                forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI,
+                forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
+                hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
         )
 
     val perm003_a2: ap =
         ap(
             iri = "http://rdfh.ch/permissions/0803/003-a2",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/003-a2", forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin, hasPermissions = Set(
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/003-a2",
+                forProject = SharedTestDataV1.INCUNABULA_PROJECT_IRI,
+                forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin,
+                hasPermissions = Set(
                                 PermissionADM.ProjectResourceCreateAllPermission,
                                 PermissionADM.ProjectAdminAllPermission
-                            ))
+                )
+            )
         )
 
     val perm003_o1: oap =
         oap(
             iri = "http://rdfh.ch/0803/00014b43f902", // incunabula:page
-            p = ObjectAccessPermissionADM(forResource = Some("http://rdfh.ch/0803/00014b43f902"), forValue = None, hasPermissions = Set(
+            p = ObjectAccessPermissionADM(
+                forResource = Some("http://rdfh.ch/0803/00014b43f902"),
+                forValue = None,
+                hasPermissions = Set(
                                 PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
                                 PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
-                            ))
+                )
+            )
         )
 
     val perm003_o2: oap =
         oap(
             iri = "http://rdfh.ch/0803/00014b43f902/values/1ad3999ad60b", // knora-base:TextValue
-            p = ObjectAccessPermissionADM(forResource = None, forValue = Some("http://rdfh.ch/0803/00014b43f902/values/1ad3999ad60b"), hasPermissions = Set(
+            p = ObjectAccessPermissionADM(
+                forResource = None,
+                forValue = Some("http://rdfh.ch/0803/00014b43f902/values/1ad3999ad60b"),
+                hasPermissions = Set(
                                     PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.UnknownUser),
                                     PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
                                     PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                     PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator)
-                                ))
+                )
+            )
         )
 
     val perm003_d1: doap =
@@ -228,13 +275,22 @@ object SharedPermissionsTestData {
     val perm005_a1: ap =
         ap(
             iri = "http://rdfh.ch/permissions/0001/005-a1",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/0001/005-a1", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectMember, hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission))
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/0001/005-a1",
+                forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI,
+                forGroup = OntologyConstants.KnoraAdmin.ProjectMember,
+                hasPermissions = Set(PermissionADM.ProjectResourceCreateAllPermission)
+            )
         )
 
     val perm005_a2: ap =
         ap(
             iri = "http://rdfh.ch/permissions/0001/005-a2",
-            p = AdministrativePermissionADM(iri = "http://rdfh.ch/permissions/0001/005-a2", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin, hasPermissions = Set(
+            p = AdministrativePermissionADM(
+                iri = "http://rdfh.ch/permissions/0001/005-a2",
+                forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI,
+                forGroup = OntologyConstants.KnoraAdmin.ProjectAdmin,
+                hasPermissions = Set(
                                 PermissionADM.ProjectResourceCreateAllPermission,
                                 PermissionADM.ProjectAdminAllPermission
                             ))
@@ -243,15 +299,18 @@ object SharedPermissionsTestData {
     val perm005_d1: doap =
         doap(
             iri = "http://rdfh.ch/permissions/0001/005-d1",
-            p = DefaultObjectAccessPermissionADM(iri = "http://rdfh.ch/permissions/0001/005-d1", forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI, forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember), forResourceClass = None, forProperty = None, hasPermissions = Set(
+            p = DefaultObjectAccessPermissionADM(
+                iri = "http://rdfh.ch/permissions/0001/005-d1",
+                forProject = SharedTestDataV1.ANYTHING_PROJECT_IRI,
+                forGroup = Some(OntologyConstants.KnoraAdmin.ProjectMember),
+                forResourceClass = None,
+                forProperty = None,
+                hasPermissions = Set(
                                 PermissionADM.changeRightsPermission(OntologyConstants.KnoraAdmin.Creator),
                                 PermissionADM.modifyPermission(OntologyConstants.KnoraAdmin.ProjectMember),
                                 PermissionADM.viewPermission(OntologyConstants.KnoraAdmin.KnownUser),
                                 PermissionADM.restrictedViewPermission(OntologyConstants.KnoraAdmin.UnknownUser)
-                            ))
+                )
+            )
         )
-
-
-
-
 }


### PR DESCRIPTION
- [x] Add CREATE administrative permission + unit tests
- [x] Add CREATE default object access permission + unit tests
- [x] Add validation to messages
- [x] Add tests for thrown exceptions
- [x] Refactor existing tests for permission operations.
- [x] Refactor responders by moving validations to messages.
- [x] Add E2E tests for permission creation
- [x] Create `AdministrativeAccessPermission` and `DefaultObjectAccessPermission` with a custom IRI
- [x] Add test data

resolves [DSP-247](https://dasch.myjetbrains.com/youtrack/issue/DSP-247)
resolves [DSP-246](https://dasch.myjetbrains.com/youtrack/agiles/110-4/111-48?issue=DSP-246)
closes [issue #1495](https://github.com/dasch-swiss/knora-api/issues/1495)
closes [issue #370](https://github.com/dasch-swiss/knora-api/issues/370)