### PR TITLE
refactor(gravsearch): Clarify optimisations

### DIFF
--- a/docs/05-internals/design/api-v2/gravsearch.md
+++ b/docs/05-internals/design/api-v2/gravsearch.md
@@ -155,8 +155,9 @@ If the client submits a count query, the prequery returns the overall number of 
 In a first step, before transforming the WHERE clause, query patterns must be further optimised by removing
 the `rdfs:type` statement for entities whose type could be inferred from a property since there would be no need 
 for explicit `rdfs:type` statements for them (unless the property from which the type of an entity must be inferred from 
-is wrapped in an `OPTIONAL` block). This optimisation has to happen in advance, because 
-otherwise `transformStatementInWhere` would expand the redundant `rdfs:type` statements.
+is wrapped in an `OPTIONAL` block). This optimisation takes the Gravsearch query as input (rather than the generated SPARQL),
+because it uses type information that refers to entities in the Gravsearch query, and the generated SPARQL might
+have different entities.
 
 Next, the Gravsearch query's WHERE clause is transformed and the prequery (SELECT and WHERE clause) is generated from this result.
 The transformation of the Gravsearch query's WHERE clause relies on the implementation of the abstract class `AbstractPrequeryGenerator`.
@@ -325,3 +326,9 @@ efficient. If Knora is not using the triplestore's inference,
 
 `SparqlTransformer.transformStatementInWhereForNoInference` replaces `knora-api:standoffTagHasStartAncestor`
 with `knora-base:standoffTagHasStartParent*`.
+
+# Optimisation of generated SPARQL
+
+The triplestore-specific transformers in `SparqlTransformer.scala` can run optimisations on the generated SPARQL, in
+the method `optimiseQueryPatterns` inherited from `WhereTransformer`. For example, `moveLuceneToBeginning` moves
+Lucene queries to the beginning of the block in which they occur.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
@@ -45,14 +45,12 @@ trait WhereVisitor[Acc] {
 }
 
 /**
- * A trait for classes that transform statements and filters in WHERE clauses. Such a class will probably need
- * to refer to a [[GravsearchTypeInspectionResult]].
+ * A trait for classes that transform statements and filters in WHERE clauses.
  */
 trait WhereTransformer {
     /**
-     * Optimises the entity type statments and order of query patterns. Does not recurse. It
-     * has to be called before transformStatementInWhere, because optimisation might remove statements that
-     * would otherwise be expanded by transformStatementInWhere
+     * Optimises query patterns. Does not recurse. Must be called before `transformStatementInWhere`,
+     * because optimisation might remove statements that would otherwise be expanded by `transformStatementInWhere`.
      *
      * @param patterns the query patterns to be optimised.
      * @return the optimised query patterns.

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlTransformer.scala
@@ -25,7 +25,7 @@ import org.knora.webapi.messages.IriConversions._
 import org.knora.webapi.messages.{OntologyConstants, SmartIri, StringFormatter}
 
 /**
- * Methods and classes for Sparql transformation.
+ * Methods and classes for transforming generated SPARQL.
  */
 object SparqlTransformer {
 
@@ -61,8 +61,7 @@ object SparqlTransformer {
         override def transformFilter(filterPattern: FilterPattern): Seq[QueryPattern] = Seq(filterPattern)
 
         override def optimiseQueryPatterns(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-            val luceneFirst = moveLuceneToBeginning(patterns)
-            moveIsDeletedToEnd(luceneFirst)
+            moveIsDeletedToEnd(moveLuceneToBeginning(patterns))
         }
 
         override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] =
@@ -101,8 +100,7 @@ object SparqlTransformer {
         override def transformFilter(filterPattern: FilterPattern): Seq[QueryPattern] = Seq(filterPattern)
 
         override def optimiseQueryPatterns(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-            val luceneFirst: Seq[QueryPattern] = moveLuceneToBeginning(patterns)
-            moveIsDeletedToEnd(luceneFirst)
+            moveIsDeletedToEnd(moveLuceneToBeginning(patterns))
         }
 
         override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] =
@@ -204,7 +202,7 @@ object SparqlTransformer {
      */
     def moveLuceneToBeginning(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
         val (luceneQueryPatterns: Seq[QueryPattern], otherPatterns: Seq[QueryPattern]) = patterns.partition {
-            case luceneQueryPattern: LuceneQueryPattern => true
+            case _: LuceneQueryPattern => true
             case _ => false
         }
 

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -1712,10 +1712,10 @@ abstract class AbstractPrequeryGenerator(constructClause: ConstructClause,
 
         // remove statements whose predicate is rdf:type, type of subject is inferred from a property, and the subject is not in optionalEntities.
         val optimisedPatterns = patterns.filter {
-            case stamentPattern: StatementPattern =>
-                stamentPattern.pred match {
+            case statementPattern: StatementPattern =>
+                statementPattern.pred match {
                     case iriRef: IriRef =>
-                        val subject = GravsearchTypeInspectionUtil.maybeTypeableEntity(stamentPattern.subj)
+                        val subject = GravsearchTypeInspectionUtil.maybeTypeableEntity(statementPattern.subj)
                         subject match {
                             case Some(typeableEntity) =>
                                 !(iriRef.iri.toString == OntologyConstants.Rdf.Type && typeInspectionResult.entitiesInferredFromProperties.keySet.contains(typeableEntity)

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToPrequeryTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToPrequeryTransformer.scala
@@ -379,8 +379,14 @@ class NonTriplestoreSpecificGravsearchToPrequeryTransformer(constructClause: Con
 
     override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] = Seq(luceneQueryPattern)
 
+    /**
+     * Runs optimisations that take a Gravsearch query as input. An optimisation needs to be run here if
+     * it uses the type inspection result that refers to the Gravsearch query.
+     *
+     * @param patterns the query patterns to be optimised.
+     * @return the optimised query patterns.
+     */
     override def optimiseQueryPatterns(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-        val noTypePatterns = removeEntitiesInferredFromProperty(patterns)
-        moveLuceneToBeginning(noTypePatterns)
+        removeEntitiesInferredFromProperty(patterns)
     }
 }


### PR DESCRIPTION
https://dasch.myjetbrains.com/youtrack/issue/DSP-567

- [x] Run Lucene optimisation only in triplestore-specific transformers.
- [x] Clarify why some optimisations work on Gravsearch queries and others work on generated SPARQL.
- [x] Fix some typos.