### PR TITLE
feat(api-v2): Make inference optional in Gravsearch

### DIFF
--- a/docs/03-apis/api-v2/query-language.md
+++ b/docs/03-apis/api-v2/query-language.md
@@ -212,6 +212,16 @@ also match subproperties of that property, and if a statement specifies that
 a subject has a particular `rdf:type`, the statement will also match subjects
 belonging to subclasses of that type.
 
+If you know that reasoning will not return any additional results for
+your query, you can disable it by adding this line to the `WHERE` clause:
+
+```sparql
+knora-api:GravsearchOptions knora-api:useInference false .
+```
+
+If Knora is implementing reasoning by query expansion, disabling it can
+improve the performance of some queries.
+
 ## Gravsearch Syntax
 
 Every Gravsearch query is a valid SPARQL 1.1

--- a/docs/05-internals/design/api-v2/gravsearch.md
+++ b/docs/05-internals/design/api-v2/gravsearch.md
@@ -315,7 +315,7 @@ When the triplestore-specific version of the query is generated:
   for text searches.
 
 - If Knora is not using the triplestore's inference (e.g. with Fuseki),
-  `SparqlTransformer.expandStatementForNoInference` removes `<http://www.knora.org/explicit>`, and expands unmarked
+  `SparqlTransformer.transformStatementInWhereForNoInference` removes `<http://www.knora.org/explicit>`, and expands unmarked
   statements using `rdfs:subClassOf*` and `rdfs:subPropertyOf*`.
 
 Gravsearch also provides some virtual properties, which take advantage of forward-chaining inference

--- a/docs/05-internals/design/api-v2/gravsearch.md
+++ b/docs/05-internals/design/api-v2/gravsearch.md
@@ -322,10 +322,8 @@ Gravsearch also provides some virtual properties, which take advantage of forwar
 as an optimisation if the triplestore provides it. For example, the virtual property
 `knora-api:standoffTagHasStartAncestor` is equivalent to `knora-base:standoffTagHasStartParent*`, but
 with GraphDB it is implemented using a custom inference rule (in `KnoraRules.pie`) and is therefore more
-efficient. If Knora is not using the triplestore's inference,
-
-`SparqlTransformer.transformStatementInWhereForNoInference` replaces `knora-api:standoffTagHasStartAncestor`
-with `knora-base:standoffTagHasStartParent*`.
+efficient. If Knora is not using the triplestore's inference, `SparqlTransformer.transformStatementInWhereForNoInference`
+replaces `knora-api:standoffTagHasStartAncestor` with `knora-base:standoffTagHasStartParent*`.
 
 # Optimisation of generated SPARQL
 

--- a/webapi/scripts/fuseki-dump-repository.sh
+++ b/webapi/scripts/fuseki-dump-repository.sh
@@ -50,7 +50,7 @@ if [[ -z "${PASSWORD}" ]]; then
 fi
 
 if [[ -z "${HOST}" ]]; then
-    HOST="localhost:8080"
+    HOST="localhost:3030"
 fi
 
 curl -sS -X GET -H "Accept: application/trig" -u "${USERNAME}:${PASSWORD}" "http://${HOST}/${REPOSITORY}" > "${FILE}"

--- a/webapi/scripts/fuseki-upload-repository.sh
+++ b/webapi/scripts/fuseki-upload-repository.sh
@@ -50,7 +50,7 @@ if [[ -z "${PASSWORD}" ]]; then
 fi
 
 if [[ -z "${HOST}" ]]; then
-    HOST="localhost:8080"
+    HOST="localhost:3030"
 fi
 
 curl -sS -X POST -H "Content-Type: application/trig" --data-binary "@${FILE}" -u "${USERNAME}:${PASSWORD}" "http://${HOST}/${REPOSITORY}" | tee /dev/null

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -656,13 +656,28 @@ object OntologyConstants {
         val KnoraApiPrefix: String = KnoraApiOntologyLabel + ":"
 
         /**
-         * Returns `true` if the specified IRI is `knora-api:Resource` in Knora API v2, in the simple
-         * or complex schema.
+         * The IRIs representing `knora-api:Resource` in Knora API v2, in the simple and complex schemas.
          */
-        def isKnoraApiV2Resource(iri: SmartIri): Boolean = {
-            val iriStr = iri.toString
-            iriStr == OntologyConstants.KnoraApiV2Simple.Resource || iriStr == OntologyConstants.KnoraApiV2Complex.Resource
-        }
+        val KnoraApiV2ResourceIris: Set[IRI] = Set(
+            OntologyConstants.KnoraApiV2Simple.Resource,
+            OntologyConstants.KnoraApiV2Complex.Resource
+        )
+
+        /**
+         * The IRIs representing `knora-api:GravsearchOptions` in Knora API v2, in the simple and complex schemas.
+         */
+        val GravsearchOptionsIris: Set[IRI] = Set(
+            OntologyConstants.KnoraApiV2Simple.GravsearchOptions,
+            OntologyConstants.KnoraApiV2Complex.GravsearchOptions
+        )
+
+        /**
+         * The IRIs representing `knora-api:useInference` in Knora API v2, in the simple and complex schemas.
+         */
+        val UseInferenceIris: Set[IRI] = Set(
+            OntologyConstants.KnoraApiV2Simple.UseInference,
+            OntologyConstants.KnoraApiV2Complex.UseInference
+        )
 
         /**
          * Returns the IRI of `knora-api:subjectType` in the specified schema.
@@ -926,6 +941,9 @@ object OntologyConstants {
         val MatchTextInStandoffFunction: IRI = KnoraApiV2PrefixExpansion + "matchTextInStandoff"
         val MatchLabelFunction: IRI = KnoraApiV2PrefixExpansion + "matchLabel"
         val StandoffLinkFunction: IRI = KnoraApiV2PrefixExpansion + "standoffLink"
+
+        val GravsearchOptions: IRI = KnoraApiV2PrefixExpansion + "GravsearchOptions"
+        val UseInference: IRI = KnoraApiV2PrefixExpansion + "useInference"
     }
 
     object SalsahGuiApiV2WithValueObjects {
@@ -1027,6 +1045,9 @@ object OntologyConstants {
 
         val ArkUrl: IRI = KnoraApiV2PrefixExpansion + "arkUrl"
         val VersionArkUrl: IRI = KnoraApiV2PrefixExpansion + "versionArkUrl"
+
+        val GravsearchOptions: IRI = KnoraApiV2PrefixExpansion + "GravsearchOptions"
+        val UseInference: IRI = KnoraApiV2PrefixExpansion + "useInference"
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/OntologyConstants.scala
@@ -658,7 +658,7 @@ object OntologyConstants {
         /**
          * The IRIs representing `knora-api:Resource` in Knora API v2, in the simple and complex schemas.
          */
-        val KnoraApiV2ResourceIris: Set[IRI] = Set(
+        lazy val KnoraApiV2ResourceIris: Set[IRI] = Set(
             OntologyConstants.KnoraApiV2Simple.Resource,
             OntologyConstants.KnoraApiV2Complex.Resource
         )
@@ -666,7 +666,7 @@ object OntologyConstants {
         /**
          * The IRIs representing `knora-api:GravsearchOptions` in Knora API v2, in the simple and complex schemas.
          */
-        val GravsearchOptionsIris: Set[IRI] = Set(
+        lazy val GravsearchOptionsIris: Set[IRI] = Set(
             OntologyConstants.KnoraApiV2Simple.GravsearchOptions,
             OntologyConstants.KnoraApiV2Complex.GravsearchOptions
         )
@@ -674,7 +674,7 @@ object OntologyConstants {
         /**
          * The IRIs representing `knora-api:useInference` in Knora API v2, in the simple and complex schemas.
          */
-        val UseInferenceIris: Set[IRI] = Set(
+        lazy val UseInferenceIris: Set[IRI] = Set(
             OntologyConstants.KnoraApiV2Simple.UseInference,
             OntologyConstants.KnoraApiV2Complex.UseInference
         )

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/QueryTraverser.scala
@@ -95,6 +95,13 @@ trait SelectToSelectTransformer extends WhereTransformer {
      * @return the result of the transformation.
      */
     def transformStatementInSelect(statementPattern: StatementPattern): Seq[StatementPattern]
+
+    /**
+     * Specifies a FROM clause, if needed.
+     *
+     * @return the FROM clause to be used, if any.
+     */
+    def getFromClause: Option[FromClause]
 }
 
 /**
@@ -189,7 +196,7 @@ object QueryTraverser {
         // remove statements that would otherwise be expanded by transformStatementInWhere
         val optimisedPatterns = whereTransformer.optimiseQueryPatterns(patterns)
 
-         optimisedPatterns.flatMap {
+        optimisedPatterns.flatMap {
             case statementPattern: StatementPattern =>
                 whereTransformer.transformStatementInWhere(
                     statementPattern = statementPattern,
@@ -338,6 +345,7 @@ object QueryTraverser {
 
     def transformSelectToSelect(inputQuery: SelectQuery, transformer: SelectToSelectTransformer): SelectQuery = {
         inputQuery.copy(
+            fromClause = transformer.getFromClause,
             whereClause = WhereClause(
                 patterns = transformWherePatterns(
                     patterns = inputQuery.whereClause.patterns,

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlQuery.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlQuery.scala
@@ -576,10 +576,10 @@ case class OrderCriterion(queryVariable: QueryVariable, isAscending: Boolean) ex
 /**
  * Represents a FROM clause.
  *
- * @param namedGraph the named graph to be used in the query.
+ * @param defaultGraph the graph to be used as the default graph in the query.
  */
-case class FromClause(namedGraph: IriRef) extends SparqlGenerator {
-    override def toSparql: String = s"FROM ${namedGraph.toSparql}\n"
+case class FromClause(defaultGraph: IriRef) extends SparqlGenerator {
+    override def toSparql: String = s"FROM ${defaultGraph.toSparql}\n"
 }
 
 /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/SparqlTransformer.scala
@@ -50,7 +50,7 @@ object SparqlTransformer {
         override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] =
             transformLuceneQueryPatternForGraphDB(luceneQueryPattern)
 
-        def getFromClause: Option[FromClause] = {
+        override def getFromClause: Option[FromClause] = {
             if (useInference) {
                 None
             } else {
@@ -82,7 +82,7 @@ object SparqlTransformer {
         override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] =
             transformLuceneQueryPatternForFuseki(luceneQueryPattern)
 
-        def getFromClause: Option[FromClause] = None
+        override def getFromClause: Option[FromClause] = None
     }
 
     /**
@@ -103,8 +103,6 @@ object SparqlTransformer {
 
         override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] =
             transformLuceneQueryPatternForGraphDB(luceneQueryPattern)
-
-        def addFromClause: Option[FromClause] = None
     }
 
     /**
@@ -126,8 +124,6 @@ object SparqlTransformer {
 
         override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] =
             transformLuceneQueryPatternForFuseki(luceneQueryPattern)
-
-        def addFromClause: Option[FromClause] = None
     }
 
     /**

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/AbstractPrequeryGenerator.scala
@@ -72,6 +72,9 @@ abstract class AbstractPrequeryGenerator(constructClause: ConstructClause,
     // variables the represent resource metadata
     private val resourceMetadataVariables = mutable.Set.empty[QueryVariable]
 
+    // The query can set this to false to disable inference.
+    var useInference = true
+
     /**
      * Saves a generated variable representing a value literal, if it hasn't been saved already.
      *
@@ -417,36 +420,63 @@ abstract class AbstractPrequeryGenerator(constructClause: ConstructClause,
         }
     }
 
+    /**
+     * Processes Gravsearch options.
+     *
+     * @param statementPattern the statement specifying the option to be set.
+     */
+    private def processGravsearchOption(statementPattern: StatementPattern): Unit = {
+        statementPattern.pred match {
+            case iriRef: IriRef if OntologyConstants.KnoraApi.UseInferenceIris.contains(iriRef.iri.toString) =>
+                useInference = statementPattern.obj match {
+                    case xsdLiteral: XsdLiteral if xsdLiteral.datatype.toString == OntologyConstants.Xsd.Boolean =>
+                        xsdLiteral.value.toBoolean
+
+                    case other => throw GravsearchException(s"Invalid object for knora-api:useInference: ${other.toSparql}")
+                }
+
+            case other => throw GravsearchException(s"Invalid predicate for knora-api:GravsearchOptions: ${other.toSparql}")
+        }
+    }
+
     protected def processStatementPatternFromWhereClause(statementPattern: StatementPattern, inputOrderBy: Seq[OrderCriterion]): Seq[QueryPattern] = {
 
-        // look at the statement's subject, predicate, and object and generate additional statements if needed based on the given type information.
-        // transform the originally given statement if necessary when processing the predicate
+        // Does this statement set a Gravsearch option?
+        statementPattern.subj match {
+            case iriRef: IriRef if OntologyConstants.KnoraApi.GravsearchOptionsIris.contains(iriRef.iri.toString) =>
+                // Yes. Process the option.
+                processGravsearchOption(statementPattern)
+                Seq.empty[QueryPattern]
 
-        // check if there exists type information for the given statement's subject
-        val additionalStatementsForSubj: Seq[QueryPattern] = checkForNonPropertyTypeInfoForEntity(
-            entity = statementPattern.subj,
-            typeInspectionResult = typeInspectionResult,
-            processedTypeInfo = processedTypeInformationKeysWhereClause,
-            conversionFuncForNonPropertyType = createAdditionalStatementsForNonPropertyType
-        )
+            case _ =>
+                // No. look at the statement's subject, predicate, and object and generate additional statements if needed based on the given type information.
+                // transform the originally given statement if necessary when processing the predicate
 
-        // check if there exists type information for the given statement's object
-        val additionalStatementsForObj: Seq[QueryPattern] = checkForNonPropertyTypeInfoForEntity(
-            entity = statementPattern.obj,
-            typeInspectionResult = typeInspectionResult,
-            processedTypeInfo = processedTypeInformationKeysWhereClause,
-            conversionFuncForNonPropertyType = createAdditionalStatementsForNonPropertyType
-        )
+                // check if there exists type information for the given statement's subject
+                val additionalStatementsForSubj: Seq[QueryPattern] = checkForNonPropertyTypeInfoForEntity(
+                    entity = statementPattern.subj,
+                    typeInspectionResult = typeInspectionResult,
+                    processedTypeInfo = processedTypeInformationKeysWhereClause,
+                    conversionFuncForNonPropertyType = createAdditionalStatementsForNonPropertyType
+                )
 
-        // Add additional statements based on the whole input statement, e.g. to deal with the value object or the link value, and transform the original statement.
-        val additionalStatementsForWholeStatement: Seq[QueryPattern] = checkForPropertyTypeInfoForStatement(
-            statementPattern = statementPattern,
-            typeInspectionResult = typeInspectionResult,
-            conversionFuncForPropertyType = convertStatementForPropertyType(inputOrderBy)
-        )
+                // check if there exists type information for the given statement's object
+                val additionalStatementsForObj: Seq[QueryPattern] = checkForNonPropertyTypeInfoForEntity(
+                    entity = statementPattern.obj,
+                    typeInspectionResult = typeInspectionResult,
+                    processedTypeInfo = processedTypeInformationKeysWhereClause,
+                    conversionFuncForNonPropertyType = createAdditionalStatementsForNonPropertyType
+                )
 
-        additionalStatementsForSubj ++ additionalStatementsForWholeStatement ++ additionalStatementsForObj
+                // Add additional statements based on the whole input statement, e.g. to deal with the value object or the link value, and transform the original statement.
+                val additionalStatementsForWholeStatement: Seq[QueryPattern] = checkForPropertyTypeInfoForStatement(
+                    statementPattern = statementPattern,
+                    typeInspectionResult = typeInspectionResult,
+                    conversionFuncForPropertyType = convertStatementForPropertyType(inputOrderBy)
+                )
 
+                additionalStatementsForSubj ++ additionalStatementsForWholeStatement ++ additionalStatementsForObj
+        }
     }
 
     /**
@@ -579,7 +609,7 @@ abstract class AbstractPrequeryGenerator(constructClause: ConstructClause,
 
         // check if the objectTypeIri of propInfo is knora-api:Resource
         // if so, it is a linking property and its link value property must be restricted too
-        if (OntologyConstants.KnoraApi.isKnoraApiV2Resource(propInfo.objectTypeIri)) {
+        if (propInfo.objectIsResourceType) {
             // it is a linking property, restrict the link value property
             val restrictionForLinkValueProp = CompareExpression(
                 leftArg = createLinkValuePropertyVariableFromLinkingPropertyVariable(queryVar), // the same variable was created during statement processing in WHERE clause in `convertStatementForPropertyType`

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToCountPrequeryTransformer.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/prequery/NonTriplestoreSpecificGravsearchToCountPrequeryTransformer.scala
@@ -86,10 +86,8 @@ class NonTriplestoreSpecificGravsearchToCountPrequeryTransformer(constructClause
     }
 
     override def optimiseQueryPatterns(patterns: Seq[QueryPattern]): Seq[QueryPattern] = {
-        val noTypePatterns = removeEntitiesInferredFromProperty(patterns)
-        moveLuceneToBeginning(noTypePatterns)
+        removeEntitiesInferredFromProperty(patterns)
     }
 
     override def transformLuceneQueryPattern(luceneQueryPattern: LuceneQueryPattern): Seq[QueryPattern] = Seq(luceneQueryPattern)
-
 }

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/AnnotationReadingGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/AnnotationReadingGravsearchTypeInspector.scala
@@ -77,13 +77,12 @@ class AnnotationReadingGravsearchTypeInspector(nextInspector: Option[GravsearchT
                 case (acc: IntermediateTypeInspectionResult, typeAnnotation: GravsearchTypeAnnotation) =>
                     typeAnnotation.annotationProp match {
                         case TypeAnnotationProperties.RdfType =>
-
-                            val isResource = OntologyConstants.KnoraApi.isKnoraApiV2Resource(typeAnnotation.typeIri)
+                            val isResource = OntologyConstants.KnoraApi.KnoraApiV2ResourceIris.contains(typeAnnotation.typeIri.toString)
                             val isValue = GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(typeAnnotation.typeIri.toString)
                             acc.addTypes(typeAnnotation.typeableEntity, Set(NonPropertyTypeInfo(typeAnnotation.typeIri, isResourceType = isResource, isValueType = isValue)))
 
                         case TypeAnnotationProperties.ObjectType =>
-                            val isResource = OntologyConstants.KnoraApi.isKnoraApiV2Resource(typeAnnotation.typeIri)
+                            val isResource = OntologyConstants.KnoraApi.KnoraApiV2ResourceIris.contains(typeAnnotation.typeIri.toString)
                             val isValue = GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(typeAnnotation.typeIri.toString)
                             acc.addTypes(typeAnnotation.typeableEntity, Set(PropertyTypeInfo(typeAnnotation.typeIri, objectIsResourceType = isResource, objectIsValueType = isValue)))
                     }

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectionUtil.scala
@@ -113,9 +113,21 @@ object GravsearchTypeInspectionUtil {
     )
 
     /**
+     * IRIs that are used to set Gravsearch options.
+     */
+    val GravsearchOptionIris: Set[IRI] = Set(
+        OntologyConstants.KnoraApiV2Simple.GravsearchOptions,
+        OntologyConstants.KnoraApiV2Complex.GravsearchOptions,
+        OntologyConstants.KnoraApiV2Simple.UseInference,
+        OntologyConstants.KnoraApiV2Complex.UseInference
+    )
+
+    /**
      * IRIs that do not need to be annotated to specify their types.
      */
-    val ApiV2NonTypeableIris: Set[IRI] = GravsearchAnnotationTypeIris ++ TypeAnnotationProperties.allTypeAnnotationIris
+    val ApiV2NonTypeableIris: Set[IRI] = GravsearchAnnotationTypeIris ++
+        TypeAnnotationProperties.allTypeAnnotationIris ++
+        GravsearchOptionIris
 
     /**
      * Given a Gravsearch entity that is known to need type information, converts it to a [[TypeableEntity]].

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -1094,9 +1094,12 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                 case _ => None
             })
 
-            // If the statement's predicate is a Knora property, and isn't a type annotation predicate, add it to the set of Knora property IRIs.
+            // If the statement's predicate is a Knora property, and isn't a type annotation predicate or a Gravsearch option predicate,
+            // add it to the set of Knora property IRIs.
             val knoraPropertyIris: Set[SmartIri] = acc.knoraPropertyIris ++ (statementPattern.pred match {
-                case IriRef(predIri, _) if predIri.isKnoraEntityIri && !GravsearchTypeInspectionUtil.TypeAnnotationProperties.allTypeAnnotationIris.contains(predIri.toString) =>
+                case IriRef(predIri, _) if predIri.isKnoraEntityIri &&
+                    !(GravsearchTypeInspectionUtil.TypeAnnotationProperties.allTypeAnnotationIris.contains(predIri.toString) ||
+                        GravsearchTypeInspectionUtil.GravsearchOptionIris.contains(predIri.toString)) =>
                     Some(predIri)
 
                 case _ => None

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/SearchResponderV2.scala
@@ -74,7 +74,11 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
      * @param requestingUser       the the client making the request.
      * @return a [[ResourceCountV2]] representing the number of resources that have been found.
      */
-    private def fulltextSearchCountV2(searchValue: String, limitToProject: Option[IRI], limitToResourceClass: Option[SmartIri], limitToStandoffClass: Option[SmartIri], requestingUser: UserADM): Future[ResourceCountV2] = {
+    private def fulltextSearchCountV2(searchValue: String,
+                                      limitToProject: Option[IRI],
+                                      limitToResourceClass: Option[SmartIri],
+                                      limitToStandoffClass: Option[SmartIri],
+                                      requestingUser: UserADM): Future[ResourceCountV2] = {
 
         val searchTerms: LuceneQueryString = LuceneQueryString(searchValue)
 
@@ -298,17 +302,21 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
             )
 
             // Convert the non-triplestore-specific query to a triplestore-specific one.
+
             triplestoreSpecificQueryPatternTransformerSelect: SelectToSelectTransformer = {
                 if (settings.triplestoreType.startsWith("graphdb")) {
                     // GraphDB
-                    new SparqlTransformer.GraphDBSelectToSelectTransformer
+                    new SparqlTransformer.GraphDBSelectToSelectTransformer(
+                        useInference = nonTriplestoreSpecificConstructToSelectTransformer.useInference
+                    )
                 } else {
                     // Other
-                    new SparqlTransformer.NoInferenceSelectToSelectTransformer
+                    new SparqlTransformer.NoInferenceSelectToSelectTransformer(
+                        simulateInference = nonTriplestoreSpecificConstructToSelectTransformer.useInference
+                    )
                 }
             }
 
-            // Convert the preprocessed query to a non-triplestore-specific query.
             triplestoreSpecificCountQuery = QueryTraverser.transformSelectToSelect(
                 inputQuery = nonTriplestoreSpecficPrequery,
                 transformer = triplestoreSpecificQueryPatternTransformerSelect
@@ -381,10 +389,14 @@ class SearchResponderV2(responderData: ResponderData) extends ResponderWithStand
             triplestoreSpecificQueryPatternTransformerSelect: SelectToSelectTransformer = {
                 if (settings.triplestoreType.startsWith("graphdb")) {
                     // GraphDB
-                    new SparqlTransformer.GraphDBSelectToSelectTransformer
+                    new SparqlTransformer.GraphDBSelectToSelectTransformer(
+                        useInference = nonTriplestoreSpecificConstructToSelectTransformer.useInference
+                    )
                 } else {
                     // Other
-                    new SparqlTransformer.NoInferenceSelectToSelectTransformer
+                    new SparqlTransformer.NoInferenceSelectToSelectTransformer(
+                        simulateInference = nonTriplestoreSpecificConstructToSelectTransformer.useInference
+                    )
                 }
             }
 

--- a/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/v2/OntologiesRouteV2.scala
@@ -95,7 +95,7 @@ class OntologiesRouteV2(routeData: KnoraRouteData) extends KnoraRoute(routeData)
 
                 val params: Map[String, String] = requestContext.request.uri.query().toMap
                 val allLanguagesStr = params.get(ALL_LANGUAGES)
-                val allLanguages = stringFormatter.optionStringToBoolean(params.get(ALL_LANGUAGES), throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
+                val allLanguages = stringFormatter.optionStringToBoolean(allLanguagesStr, throw BadRequestException(s"Invalid boolean for $ALL_LANGUAGES: $allLanguagesStr"))
 
                 val requestMessageFuture: Future[OntologyEntitiesGetRequestV2] = for {
                     requestingUser <- getUserADM(requestContext)

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -6397,6 +6397,29 @@ class SearchRouteV2R2RSpec extends R2RSpec {
 
         }
 
+        "search for an anything:Thing that has a decimal value of 2.1 (submitting the complex schema), without inference" in {
+            val gravsearchQuery =
+                """PREFIX anything: <http://0.0.0.0:3333/ontology/0001/anything/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?thing knora-api:isMainResource true .
+                  |    ?thing anything:hasDecimal ?decimal .
+                  |} WHERE {
+                  |    knora-api:GravsearchOptions knora-api:useInference false .
+                  |    ?thing a anything:Thing .
+                  |    ?thing anything:hasDecimal ?decimal .
+                  |    ?decimal knora-api:decimalValueAsDecimal "2.1"^^xsd:decimal .
+                  |}""".stripMargin
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
+                assert(status == StatusCodes.OK, response.toString)
+                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("test_data/searchR2RV2/ThingEqualsDecimal.jsonld"), writeTestDataFiles)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
+                checkSearchResponseNumberOfResults(responseAs[String], 1)
+            }
+        }
+
         "search for an anything:Thing that has a decimal value bigger than 2.0 (submitting the complex schema)" in {
             val gravsearchQuery =
                 """

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
@@ -593,7 +593,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         TypeableVariable(variableName = "label") -> NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri, isValueType = true)
     ))
 
-    val queryWithReduntentTypes: String =
+    val QueryWithRedundantTypes: String =
         """
           |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
           |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
@@ -616,23 +616,23 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
           |} ORDER BY ?date
         """.stripMargin
 
-        val queryWithInconsistentTypes =
-            """
-              |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
-              |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
-              |
-              |CONSTRUCT {
-              |  ?person knora-api:isMainResource true .
-              |  ?document beol:hasAuthor ?person .
-              |} WHERE {
-              |  ?person a knora-api:Resource .
-              |  ?person a beol:person .
-              |
-              |  ?document beol:hasAuthor ?person .
-              |  beol:hasAuthor knora-api:objectType knora-api:Resource .
-              |  ?document a knora-api:Resource .
-              |  { ?document a beol:manuscript . } UNION { ?document a beol:letter .}
-              |}
+    val QueryWithInconsistentTypes3: String =
+        """
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+          |
+          |CONSTRUCT {
+          |  ?person knora-api:isMainResource true .
+          |  ?document beol:hasAuthor ?person .
+          |} WHERE {
+          |  ?person a knora-api:Resource .
+          |  ?person a beol:person .
+          |
+          |  ?document beol:hasAuthor ?person .
+          |  beol:hasAuthor knora-api:objectType knora-api:Resource .
+          |  ?document a knora-api:Resource .
+          |  { ?document a beol:manuscript . } UNION { ?document a beol:letter .}
+          |}
             """.stripMargin
 
     "The type inspection utility" should {
@@ -655,146 +655,158 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
 
     "The inferring type inspector" should {
         "remove a type from IntermediateTypeInspectionResult" in {
-            val multipleDetectedTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(entities = Map(
-                TypeableVariable(variableName = "mainRes") -> Set(
-                    NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true),
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
+            val multipleDetectedTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(
+                entities = Map(
+                    TypeableVariable(variableName = "mainRes") -> Set(
+                        NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true),
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
                 ),
                 entitiesInferredFromProperties = Map(TypeableVariable(variableName = "mainRes") -> Set(
                     NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
                     NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
                 )
             )
-            //remove type basicLettr
+
+            // remove type basicLetter
             val intermediateTypesWithoutResource: IntermediateTypeInspectionResult = multipleDetectedTypes.removeType(TypeableVariable(variableName = "mainRes"),
                 NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
 
-            //Is it removed from entities?
-            intermediateTypesWithoutResource.entities should contain (TypeableVariable(variableName = "mainRes") -> Set(
+            // Is it removed from entities?
+            intermediateTypesWithoutResource.entities should contain(TypeableVariable(variableName = "mainRes") -> Set(
                 NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true),
                 NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)
             ))
 
-            //Is it removed from entitiesInferredFromProperties?
-            intermediateTypesWithoutResource.entitiesInferredFromProperties should contain (TypeableVariable(variableName = "mainRes") -> Set(
+            // Is it removed from entitiesInferredFromProperties?
+            intermediateTypesWithoutResource.entitiesInferredFromProperties should contain(TypeableVariable(variableName = "mainRes") -> Set(
                 NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
         }
 
         "refine the inspected types for each typeableEntity" in {
             val typeInspectionRunner = new InferringGravsearchTypeInspector(nextInspector = None, responderData = responderData)
             val parsedQuery = GravsearchParser.parseQuery(QueryRdfTypeRule)
-            val  (usageIndex , entityInfo) = Await.result(typeInspectionRunner.getUsageIndexAndEntityInfos(parsedQuery.whereClause, requestingUser = anythingAdminUser), timeout)
-            val multipleDetectedTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(entities = Map(
-                TypeableVariable(variableName = "letter") -> Set(
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
-                    NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true),
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true)
+            val (_, entityInfo) = Await.result(typeInspectionRunner.getUsageIndexAndEntityInfos(parsedQuery.whereClause, requestingUser = anythingAdminUser), timeout)
+            val multipleDetectedTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(
+                entities = Map(
+                    TypeableVariable(variableName = "letter") -> Set(
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
+                        NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true),
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true)
                     )
                 ),
-                entitiesInferredFromProperties = Map(TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true)
-                ))
+                entitiesInferredFromProperties = Map(
+                    TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
+                )
             )
 
             val refinedIntermediateResults = typeInspectionRunner.refineDeterminedTypes(
                 intermediateResult = multipleDetectedTypes,
-                entityInfo = entityInfo)
+                entityInfo = entityInfo
+            )
+
             assert(refinedIntermediateResults.entities.size == 1)
-            refinedIntermediateResults.entities should contain (TypeableVariable(variableName = "letter") -> Set(
+            refinedIntermediateResults.entities should contain(TypeableVariable(variableName = "letter") -> Set(
                 NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
             assert(refinedIntermediateResults.entitiesInferredFromProperties.isEmpty)
         }
 
         "sanitize inconsistent resource types that only have knora-base:Resource as base class in common" in {
-                val typeInspectionRunner = new InferringGravsearchTypeInspector(nextInspector = None, responderData = responderData)
-                val parsedQuery = GravsearchParser.parseQuery(QueryRdfTypeRule)
-                val  (usageIndex , entityInfo) = Await.result(typeInspectionRunner.getUsageIndexAndEntityInfos(parsedQuery.whereClause, requestingUser = anythingAdminUser), timeout)
-                val inconsistentTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(entities = Map(
+            val typeInspectionRunner = new InferringGravsearchTypeInspector(nextInspector = None, responderData = responderData)
+            val parsedQuery = GravsearchParser.parseQuery(QueryRdfTypeRule)
+            val (usageIndex, entityInfo) = Await.result(typeInspectionRunner.getUsageIndexAndEntityInfos(parsedQuery.whereClause, requestingUser = anythingAdminUser), timeout)
+            val inconsistentTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(
+                entities = Map(
                     TypeableVariable(variableName = "letter") -> Set(
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true)
-                        ),
+                    ),
                     TypeableVariable(variableName = "linkingProp1") -> Set(
                         PropertyTypeInfo(objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, objectIsResourceType = true),
                         PropertyTypeInfo(objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, objectIsResourceType = true)
-                    )
-                    ),
-                    entitiesInferredFromProperties = Map(TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
-                )
-
-                val refinedIntermediateResults = typeInspectionRunner.refineDeterminedTypes(
-                    intermediateResult = inconsistentTypes,
-                    entityInfo = entityInfo)
-
-                val sanitizedResults = typeInspectionRunner.sanitizeInconsistentResourceTypes(
-                    lastResults = refinedIntermediateResults,
-                    usageIndex.querySchema,
-                    entityInfo = entityInfo)
-
-                val expectedResult: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(entities = Map(
-                    TypeableVariable(variableName = "letter") -> Set(
-                        NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true)
-                    ),
-                    TypeableVariable(variableName = "linkingProp1") -> Set(
-                        PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, objectIsResourceType = true)
                     )
                 ),
                 entitiesInferredFromProperties = Map(TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
             )
 
-                assert(sanitizedResults.entities == expectedResult.entities )
+            val refinedIntermediateResults = typeInspectionRunner.refineDeterminedTypes(
+                intermediateResult = inconsistentTypes,
+                entityInfo = entityInfo)
+
+            val sanitizedResults = typeInspectionRunner.sanitizeInconsistentResourceTypes(
+                lastResults = refinedIntermediateResults,
+                usageIndex.querySchema,
+                entityInfo = entityInfo)
+
+            val expectedResult: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(
+                entities = Map(
+                    TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true)),
+                    TypeableVariable(variableName = "linkingProp1") -> Set(PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, objectIsResourceType = true))
+                ),
+                entitiesInferredFromProperties = Map(
+                    TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true))
+                )
+            )
+
+            assert(sanitizedResults.entities == expectedResult.entities)
         }
 
         "sanitize inconsistent resource types that have common base classes other than knora-base:Resource" in {
             val typeInspectionRunner = new InferringGravsearchTypeInspector(nextInspector = None, responderData = responderData)
-            val parsedQuery = GravsearchParser.parseQuery(queryWithInconsistentTypes)
-            val  (usageIndex , entityInfo) = Await.result(typeInspectionRunner.getUsageIndexAndEntityInfos(parsedQuery.whereClause, requestingUser = anythingAdminUser), timeout)
-            val inconsistentTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(entities = Map(
-                TypeableVariable(variableName = "document") -> Set(
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#manuscript".toSmartIri, isResourceType = true)
-                )
-            ),
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithInconsistentTypes3)
+            val (usageIndex, entityInfo) = Await.result(typeInspectionRunner.getUsageIndexAndEntityInfos(parsedQuery.whereClause, requestingUser = anythingAdminUser), timeout)
+            val inconsistentTypes: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(
+                entities = Map(
+                    TypeableVariable(variableName = "document") -> Set(
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#manuscript".toSmartIri, isResourceType = true)
+                    )
+                ),
                 entitiesInferredFromProperties = Map(TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
             )
 
             val refinedIntermediateResults = typeInspectionRunner.refineDeterminedTypes(
                 intermediateResult = inconsistentTypes,
                 entityInfo = entityInfo)
+
             val sanitizedResults = typeInspectionRunner.sanitizeInconsistentResourceTypes(
                 lastResults = refinedIntermediateResults,
                 usageIndex.querySchema,
                 entityInfo = entityInfo)
-            val expectedResult: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(entities = Map(
-                TypeableVariable(variableName = "document") -> Set(
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#writtenSource".toSmartIri, isResourceType = true)
+
+            val expectedResult: IntermediateTypeInspectionResult = IntermediateTypeInspectionResult(
+                entities = Map(
+                    TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#writtenSource".toSmartIri, isResourceType = true))
+                ),
+                entitiesInferredFromProperties = Map(
+                    TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true))
                 )
-            ),
-                entitiesInferredFromProperties = Map(TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
             )
 
-            assert(sanitizedResults.entities == expectedResult.entities )
+            assert(sanitizedResults.entities == expectedResult.entities)
         }
 
         "sanitize inconsistent types resulted from a union" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithInconsistentTypes3)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
 
-                val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-                val parsedQuery = GravsearchParser.parseQuery(queryWithInconsistentTypes)
-                val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
-                val result = Await.result(resultFuture, timeout)
-
-                val expectedResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
+            val expectedResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(
+                entities = Map(
                     TypeableVariable(variableName = "person") ->
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true),
                     TypeableVariable(variableName = "document") ->
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#writtenSource".toSmartIri, isResourceType = true),
                     TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasAuthor".toSmartIri) ->
                         PropertyTypeInfo(objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, objectIsResourceType = true)
-                    ),
-                    entitiesInferredFromProperties = Map(TypeableVariable(variableName = "person") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true)),
-                    )
+                ),
+                entitiesInferredFromProperties = Map(
+                    TypeableVariable(variableName = "person") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true)),
                 )
-                assert(result.entities == expectedResult.entities)
+            )
+
+            assert(result.entities == expectedResult.entities)
         }
 
         "types resulted from a query with optional" in {
@@ -818,6 +830,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                   |}
                   |}
                 """.stripMargin
+
             val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
             val parsedQuery = GravsearchParser.parseQuery(queryWithOptional)
             val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
@@ -827,37 +840,39 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
             // since writtenSource is a base class of basicLetter, it is ignored and type "beol:basicLetter" is considered for ?document.
             // The OPTIONAL would become meaningless here. Therefore, in cases where property is in OPTIONAL block,
             // the rdf:type statement for ?document must not be removed from query even though ?document is in entitiesInferredFromProperties.
-            val expectedResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(entities = Map(
-                TypeableVariable(variableName = "document") ->
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true),
-                TypeableVariable(variableName = "familyName") ->
-                    NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri, isValueType = true),
-                TypeableVariable(variableName = "recipient") ->
-                    NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true),
-                TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasRecipient".toSmartIri) ->
-                    PropertyTypeInfo(objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, objectIsResourceType = true),
-                TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasFamilyName".toSmartIri) ->
-                    PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri, objectIsValueType = true)
-            ),
-                entitiesInferredFromProperties = Map(TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true)),
+            val expectedResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(
+                entities = Map(
+                    TypeableVariable(variableName = "document") ->
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true),
+                    TypeableVariable(variableName = "familyName") ->
+                        NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri, isValueType = true),
+                    TypeableVariable(variableName = "recipient") ->
+                        NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true),
+                    TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasRecipient".toSmartIri) ->
+                        PropertyTypeInfo(objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, objectIsResourceType = true),
+                    TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasFamilyName".toSmartIri) ->
+                        PropertyTypeInfo(objectTypeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri, objectIsValueType = true)
+                ),
+                entitiesInferredFromProperties = Map(
+                    TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true)),
                     TypeableVariable(variableName = "familyName") ->
                         Set(NonPropertyTypeInfo(typeIri = "http://www.w3.org/2001/XMLSchema#string".toSmartIri, isValueType = true)),
                     TypeableVariable(variableName = "recipient") ->
                         Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, isResourceType = true)),
                 )
             )
+
             assert(result.entities == expectedResult.entities)
             assert(result.entitiesInferredFromProperties == expectedResult.entitiesInferredFromProperties)
-
         }
 
         "infer the most specific type from redundant ones given in a query" in {
             val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
-            val parsedQuery = GravsearchParser.parseQuery(queryWithReduntentTypes)
+            val parsedQuery = GravsearchParser.parseQuery(QueryWithRedundantTypes)
             val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
             val result = Await.result(resultFuture, timeout)
             assert(result.entities.size == 5)
-            result.entitiesInferredFromProperties.keySet should not contain(TypeableVariable("letter"))
+            result.entitiesInferredFromProperties.keySet should not contain TypeableVariable("letter")
         }
 
         "infer that an entity is a knora-api:Resource if there is an rdf:type statement about it and the specified type is a Knora resource class" in {
@@ -868,7 +883,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
             assert(result.entities == TypeInferenceResult1.entities)
             result.entitiesInferredFromProperties.keySet should contain(TypeableVariable("date"))
             result.entitiesInferredFromProperties.keySet should contain(TypeableIri("http://rdfh.ch/0801/H7s3FmuWTkaCXa54eFANOA".toSmartIri))
-            result.entitiesInferredFromProperties.keySet should not contain(TypeableVariable("linkingProp1"))
+            result.entitiesInferredFromProperties.keySet should not contain TypeableVariable("linkingProp1")
         }
 
         "infer a property's knora-api:objectType if the property's IRI is used as a predicate" in {


### PR DESCRIPTION
https://dasch.myjetbrains.com/youtrack/issue/DSP-534

- [x] In `AbstractPrequeryGenerator`, parse `knora-api:GravsearchOptions knora-api:useInference` with a boolean object.
- [x] Ignore `knora-api:GravsearchOptions` and `knora-api:useInference` in type inspection.
- [x] In `SparqlTransformer`, if that option is set, change the way the generated prequery is processed:
  - [x] With Fuseki, don't simulate inference by expanding statements.
  - [x] With GraphDB, add `FROM <http://www.ontotext.com/explicit>`.
- [x] Add tests.
- [x] Add docs.
