### PR TITLE
chore: Update ci workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -343,10 +343,20 @@ jobs:
             ${{ runner.OS }}-build-${{ env.cache-name }}-
             ${{ runner.OS }}-build-
             ${{ runner.OS }}-
-      - name: Generate Github release notes
-        uses: lakto/gren-action@v1.1.0
+      - if: "github.event.release.prerelease"
+        name: Update release notes
+        uses: lakto/gren-action@v2.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          options: '--override --prerelease'
+      - if: "!github.event.release.prerelease"
+        name: Update release notes
+        uses: lakto/gren-action@v2.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          options: '--override'
       - name: Disk Free
         run: |
           df -h


### PR DESCRIPTION
We still use gren which generates release notes on each release automatically. This PR resolves the issue we had with `release candidates`.