### PR TITLE
fix(api-v2): Fix generated SPARQL for updating property comment

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -3251,7 +3251,7 @@ class OntologyResponderV2(responderData: ResponderData) extends Responder(respon
                 maybeUnescapedNewLinkValuePropertyDef: Option[PropertyInfoContentV2] = maybeLoadedLinkValuePropertyDef.map {
                     loadedLinkValuePropertyDef =>
                         val unescapedNewLinkPropertyDef = maybeCurrentLinkValueReadPropertyInfo.get.entityInfoContent.copy(
-                            predicates = currentReadPropertyInfo.entityInfoContent.predicates + (changePropertyLabelsOrCommentsRequest.predicateToUpdate -> unescapedNewLabelOrCommentPredicate)
+                            predicates = maybeCurrentLinkValueReadPropertyInfo.get.entityInfoContent.predicates + (changePropertyLabelsOrCommentsRequest.predicateToUpdate -> unescapedNewLabelOrCommentPredicate)
                         )
 
                         if (loadedLinkValuePropertyDef != unescapedNewLinkPropertyDef) {

--- a/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -2851,6 +2851,38 @@ object SharedTestDataADM {
           """.stripMargin
     }
 
+    def addCommentToPropertyThatHasNoComment(anythingOntologyIri: IRI, anythingLastModDate: Instant): String = {
+        s"""{
+          |    "@id": "$anythingOntologyIri",
+          |    "@type": "owl:Ontology",
+          |    "knora-api:lastModificationDate": {
+          |        "@type": "xsd:dateTimeStamp",
+          |        "@value": "$anythingLastModDate"
+          |    },
+          |    "@graph": [
+          |        {
+          |            "@id": "anything:hasBlueThing",
+          |            "@type": "owl:ObjectProperty",
+          |            "rdfs:comment": [
+          |                {
+          |                    "@language": "en",
+          |                    "@value": "asdas asd as dasdasdas"
+          |                }
+          |            ]
+          |        }
+          |    ],
+          |    "@context": {
+          |        "anything": "http://0.0.0.0:3333/ontology/0001/anything/v2#",
+          |        "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+          |        "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+          |        "owl": "http://www.w3.org/2002/07/owl#",
+          |        "xsd": "http://www.w3.org/2001/XMLSchema#",
+          |        "knora-api": "http://api.knora.org/ontology/knora-api/v2#",
+          |        "salsah-gui": "http://api.knora.org/ontology/salsah-gui/v2#"
+          |    }
+          |}""".stripMargin
+    }
+
     object AThing {
         val iri: IRI = "http://rdfh.ch/0001/a-thing"
         val iriEncoded: String = URLEncoder.encode(iri, "UTF-8")

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
@@ -100,8 +100,9 @@ DELETE {
     USING <http://www.ontotext.com/explicit>
 }
 WHERE {
+    BIND(IRI("@ontologyNamedGraphIri") AS ?ontologyNamedGraph)
+
     GRAPH ?ontologyNamedGraph {
-        BIND(IRI("@ontologyNamedGraphIri") AS ?ontologyNamedGraph)
         BIND(IRI("@ontologyIri") AS ?ontology)
         BIND(IRI("@propertyIri") AS ?property)
 

--- a/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
+++ b/webapi/src/main/twirl/org/knora/webapi/messages/twirl/queries/sparql/v2/changePropertyLabelsOrComments.scala.txt
@@ -100,11 +100,11 @@ DELETE {
     USING <http://www.ontotext.com/explicit>
 }
 WHERE {
-    BIND(IRI("@ontologyNamedGraphIri") AS ?ontologyNamedGraph)
-    BIND(IRI("@ontologyIri") AS ?ontology)
-    BIND(IRI("@propertyIri") AS ?property)
-
     GRAPH ?ontologyNamedGraph {
+        BIND(IRI("@ontologyNamedGraphIri") AS ?ontologyNamedGraph)
+        BIND(IRI("@ontologyIri") AS ?ontology)
+        BIND(IRI("@propertyIri") AS ?property)
+
         ?ontology rdf:type owl:Ontology ;
             knora-base:lastModificationDate "@lastModificationDate"^^xsd:dateTime .
 

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/OntologyV2R2RSpec.scala
@@ -162,7 +162,6 @@ class OntologyV2R2RSpec extends R2RSpec {
     private val fooIri = new MutableTestIri
     private var fooLastModDate: Instant = Instant.now
 
-    private val AnythingOntologyIri = "http://0.0.0.0:3333/ontology/0001/anything/v2".toSmartIri
     private var anythingLastModDate: Instant = Instant.parse("2017-12-19T15:23:42.166Z")
 
     private val uselessIri = new MutableTestIri
@@ -312,7 +311,7 @@ class OntologyV2R2RSpec extends R2RSpec {
             }
         }
 
-        "change the labels of a property" in {
+        "change the rdfs:label of a property" in {
             val params = SharedTestDataADM.changePropertyLabel(SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost, anythingLastModDate)
 
             // Convert the submitted JSON-LD to an InputOntologyV2, without SPARQL-escaping, so we can compare it to the response.
@@ -324,7 +323,7 @@ class OntologyV2R2RSpec extends R2RSpec {
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
                 val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
-                responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates.head._2.objects)
+                responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Label.toSmartIri).objects)
 
                 // Check that the ontology's last modification date was updated.
                 val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
@@ -333,7 +332,7 @@ class OntologyV2R2RSpec extends R2RSpec {
             }
         }
 
-        "change the comments of a property" in {
+        "change the rdfs:comment of a property" in {
             val params = SharedTestDataADM.changePropertyComment(SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost, anythingLastModDate)
 
             // Convert the submitted JSON-LD to an InputOntologyV2, without SPARQL-escaping, so we can compare it to the response.
@@ -345,7 +344,28 @@ class OntologyV2R2RSpec extends R2RSpec {
 
                 // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
                 val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
-                responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates.head._2.objects)
+                responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects)
+
+                // Check that the ontology's last modification date was updated.
+                val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get
+                assert(newAnythingLastModDate.isAfter(anythingLastModDate))
+                anythingLastModDate = newAnythingLastModDate
+            }
+        }
+
+        "add an rdfs:comment to a link property that has no rdfs:comment" in {
+            val params = SharedTestDataADM.addCommentToPropertyThatHasNoComment(SharedOntologyTestDataADM.ANYTHING_ONTOLOGY_IRI_LocalHost, anythingLastModDate)
+
+            // Convert the submitted JSON-LD to an InputOntologyV2, without SPARQL-escaping, so we can compare it to the response.
+            val paramsAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(JsonLDUtil.parseJsonLD(params)).unescape
+
+            Put("/v2/ontologies/properties", HttpEntity(RdfMediaTypes.`application/ld+json`, params)) ~> addCredentials(BasicHttpCredentials(anythingUsername, password)) ~> ontologiesPath ~> check {
+                assert(status == StatusCodes.OK, response.toString)
+                val responseJsonDoc = responseToJsonLDDocument(response)
+
+                // Convert the response to an InputOntologyV2 and compare the relevant part of it to the request.
+                val responseAsInput: InputOntologyV2 = InputOntologyV2.fromJsonLD(responseJsonDoc, parsingMode = TestResponseParsingModeV2).unescape
+                responseAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects should ===(paramsAsInput.properties.head._2.predicates(OntologyConstants.Rdfs.Comment.toSmartIri).objects)
 
                 // Check that the ontology's last modification date was updated.
                 val newAnythingLastModDate = responseAsInput.ontologyMetadata.lastModificationDate.get


### PR DESCRIPTION
https://dasch.myjetbrains.com/youtrack/issue/DSP-561

- [x] In the `WHERE` clause of `changePropertyLabelsOrComments.scala.txt`, move `BIND` statements inside the `GRAPH` block, so that the `WHERE` clause will return results even if the property doesn't have an `rdfs:comment`. **TODO: ask the Jena developers why this makes a difference.**
- [x] Fix a bug in `OntologyResponderV2.changePropertyLabelsOrComments` which would incorrectly compare a saved link value property with the expected result.
- [x] Add a test for adding an `rdfs:comment` to a link property that doesn't have one.
