### PR TITLE
Get Project Permissions

### DIFF
--- a/docs/03-apis/api-admin/groups.md
+++ b/docs/03-apis/api-admin/groups.md
@@ -25,7 +25,7 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 
 - `GET: /admin/groups` : return all groups
 - `GET: /admin/groups/<groupIri>` : return single group identified by [IRI]
-- `POST: /admin/groups` : create new group
+- `POST: /admin/groups` : create a new group
 - `PUT: /admin/groups/<groupIri>` : update groups's basic information
 - `PUT: /admin/groups/<groupIri>/status` : update group's status
 - `DELETE: /admin/groups/<groupIri>` : delete group (set status to false)

--- a/docs/03-apis/api-admin/permissions.md
+++ b/docs/03-apis/api-admin/permissions.md
@@ -21,8 +21,8 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 
 ##Permission Operations:
 
-**Note:** For the following operations, the requesting user must be either a `systemAdmin`, 
-a `projectAdmin` or a `systemUser`.
+**Note:** For the following operations, the requesting user must be either a `systemAdmin`or 
+a `projectAdmin`.
 
 ### Getting Permissions: 
 - `GET: /admin/permissions/<projectIri>` : return all permissions for a project.

--- a/docs/03-apis/api-admin/permissions.md
+++ b/docs/03-apis/api-admin/permissions.md
@@ -19,12 +19,119 @@ License along with Knora.  If not, see <http://www.gnu.org/licenses/>.
 
 # Permissions Endpoint
 
-  - **Add/change/delete administrative permissions**:
+##Permission Operations:
 
-      - Required permission: SystemAdmin / hasProjectAllAdminPermission
-        / hasProjectRightsAdminPermission
+**Note:** For the following operations, the requesting user must be either a `systemAdmin`, 
+a `projectAdmin` or a `systemUser`.
 
-  - **Add/change/delete default object access permissions**:
+### Getting Permissions: 
+- `GET: /admin/permissions/<projectIri>` : return all permissions for a project.
+As a response, the IRI and the type of all `permissions` of a project are returned.
+  
+- `GET: /admin/permissions/ap/<projectIri>`: return all administrative permissions 
+for a project. As a response, all `administrative_permissions` of a project are returned.
 
-      - Required permission: SystemAdmin / hasProjectAllAdminPermission
-        / hasProjectRightsAdminPermission
+- `GET: /admin/permissions/ap/<projectIri>/<groupIri>`: return the administrative 
+permissions for a project group. As a response, the `administrative_permission` defined 
+for the group is returned. 
+
+- `GET: /admin/permissions/doap/<projectIri>`: return all default object access 
+permissions for a project. As a response, all `default_object_acces_permissions` of a 
+project are returned. 
+
+### Creating New Permissions:
+ 
+- `POST: /admin/permissions/ap`: create a new administrative permission. The type of 
+permissions, the project and group to which the permission should be added must be 
+included in the request body, for example:
+
+```json
+{
+    "forGroup":"http://rdfh.ch/groups/0001/thing-searcher", 
+    "forProject":"http://rdfh.ch/projects/0001", 
+    "hasPermissions":[{"additionalInformation":null,"name":"ProjectAdminGroupAllPermission","permissionCode":null}]
+}
+``` 
+
+In addition, in the body of the request, it is possible to specify a custom IRI (of [Knora IRI](knora-iris.md#iris-for-data) form) for a permission through
+the `@id` attribute which will then be assigned to the permission; otherwise the permission will get a unique random IRI.
+A custom permission IRI must be `http://rdfh.ch/permissions/PROJECT_SHORTCODE/` (where `PROJECT_SHORTCODE`
+is the shortcode of the project that the permission belongs to), plus a custom ID string. For example:
+```
+"id": "http://rdfh.ch/permissions/0001/AP-with-customIri",
+```
+
+As a response, the created administrative permission and its IRI are returned as below:
+
+```json
+{
+    "administrative_permission": {
+        "forGroup": "http://rdfh.ch/groups/0001/thing-searcher",
+        "forProject": "http://rdfh.ch/projects/0001",
+        "hasPermissions": [
+            {
+                "additionalInformation": null,
+                "name": "ProjectAdminGroupAllPermission",
+                "permissionCode": null
+            }
+        ],
+        "iri": "http://rdfh.ch/permissions/0001/mFlyBEiMQtGzwy_hK0M-Ow"
+    }
+}
+```
+
+- `POST: /admin/permissions/doap` : create a new default object access permission. 
+A single instance of `knora-admin:DefaultObjectAccessPermission` must
+always reference a project, but can only reference **either** a group
+(`knora-admin:forGroup` property), a resource class
+(`knora-admin:forResourceClass`), a property (`knora-admin:forProperty`),
+or a combination of resource class **and** property. For example, to create a new 
+default object access permission for a group of a project the request body would be
+ 
+```
+{
+    "forGroup":"http://rdfh.ch/groups/0001/thing-searcher",
+    "forProject":"http://rdfh.ch/projects/0001",
+    "forProperty":null,
+    "forResourceClass":null,
+    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
+}
+```
+
+Similar to the previous case a custom IRI can be assigned to a permission through 
+the `@id` attribute. The example below shows the request body to create a new default 
+object access permission with a custom IRI defined for a resource class 
+of a specific project:
+
+```json
+{
+    "id": "http://rdfh.ch/permissions/00FF/DOAP-with-customIri",
+    "forGroup":null,
+    "forProject":"http://rdfh.ch/projects/00FF",
+    "forProperty":null,
+    "forResourceClass":"http://www.knora.org/ontology/00FF/images#bild",
+    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
+}
+```
+
+The response contains the newly created permission and its IRI, as:
+
+```json
+{
+    "default_object_access_permission": {
+        "forGroup": null,
+        "forProject": "http://rdfh.ch/projects/00FF",
+        "forProperty": null,
+        "forResourceClass": "http://www.knora.org/ontology/00FF/images#bild",
+        "hasPermissions": [
+            {
+                "additionalInformation": "http://www.knora.org/ontology/knora-admin#ProjectMember",
+                "name": "D",
+                "permissionCode": 7
+            }
+        ],
+        "iri": "http://rdfh.ch/permissions/00FF/DOAP-with-customIri"
+    }
+}
+```
+

--- a/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADM.scala
@@ -148,10 +148,8 @@ case class PermissionsForProjectGetRequestADM(projectIri: IRI,
 
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-        && !requestingUser.permissions.isProjectAdmin(projectIri)
-        && !requestingUser.isSystemUser
-    ) {
-        // not a system admin
+        && !requestingUser.permissions.isProjectAdmin(projectIri)) {
+        // not a system or project admin
         throw ForbiddenException("Permissions can only be queried by system and project admin.")
     }
 }
@@ -176,10 +174,8 @@ case class AdministrativePermissionsForProjectGetRequestADM(projectIri: IRI,
 
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-                && !requestingUser.permissions.isProjectAdmin(projectIri)
-                && !requestingUser.isSystemUser
-        ) {
-            // not a system admin
+                && !requestingUser.permissions.isProjectAdmin(projectIri)) {
+            // not a system or project admin
             throw ForbiddenException("Administrative permission can only be queried by system and project admin.")
         }
 }
@@ -348,10 +344,8 @@ case class DefaultObjectAccessPermissionsForProjectGetRequestADM(projectIri: IRI
 
     // Check user's permission for the operation
     if (!requestingUser.isSystemAdmin
-        && !requestingUser.permissions.isProjectAdmin(projectIri)
-        && !requestingUser.isSystemUser
-    ) {
-        // not a system admin
+        && !requestingUser.permissions.isProjectAdmin(projectIri)) {
+        // not a system or project admin
         throw ForbiddenException("Default object access permissions can only be queried by system and project admin.")
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -1299,32 +1299,6 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
                 }.toSet
             }
 
-
-
-//            if (permissionsQueryResponseStatements.isEmpty){
-//
-//            } else {
-//                val statementMap: Map[IRI, Seq[String]] = permissionsQueryResponseStatements.groupBy {
-//                    case (pred, _) => pred
-//                }.map {
-//                    case (pred, predStatements) =>
-//                        pred -> predStatements.map {
-//                            case (_, obj) => obj
-//                        }
-//                }
-//                val permissionType: String = statementMap.getOrElse(OntologyConstants.Rdfs.Type, throw InconsistentTriplestoreDataException(s"Type of Permission $permissionIri not known."))
-//
-//            }
-//
-//
-//
-//
-//            permissionsQueryResponseStatements.map {
-//                case (permissionIri: IRI, propsMap: Seq[(IRI, String)]) =>
-//                    /* construct permission object */
-//                    PermissionInfoADM(iri = permissionIri, permissionType = propsMap.getOrElse(OntologyConstants.Rdf.Type, ))
-//            }.toSeq
-
             /* construct response object */
             response = permissionsmessages.PermissionsForProjectGetResponseADM(permissionsInfo)
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/admin/PermissionsResponderADM.scala
@@ -71,6 +71,7 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
         case DefaultObjectAccessPermissionsStringForResourceClassGetADM(projectIri, resourceClassIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, None, ResourceEntityType, targetUser, requestingUser)
         case DefaultObjectAccessPermissionsStringForPropertyGetADM(projectIri, resourceClassIri, propertyTypeIri, targetUser, requestingUser) => defaultObjectAccessPermissionsStringForEntityGetADM(projectIri, resourceClassIri, Some(propertyTypeIri), PropertyEntityType, targetUser, requestingUser)
         case DefaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID) => defaultObjectAccessPermissionCreateRequestADM(createRequest, requestingUser, apiRequestID)
+        case PermissionsForProjectGetRequestADM(projectIri, groupIri, requestingUser) => permissionsForProjectGetRequestADM(projectIri, groupIri, requestingUser)
         case other => handleUnexpectedMessage(other, log, this.getClass.getName)
     }
 
@@ -1261,6 +1262,73 @@ class PermissionsResponderADM(responderData: ResponderData) extends Responder(re
                     () => createPermissionTask(createRequest, requestingUser)
                 )
             } yield taskResult
+    }
+
+    /**
+     * Gets all permissions defined inside a project.
+     *
+     * @param projectIRI     the IRI of the project.
+     * @param requestingUser the [[UserADM]] of the requesting user.
+     * @param apiRequestID    the API request ID.
+     * @return a list of of [[PermissionInfoADM]] objects.
+     */
+    private def permissionsForProjectGetRequestADM(projectIRI: IRI,
+                                                    requestingUser: UserADM,
+                                                    apiRequestID: UUID
+                                                    ): Future[PermissionsForProjectGetResponseADM] = {
+
+        for {
+            sparqlQueryString <- Future(org.knora.webapi.messages.twirl.queries.sparql.admin.txt.getProjectPermissions(
+                triplestore = settings.triplestoreType,
+                projectIri = projectIRI
+            ).toString())
+
+            permissionsQueryResponse <- (storeManager ? SparqlConstructRequest(sparqlQueryString)).mapTo[SparqlConstructResponse]
+
+            /* extract response statements */
+            permissionsQueryResponseStatements: Map[IRI, Seq[(IRI, String)]] = permissionsQueryResponse.statements
+
+
+            permissionsInfo: Set[PermissionInfoADM] = if (permissionsQueryResponseStatements.isEmpty) {
+                throw NotFoundException(s"No permission could be found for $projectIRI.")
+            } else {
+                permissionsQueryResponseStatements.map{ statement =>
+                        val permissionIri = statement._1
+                        val (_, permissionType) = statement._2.filter(_._1 == OntologyConstants.Rdf.Type).head
+                        PermissionInfoADM(iri = permissionIri, permissionType = permissionType)
+                }.toSet
+            }
+
+
+
+//            if (permissionsQueryResponseStatements.isEmpty){
+//
+//            } else {
+//                val statementMap: Map[IRI, Seq[String]] = permissionsQueryResponseStatements.groupBy {
+//                    case (pred, _) => pred
+//                }.map {
+//                    case (pred, predStatements) =>
+//                        pred -> predStatements.map {
+//                            case (_, obj) => obj
+//                        }
+//                }
+//                val permissionType: String = statementMap.getOrElse(OntologyConstants.Rdfs.Type, throw InconsistentTriplestoreDataException(s"Type of Permission $permissionIri not known."))
+//
+//            }
+//
+//
+//
+//
+//            permissionsQueryResponseStatements.map {
+//                case (permissionIri: IRI, propsMap: Seq[(IRI, String)]) =>
+//                    /* construct permission object */
+//                    PermissionInfoADM(iri = permissionIri, permissionType = propsMap.getOrElse(OntologyConstants.Rdf.Type, ))
+//            }.toSeq
+
+            /* construct response object */
+            response = permissionsmessages.PermissionsForProjectGetResponseADM(permissionsInfo)
+
+        } yield response
     }
 
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -64,7 +64,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
      * Returns the route.
      */
     override def knoraApiPath: Route =
-        getAdministrativePermissionProjectGroup ~
+        getAdministrativePermissionForProjectGroup ~
         getAdministrativePermissionsForProject ~
         getDefaultObjectAccessPermissionsForProject ~
         getPermissionsForProject ~
@@ -72,7 +72,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
         createDefaultObjectAccessPermission
 
 
-    private def getAdministrativePermissionProjectGroup: Route = path(PermissionsBasePath / "ap" / Segment / Segment) {
+    private def getAdministrativePermissionForProjectGroup: Route = path(PermissionsBasePath / "ap" / Segment / Segment) {
         (projectIri, groupIri) =>
             get {
                 requestContext =>

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -94,7 +94,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
         for {
             responseStr <- doTestDataRequest(Get(s"$baseApiUrl$PermissionsBasePathString/ap/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass)))
         } yield TestDataFileContent(
-            filePath = TestDataFilePath.makeJsonPath("get-administrative-permission-response"),
+            filePath = TestDataFilePath.makeJsonPath("get-administrative-permission-for-project-group-response"),
             text = responseStr
         )
     }
@@ -124,7 +124,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
         for {
             responseStr <- doTestDataRequest(Get(s"$baseApiUrl$PermissionsBasePathString/ap/$projectIri") ~> addCredentials(BasicHttpCredentials(SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass)))
         } yield TestDataFileContent(
-            filePath = TestDataFilePath.makeJsonPath("get-administrative-permission-for-project-response"),
+            filePath = TestDataFilePath.makeJsonPath("get-administrative-permissions-for-project-response"),
             text = responseStr
         )
     }
@@ -154,7 +154,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
         for {
             responseStr <- doTestDataRequest(Get(s"$baseApiUrl$PermissionsBasePathString/doap/$projectIri") ~> addCredentials(BasicHttpCredentials(SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass)))
         } yield TestDataFileContent(
-            filePath = TestDataFilePath.makeJsonPath("get-defaultObjectAccess-permission-for-project-response"),
+            filePath = TestDataFilePath.makeJsonPath("get-defaultObjectAccess-permissions-for-project-response"),
             text = responseStr
         )
     }
@@ -181,6 +181,16 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
                     )
             }
     }
+
+    private def getPermissionsForProjectTestResponse: Future[TestDataFileContent] = {
+        for {
+            responseStr <- doTestDataRequest(Get(s"$baseApiUrl$PermissionsBasePathString/$projectIri") ~> addCredentials(BasicHttpCredentials(SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass)))
+        } yield TestDataFileContent(
+            filePath = TestDataFilePath.makeJsonPath("get-permissions-for-project-response"),
+            text = responseStr
+        )
+    }
+
     /**
      * Create a new administrative permission
      */
@@ -293,9 +303,10 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
                 getAdminPermissionForPG <- getAdministrativePermissionForProjectGroupTestResponse
                 getAdminPermissionsForP <- getAdministrativePermissionsForProjectTestResponse
                 getDOAPermissionsForP <- getDefaultObjectAccessPermissionsForProjectTestResponse
+                getAllPermissionsForP <- getPermissionsForProjectTestResponse
                 createAP <- createAdminPermissionTestRequestAndResponse
                 createDOAP <- createDOAPermissionTestRequestAndResponse
 
-        } yield createAP ++ createDOAP + getAdminPermissionForPG + getAdminPermissionsForP + getDOAPermissionsForP
+        } yield createAP ++ createDOAP + getAdminPermissionForPG + getAdminPermissionsForP + getDOAPermissionsForP + getAllPermissionsForP
     }
 }

--- a/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/routing/admin/PermissionsRouteADM.scala
@@ -67,6 +67,7 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
         getAdministrativePermissionProjectGroup ~
         getAdministrativePermissionsForProject ~
         getDefaultObjectAccessPermissionsForProject ~
+        getPermissionsForProject ~
         createAdministrativePermission ~
         createDefaultObjectAccessPermission
 
@@ -158,6 +159,28 @@ class PermissionsRouteADM(routeData: KnoraRouteData) extends KnoraRoute(routeDat
         )
     }
 
+
+    private def getPermissionsForProject: Route = path(PermissionsBasePath / Segment) {
+        (projectIri) =>
+            get {
+                requestContext =>
+                    val requestMessage = for {
+                        requestingUser <- getUserADM(requestContext)
+                    } yield PermissionsForProjectGetRequestADM(
+                        projectIri = projectIri,
+                        requestingUser = requestingUser,
+                        apiRequestID = UUID.randomUUID()
+                    )
+
+                    RouteUtilADM.runJsonRoute(
+                        requestMessage,
+                        requestContext,
+                        settings,
+                        responderManager,
+                        log
+                    )
+            }
+    }
     /**
      * Create a new administrative permission
      */

--- a/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
+++ b/webapi/src/main/scala/org/knora/webapi/sharedtestdata/SharedTestDataADM.scala
@@ -722,6 +722,22 @@ object SharedTestDataADM {
            |	"hasPermissions":[{"additionalInformation":null,"name":"ProjectAdminGroupAllPermission","permissionCode":null}]
            |}""".stripMargin
 
+    val createAdministrativePermissionResponse: String =
+        s"""{
+           |    "administrative_permission": {
+           |        "forGroup": "http://rdfh.ch/groups/0001/thing-searcher",
+           |        "forProject": "http://rdfh.ch/projects/0001",
+           |        "hasPermissions": [
+           |            {
+           |                "additionalInformation": null,
+           |                "name": "ProjectAdminGroupAllPermission",
+           |                "permissionCode": null
+           |            }
+           |        ],
+           |        "iri": "http://rdfh.ch/permissions/0001/mFlyBEiMQtGzwy_hK0M-Ow"
+           |    }
+           |}""".stripMargin
+
     val createDefaultObjectAccessPermissionRequest: String =
         s"""{
            |    "forGroup":"${SharedTestDataADM.thingSearcherGroup.id}",
@@ -729,6 +745,24 @@ object SharedTestDataADM {
            |    "forProperty":null,
            |    "forResourceClass":null,
            |    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
+           |}""".stripMargin
+
+    val createDefaultObjectAccessPermissionResponse: String =
+        s"""{
+           |    "default_object_access_permission": {
+           |        "forGroup": "http://rdfh.ch/groups/0001/thing-searcher",
+           |        "forProject": "http://rdfh.ch/projects/0001",
+           |        "forProperty": null,
+           |        "forResourceClass": null,
+           |        "hasPermissions": [
+           |            {
+           |                "additionalInformation": "http://www.knora.org/ontology/knora-admin#ProjectMember",
+           |                "name": "D",
+           |                "permissionCode": 7
+           |            }
+           |        ],
+           |        "iri": "http://rdfh.ch/permissions/0001/v4uUcwD7S5-rfus1uaq1ZQ"
+           |    }
            |}""".stripMargin
 
     val createAdministrativePermissionWithCustomIriRequest: String =
@@ -739,6 +773,22 @@ object SharedTestDataADM {
            |	"hasPermissions":[{"additionalInformation":null,"name":"ProjectAdminGroupAllPermission","permissionCode":null}]
            |}""".stripMargin
 
+    val createAdministrativePermissionWithCustomIriResponse: String =
+        s"""{
+           |    "administrative_permission": {
+           |        "forGroup": "http://rdfh.ch/groups/0001/thing-searcher",
+           |        "forProject": "http://rdfh.ch/projects/0001",
+           |        "hasPermissions": [
+           |            {
+           |                "additionalInformation": null,
+           |                "name": "ProjectAdminGroupAllPermission",
+           |                "permissionCode": null
+           |            }
+           |        ],
+           |        "iri": "http://rdfh.ch/permissions/0001/AP-with-customIri"
+           |    }
+           |}""".stripMargin
+
     val createDefaultObjectAccessPermissionWithCustomIriRequest: String =
         s"""{
            |    "id": "http://rdfh.ch/permissions/00FF/DOAP-with-customIri",
@@ -747,6 +797,24 @@ object SharedTestDataADM {
            |    "forProperty":null,
            |    "forResourceClass":"${SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS}",
            |    "hasPermissions":[{"additionalInformation":"http://www.knora.org/ontology/knora-admin#ProjectMember","name":"D","permissionCode":7}]
+           |}""".stripMargin
+
+    val createDefaultObjectAccessPermissionWithCustomIriResponse: String =
+        s"""{
+           |    "default_object_access_permission": {
+           |        "forGroup": null,
+           |        "forProject": "http://rdfh.ch/projects/00FF",
+           |        "forProperty": null,
+           |        "forResourceClass": "http://www.knora.org/ontology/00FF/images#bild",
+           |        "hasPermissions": [
+           |            {
+           |                "additionalInformation": "http://www.knora.org/ontology/knora-admin#ProjectMember",
+           |                "name": "D",
+           |                "permissionCode": 7
+           |            }
+           |        ],
+           |        "iri": "http://rdfh.ch/permissions/00FF/DOAP-with-customIri"
+           |    }
            |}""".stripMargin
 
     def updateListInfoRequest(listIri: IRI): String = {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -50,19 +50,19 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
     "The Permissions Route ('admin/permissions')" when {
 
         "getting permissions" should {
-//            "return a group's administrative permissions" in {
-//
-//                val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
-//                val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
-//                val request = Get(baseApiUrl + s"/admin/permissions/ap/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
-//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-//                val response = singleAwaitingRequest(request, 1.seconds)
-//                logger.debug("==>> " + response.toString)
-//                assert(response.status === StatusCodes.OK)
-//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
-//                val iri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
-//                assert(iri == "http://rdfh.ch/permissions/00FF/a1")
-//            }
+            "return a group's administrative permissions" in {
+
+                val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+                val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
+                val request = Get(baseApiUrl + s"/admin/permissions/ap/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response = singleAwaitingRequest(request, 1.seconds)
+                logger.debug("==>> " + response.toString)
+                assert(response.status === StatusCodes.OK)
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
+                val iri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
+                assert(iri == "http://rdfh.ch/permissions/00FF/a1")
+            }
 
             "return a project's administrative permissions" in {
 
@@ -87,6 +87,19 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
                 val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permissions")
                 result.asInstanceOf[JsArray].elements.size should be (3)
             }
+
+            "return a project's all permissions" in {
+
+                val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+                val request = Get(baseApiUrl + s"/admin/permissions/$projectIri") ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response = singleAwaitingRequest(request, 1.seconds)
+                logger.debug("==>> " + response.toString)
+                assert(response.status === StatusCodes.OK)
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("permissions")
+                result.asInstanceOf[JsArray].elements.size should be (6)
+            }
+
         }
 
         "creating permissions" should {

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -75,59 +75,71 @@ class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with T
                 val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permissions")
                 result.asInstanceOf[JsArray].elements.size should be (3)
             }
+
+            "return a project's default object access permissions" in {
+
+                val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+                val request = Get(baseApiUrl + s"/admin/permissions/doap/$projectIri") ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response = singleAwaitingRequest(request, 1.seconds)
+                logger.debug("==>> " + response.toString)
+                assert(response.status === StatusCodes.OK)
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permissions")
+                result.asInstanceOf[JsArray].elements.size should be (3)
+            }
         }
 
-//        "creating permissions" should {
-//            "create an administrative access permission" in {
-//
-//                val request = Post(baseApiUrl + s"/admin/permissions/ap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createAdministrativePermissionRequest)) ~> addCredentials(BasicHttpCredentials(
-//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-//                val response: HttpResponse = singleAwaitingRequest(request)
-//                assert(response.status === StatusCodes.OK)
-//
-//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
-//                val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
-//                assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
-//                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
-//                assert(projectIri == "http://rdfh.ch/projects/0001")
-//                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
-//                assert(permissions.contains("ProjectAdminGroupAllPermission"))
-//            }
-//
-//            "create a default object access permission" in {
-//
-//                val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createDefaultObjectAccessPermissionRequest)) ~> addCredentials(BasicHttpCredentials(
-//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-//                val response: HttpResponse = singleAwaitingRequest(request)
-//                assert(response.status === StatusCodes.OK)
-//
-//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
-//                val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
-//                assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
-//                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
-//                assert(projectIri == "http://rdfh.ch/projects/0001")
-//                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
-//                assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
-//            }
-//
-//            "create a default object access permission with a custom IRI" in {
-//
-//                val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`,
-//                    SharedTestDataADM.createDefaultObjectAccessPermissionWithCustomIriRequest)) ~> addCredentials(BasicHttpCredentials(
-//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-//                val response: HttpResponse = singleAwaitingRequest(request)
-//                assert(response.status === StatusCodes.OK)
-//
-//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
-//                val permissionIri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
-//                assert(permissionIri == "http://rdfh.ch/permissions/00FF/DOAP-with-customIri")
-//                val forResourceClassIRI = result.getOrElse("forResourceClass", throw DeserializationException("The expected field 'forResourceClass' is missing.")).convertTo[String]
-//                assert(forResourceClassIRI == SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS)
-//                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
-//                assert(projectIri == "http://rdfh.ch/projects/00FF")
-//                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
-//                assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
-//            }
-//        }
+        "creating permissions" should {
+            "create an administrative access permission" in {
+
+                val request = Post(baseApiUrl + s"/admin/permissions/ap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createAdministrativePermissionRequest)) ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                assert(response.status === StatusCodes.OK)
+
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
+                val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
+                assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
+                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+                assert(projectIri == "http://rdfh.ch/projects/0001")
+                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+                assert(permissions.contains("ProjectAdminGroupAllPermission"))
+            }
+
+            "create a default object access permission" in {
+
+                val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createDefaultObjectAccessPermissionRequest)) ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                assert(response.status === StatusCodes.OK)
+
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
+                val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
+                assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
+                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+                assert(projectIri == "http://rdfh.ch/projects/0001")
+                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+                assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
+            }
+
+            "create a default object access permission with a custom IRI" in {
+
+                val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`,
+                    SharedTestDataADM.createDefaultObjectAccessPermissionWithCustomIriRequest)) ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response: HttpResponse = singleAwaitingRequest(request)
+                assert(response.status === StatusCodes.OK)
+
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
+                val permissionIri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
+                assert(permissionIri == "http://rdfh.ch/permissions/00FF/DOAP-with-customIri")
+                val forResourceClassIRI = result.getOrElse("forResourceClass", throw DeserializationException("The expected field 'forResourceClass' is missing.")).convertTo[String]
+                assert(forResourceClassIRI == SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS)
+                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+                assert(projectIri == "http://rdfh.ch/projects/00FF")
+                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+                assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
+            }
+        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/admin/PermissionsADME2ESpec.scala
@@ -25,6 +25,7 @@ import com.typesafe.config.ConfigFactory
 import org.knora.webapi.messages.store.triplestoremessages.TriplestoreJsonProtocol
 import org.knora.webapi.E2ESpec
 import org.knora.webapi.messages.OntologyConstants
+import org.knora.webapi.messages.admin.responder.permissionsmessages.AdministrativePermissionADM
 import org.knora.webapi.sharedtestdata.{SharedOntologyTestDataADM, SharedTestDataADM, SharedTestDataV1}
 import org.knora.webapi.util.AkkaHttpUtils
 import spray.json._
@@ -46,70 +47,87 @@ object PermissionsADME2ESpec {
   */
 class PermissionsADME2ESpec extends E2ESpec(PermissionsADME2ESpec.config) with TriplestoreJsonProtocol {
 
-    "The Permissions Route ('admin/permissions/projectIri/groupIri')" should {
+    "The Permissions Route ('admin/permissions')" when {
 
-        "return group's administrative permissions" in {
+        "getting permissions" should {
+//            "return a group's administrative permissions" in {
+//
+//                val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+//                val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
+//                val request = Get(baseApiUrl + s"/admin/permissions/ap/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
+//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+//                val response = singleAwaitingRequest(request, 1.seconds)
+//                logger.debug("==>> " + response.toString)
+//                assert(response.status === StatusCodes.OK)
+//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
+//                val iri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
+//                assert(iri == "http://rdfh.ch/permissions/00FF/a1")
+//            }
 
-            val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
-            val groupIri = java.net.URLEncoder.encode(OntologyConstants.KnoraAdmin.ProjectMember, "utf-8")
-            val request = Get(baseApiUrl + s"/admin/permissions/$projectIri/$groupIri") ~> addCredentials(BasicHttpCredentials(
-                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-            val response = singleAwaitingRequest(request, 1.seconds)
-            logger.debug("==>> " + response.toString)
-            assert(response.status === StatusCodes.OK)
-        }
-    }
-    "The Permissions Route ('admin/permissions')" should {
-        "create an administrative access permission" in {
+            "return a project's administrative permissions" in {
 
-            val request = Post(baseApiUrl + s"/admin/permissions/ap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createAdministrativePermissionRequest)) ~> addCredentials(BasicHttpCredentials(
-                            SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-            val response: HttpResponse = singleAwaitingRequest(request)
-            assert(response.status === StatusCodes.OK)
-
-            val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
-            val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
-            assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
-            val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
-            assert(projectIri == "http://rdfh.ch/projects/0001")
-            val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
-            assert(permissions.contains("ProjectAdminGroupAllPermission"))
-        }
-
-        "create a default object access permission" in {
-
-            val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createDefaultObjectAccessPermissionRequest)) ~> addCredentials(BasicHttpCredentials(
-                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-            val response: HttpResponse = singleAwaitingRequest(request)
-            assert(response.status === StatusCodes.OK)
-
-            val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
-            val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
-            assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
-            val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
-            assert(projectIri == "http://rdfh.ch/projects/0001")
-            val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
-            assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
+                val projectIri = java.net.URLEncoder.encode(SharedTestDataV1.imagesProjectInfo.id, "utf-8")
+                val request = Get(baseApiUrl + s"/admin/permissions/ap/$projectIri") ~> addCredentials(BasicHttpCredentials(
+                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+                val response = singleAwaitingRequest(request, 1.seconds)
+                logger.debug("==>> " + response.toString)
+                assert(response.status === StatusCodes.OK)
+                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permissions")
+                result.asInstanceOf[JsArray].elements.size should be (3)
+            }
         }
 
-        "create a default object access permission with a custom IRI" in {
-
-            val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`,
-                SharedTestDataADM.createDefaultObjectAccessPermissionWithCustomIriRequest)) ~> addCredentials(BasicHttpCredentials(
-                SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
-            val response: HttpResponse = singleAwaitingRequest(request)
-            assert(response.status === StatusCodes.OK)
-
-            val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
-            val permissionIri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
-            assert(permissionIri == "http://rdfh.ch/permissions/00FF/DOAP-with-customIri")
-            val forResourceClassIRI = result.getOrElse("forResourceClass", throw DeserializationException("The expected field 'forResourceClass' is missing.")).convertTo[String]
-            assert(forResourceClassIRI == SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS)
-            val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
-            assert(projectIri == "http://rdfh.ch/projects/00FF")
-            val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
-            assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
-        }
-
+//        "creating permissions" should {
+//            "create an administrative access permission" in {
+//
+//                val request = Post(baseApiUrl + s"/admin/permissions/ap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createAdministrativePermissionRequest)) ~> addCredentials(BasicHttpCredentials(
+//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+//                val response: HttpResponse = singleAwaitingRequest(request)
+//                assert(response.status === StatusCodes.OK)
+//
+//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("administrative_permission").asJsObject.fields
+//                val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
+//                assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
+//                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+//                assert(projectIri == "http://rdfh.ch/projects/0001")
+//                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+//                assert(permissions.contains("ProjectAdminGroupAllPermission"))
+//            }
+//
+//            "create a default object access permission" in {
+//
+//                val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`, SharedTestDataADM.createDefaultObjectAccessPermissionRequest)) ~> addCredentials(BasicHttpCredentials(
+//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+//                val response: HttpResponse = singleAwaitingRequest(request)
+//                assert(response.status === StatusCodes.OK)
+//
+//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
+//                val groupIri = result.getOrElse("forGroup", throw DeserializationException("The expected field 'forGroup' is missing.")).convertTo[String]
+//                assert(groupIri == "http://rdfh.ch/groups/0001/thing-searcher")
+//                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+//                assert(projectIri == "http://rdfh.ch/projects/0001")
+//                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+//                assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
+//            }
+//
+//            "create a default object access permission with a custom IRI" in {
+//
+//                val request = Post(baseApiUrl + s"/admin/permissions/doap", HttpEntity(ContentTypes.`application/json`,
+//                    SharedTestDataADM.createDefaultObjectAccessPermissionWithCustomIriRequest)) ~> addCredentials(BasicHttpCredentials(
+//                    SharedTestDataADM.rootUser.email, SharedTestDataADM.testPass))
+//                val response: HttpResponse = singleAwaitingRequest(request)
+//                assert(response.status === StatusCodes.OK)
+//
+//                val result = AkkaHttpUtils.httpResponseToJson(response).fields("default_object_access_permission").asJsObject.fields
+//                val permissionIri = result.getOrElse("iri", throw DeserializationException("The expected field 'iri' is missing.")).convertTo[String]
+//                assert(permissionIri == "http://rdfh.ch/permissions/00FF/DOAP-with-customIri")
+//                val forResourceClassIRI = result.getOrElse("forResourceClass", throw DeserializationException("The expected field 'forResourceClass' is missing.")).convertTo[String]
+//                assert(forResourceClassIRI == SharedOntologyTestDataADM.IMAGES_BILD_RESOURCE_CLASS)
+//                val projectIri = result.getOrElse("forProject", throw DeserializationException("The expected field 'forProject' is missing.")).convertTo[String]
+//                assert(projectIri == "http://rdfh.ch/projects/00FF")
+//                val permissions = result.getOrElse("hasPermissions", throw DeserializationException("The expected field 'hasPermissions' is missing.")).toString()
+//                assert(permissions.contains("http://www.knora.org/ontology/knora-admin#ProjectMember"))
+//            }
+//        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/admin/responder/permissionsmessages/PermissionsMessagesADMSpec.scala
@@ -580,6 +580,30 @@ class PermissionsMessagesADMSpec extends AnyWordSpecLike with Matchers {
         }
     }
 
+    "get all project permissions" should {
+        "return 'BadRequest' if the supplied project IRI for PermissionsForProjectGetRequestADM is not valid" in {
+            val caught = intercept[BadRequestException](
+                PermissionsForProjectGetRequestADM(
+                    projectIri = "invalid-project-IRI",
+                    requestingUser = SharedTestDataADM.imagesUser01,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Invalid project IRI")
+        }
+
+        "return 'ForbiddenException' if the user requesting PermissionsForProjectGetRequestADM is not SystemAdmin" in {
+            val caught = intercept[ForbiddenException](
+                PermissionsForProjectGetRequestADM(
+                    projectIri = SharedTestDataADM.IMAGES_PROJECT_IRI,
+                    requestingUser = SharedTestDataADM.imagesUser02,
+                    apiRequestID = UUID.randomUUID()
+                )
+            )
+            assert(caught.getMessage === "Permissions can only be queried by system and project admin.")
+        }
+    }
+    
     "querying the user's 'PermissionsDataADM' with 'hasPermissionFor'" should {
         "return true if the user is allowed to create a resource (root user)" in {
 

--- a/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/admin/PermissionsResponderADMSpec.scala
@@ -421,6 +421,36 @@ class PermissionsResponderADMSpec extends CoreSpec(PermissionsResponderADMSpec.c
                 expectMsg(Failure(DuplicateValueException(s"Default object access permission already exists.")))
             }
         }
+
+        "asked to get all permissions" should {
+
+            "return all permissions for 'image' project " in {
+                responderManager ! PermissionsForProjectGetRequestADM(
+                    projectIri = IMAGES_PROJECT_IRI,
+                    requestingUser = rootUser,
+                    apiRequestID = UUID.randomUUID()
+                )
+                val received: PermissionsForProjectGetResponseADM = expectMsgType[PermissionsForProjectGetResponseADM]
+                received.allPermissions.size should be (8)
+            }
+
+            "return all permissions for 'incunabula' project " in {
+                responderManager ! PermissionsForProjectGetRequestADM(
+                    projectIri = INCUNABULA_PROJECT_IRI,
+                    requestingUser = rootUser,
+                    apiRequestID = UUID.randomUUID()
+                )
+                expectMsg(PermissionsForProjectGetResponseADM( allPermissions =
+                    Set(PermissionInfoADM(perm003_a1.iri, OntologyConstants.KnoraAdmin.AdministrativePermission),
+                        PermissionInfoADM(perm003_a2.iri, OntologyConstants.KnoraAdmin.AdministrativePermission),
+                        PermissionInfoADM(perm003_d1.iri, OntologyConstants.KnoraAdmin.DefaultObjectAccessPermission),
+                        PermissionInfoADM(perm003_d2.iri, OntologyConstants.KnoraAdmin.DefaultObjectAccessPermission),
+                        PermissionInfoADM(perm003_d3.iri, OntologyConstants.KnoraAdmin.DefaultObjectAccessPermission)
+                    )
+                ))
+            }
+        }
+
         "asked to delete a permission object " should {
 
             "delete an administrative permission " ignore {}


### PR DESCRIPTION
resolves [DSP-557](https://dasch.myjetbrains.com/youtrack/issue/DSP-557)

resolves [DSP-580](https://dasch.myjetbrains.com/youtrack/issue/DSP-580) Documentation of Permissions end point added

**BreakingChanges**:
- route to get administrative permission for a project group has an extra segment `ap`. The entire route is now `admin/permissions/ap/$projectIri/$groupIr`
- the test data for response of getting administrative permission for a project group is now in: `get-administrative-permission-for-project-group-response.json`