### PR TITLE
fix(OntologyResponderV2): Fix ontology cache update when ontology metadata changed

### DIFF
--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/OntologyResponderV2.scala
@@ -1854,7 +1854,7 @@ class OntologyResponderV2(responderData: ResponderData) extends Responder(respon
                 // Update the ontology cache with the unescaped metadata.
 
                 _ = storeCacheData(cacheData.copy(
-                    ontologies = cacheData.ontologies + (internalOntologyIri -> ReadOntologyV2(ontologyMetadata = unescapedNewMetadata))
+                    ontologies = cacheData.ontologies + (internalOntologyIri -> cacheData.ontologies(internalOntologyIri).copy(ontologyMetadata = unescapedNewMetadata))
                 ))
 
             } yield ReadOntologyMetadataV2(ontologies = Set(unescapedNewMetadata))

--- a/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/responders/v2/OntologyResponderV2Spec.scala
@@ -2038,6 +2038,27 @@ class OntologyResponderV2Spec extends CoreSpec() with ImplicitSender {
             }
         }
 
+        "change the metadata of the 'anything' ontology" in {
+            val newLabel = "The modified anything ontology"
+
+            responderManager ! ChangeOntologyMetadataRequestV2(
+                ontologyIri = AnythingOntologyIri,
+                label = newLabel,
+                lastModificationDate = anythingLastModDate,
+                apiRequestID = UUID.randomUUID,
+                requestingUser = anythingAdminUser
+            )
+
+            val response = expectMsgType[ReadOntologyMetadataV2](timeout)
+            assert(response.ontologies.size == 1)
+            val metadata = response.ontologies.head
+            assert(metadata.ontologyIri.toOntologySchema(ApiV2Complex) == AnythingOntologyIri)
+            assert(metadata.label.contains(newLabel))
+            val newAnythingLastModDate = metadata.lastModificationDate.getOrElse(throw AssertionException(s"${metadata.ontologyIri} has no last modification date"))
+            assert(newAnythingLastModDate.isAfter(anythingLastModDate))
+            anythingLastModDate = newAnythingLastModDate
+        }
+
         "delete the class anything:CardinalityThing" in {
             val classIri = AnythingOntologyIri.makeEntityIri("CardinalityThing")
 


### PR DESCRIPTION
https://dasch.myjetbrains.com/youtrack/issue/DSP-626

- [x] When ontology metadata is changed, update the ontology cache correctly.
- [x] Add test.