### PR TITLE
feat(gravsearch): Allow comparing variables representing resource IRIs

### DIFF
--- a/docs/03-apis/api-v2/query-language.md
+++ b/docs/03-apis/api-v2/query-language.md
@@ -649,6 +649,48 @@ except that the first argument is a variable representing a resource:
 FILTER knora-api:matchLabel(?book, "Zeitglöcklein")
 ```
 
+### Filtering on Resource IRIs
+
+A `FILTER` can compare a variable with another variable or IRI
+representing a resource. For example, to find a letter whose
+author and recipient are different persons:
+
+```
+PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
+PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+
+CONSTRUCT {
+    ?letter knora-api:isMainResource true .
+    ?letter beol:hasAuthor ?person1 .
+    ?letter beol:hasRecipient ?person2 .
+} WHERE {
+    ?letter a beol:letter .
+    ?letter beol:hasAuthor ?person1 .
+    ?letter beol:hasRecipient ?person2 .
+    FILTER(?person1 != ?person2) .
+}
+OFFSET 0
+```
+
+To find a letter whose author is not a person with a specified IRI:
+
+```
+PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
+PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+
+CONSTRUCT {
+    ?letter knora-api:isMainResource true .
+    ?letter beol:hasAuthor ?person1 .
+    ?letter beol:hasRecipient ?person2 .
+} WHERE {
+    ?letter a beol:letter .
+    ?letter beol:hasAuthor ?person1 .
+    ?letter beol:hasRecipient ?person2 .
+    FILTER(?person1 != <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>) .
+}
+OFFSET 0
+```
+
 ### CONSTRUCT Clause
 
 In the `CONSTRUCT` clause of a Gravsearch query, the variable representing the

--- a/docs/05-internals/design/api-v2/gravsearch.md
+++ b/docs/05-internals/design/api-v2/gravsearch.md
@@ -153,8 +153,8 @@ The classes involved in generating prequeries can be found in `org.knora.webapi.
 If the client submits a count query, the prequery returns the overall number of hits, but not the results themselves.
 
 In a first step, before transforming the WHERE clause, query patterns must be further optimised by removing
-the `rdfs:type` statement for entities whose type could be inferred from a property since there would be no need 
-for explicit `rdfs:type` statements for them (unless the property from which the type of an entity must be inferred from 
+the `rdfs:type` statement for entities whose type could be inferred from their use with a property IRI, since there would be no need 
+for explicit `rdfs:type` statements for them (unless the property IRI from which the type of an entity must be inferred from 
 is wrapped in an `OPTIONAL` block). This optimisation takes the Gravsearch query as input (rather than the generated SPARQL),
 because it uses type information that refers to entities in the Gravsearch query, and the generated SPARQL might
 have different entities.

--- a/test_data/all_data/beol-data.ttl
+++ b/test_data/all_data/beol-data.ttl
@@ -65,6 +65,34 @@
   knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser";
   knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
 
+<http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA> a beol:person;
+  rdfs:label "Testperson3";
+  knora-base:isDeleted false;
+  knora-base:attachedToProject <http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF>;
+  knora-base:creationDate "2020-09-21T07:14:09.621165Z"^^xsd:dateTime;
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF>;
+  beol:hasGivenName <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA/values/R0yqYbumTD-R7wA3U57ndQ>;
+  beol:hasFamilyName <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA/values/Eaj-gUutRpONYPetDp-SyQ> .
+
+<http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA/values/Eaj-gUutRpONYPetDp-SyQ> a knora-base:TextValue;
+  knora-base:valueHasUUID "Eaj-gUutRpONYPetDp-SyQ"^^xsd:string;
+  knora-base:isDeleted false;
+  knora-base:valueCreationDate "2020-09-21T07:14:09.621165Z"^^xsd:dateTime;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasString "Hummel";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
+<http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA/values/R0yqYbumTD-R7wA3U57ndQ> a knora-base:TextValue;
+  knora-base:valueHasUUID "R0yqYbumTD-R7wA3U57ndQ"^^xsd:string;
+  knora-base:isDeleted false;
+  knora-base:valueCreationDate "2020-09-21T07:14:09.621165Z"^^xsd:dateTime;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasString "Johann Nepomuk";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
 <http://rdfh.ch/0801/_B3lQa6tSymIq7_7SowBsA> a beol:letter;
   rdfs:label "Testbrief1";
   knora-base:isDeleted false;
@@ -178,9 +206,9 @@
   beol:title <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/jGtT_87FS2qTkUEigdXMPg>;
   beol:hasSubject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/YdnovfaXRnW4c5qO7h02Ag>;
   beol:creationDate <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/5_JuhLykRBmhJs_b9X0qhg>;
-  beol:hasAuthor <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  beol:hasAuthor <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>;
   beol:hasAuthorValue <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/b5JkQWJEQz6V-Spue9TqGA>;
-  beol:hasRecipient <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  beol:hasRecipient <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>;
   beol:hasRecipientValue <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/HqYA8dx1QzGzb9hqZNLDzA>;
   beol:hasText <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/xFaiZnw4RH-ES-eovy_FgQ> .
 
@@ -199,7 +227,7 @@
   knora-base:isDeleted false;
   rdf:subject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g>;
   rdf:predicate beol:hasAuthor;
-  rdf:object <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  rdf:object <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>;
   knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
   knora-base:valueHasOrder 0;
   knora-base:valueHasRefCount 1;
@@ -212,7 +240,7 @@
   knora-base:isDeleted false;
   rdf:subject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g>;
   rdf:predicate beol:hasRecipient;
-  rdf:object <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  rdf:object <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>;
   knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
   knora-base:valueHasOrder 0;
   knora-base:valueHasRefCount 1;
@@ -240,7 +268,7 @@
   knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
   knora-base:isDeleted false;
   knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
-  knora-base:valueHasListNode <http://rdfh.ch/lists/0801/logarithmic_curves>;
+  knora-base:valueHasListNode <http://rdfh.ch/lists/0801/dragging_motion_pursuit_curves_tractrix_construction>;
   knora-base:valueHasOrder 0;
   knora-base:valueHasString "http://rdfh.ch/lists/0801/logarithmic_curves" .
 
@@ -249,7 +277,7 @@
   knora-base:isDeleted false;
   knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
   knora-base:valueHasOrder 0;
-  knora-base:valueHasString "Testbrief2";
+  knora-base:valueHasString "letter to self";
   knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
   knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
 

--- a/test_data/all_data/beol-data.ttl
+++ b/test_data/all_data/beol-data.ttl
@@ -168,6 +168,91 @@
   knora-base:hasPermissions "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser";
   knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
 
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g> a beol:letter;
+  rdfs:label "letter to self";
+  knora-base:isDeleted false;
+  knora-base:attachedToProject <http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF>;
+  knora-base:creationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF>;
+  beol:title <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/jGtT_87FS2qTkUEigdXMPg>;
+  beol:hasSubject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/YdnovfaXRnW4c5qO7h02Ag>;
+  beol:creationDate <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/5_JuhLykRBmhJs_b9X0qhg>;
+  beol:hasAuthor <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  beol:hasAuthorValue <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/b5JkQWJEQz6V-Spue9TqGA>;
+  beol:hasRecipient <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  beol:hasRecipientValue <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/HqYA8dx1QzGzb9hqZNLDzA>;
+  beol:hasText <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/xFaiZnw4RH-ES-eovy_FgQ> .
+
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/xFaiZnw4RH-ES-eovy_FgQ> a knora-base:TextValue;
+  knora-base:valueHasUUID "xFaiZnw4RH-ES-eovy_FgQ"^^xsd:string;
+  knora-base:isDeleted false;
+  knora-base:valueHasMaxStandoffStartIndex "1"^^xsd:nonNegativeInteger;
+  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasString "I am writing this to myself.";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/b5JkQWJEQz6V-Spue9TqGA> a knora-base:LinkValue;
+  knora-base:valueHasUUID "Cvp07eTqQQSnYdcvqlWW_g"^^xsd:string;
+  knora-base:isDeleted false;
+  rdf:subject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g>;
+  rdf:predicate beol:hasAuthor;
+  rdf:object <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasRefCount 1;
+  knora-base:valueHasString "http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/HqYA8dx1QzGzb9hqZNLDzA> a knora-base:LinkValue;
+  knora-base:valueHasUUID "HqYA8dx1QzGzb9hqZNLDzA"^^xsd:string;
+  knora-base:isDeleted false;
+  rdf:subject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g>;
+  rdf:predicate beol:hasRecipient;
+  rdf:object <http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw>;
+  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasRefCount 1;
+  knora-base:valueHasString "http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/5_JuhLykRBmhJs_b9X0qhg> a knora-base:DateValue;
+  knora-base:valueHasUUID "5_JuhLykRBmhJs_b9X0qhg"^^xsd:string;
+  knora-base:isDeleted false;
+  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:valueHasCalendar "GREGORIAN";
+  knora-base:valueHasEndJDN 2458274;
+  knora-base:valueHasEndPrecision "DAY";
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasStartJDN 2458274;
+  knora-base:valueHasStartPrecision "DAY";
+  knora-base:valueHasString "2018-06-04 CE";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/YdnovfaXRnW4c5qO7h02Ag> a knora-base:ListValue;
+  knora-base:valueHasUUID "YdnovfaXRnW4c5qO7h02Ag"^^xsd:string;
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF>;
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:isDeleted false;
+  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:valueHasListNode <http://rdfh.ch/lists/0801/logarithmic_curves>;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasString "http://rdfh.ch/lists/0801/logarithmic_curves" .
+
+<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/jGtT_87FS2qTkUEigdXMPg> a knora-base:TextValue;
+  knora-base:valueHasUUID "jGtT_87FS2qTkUEigdXMPg"^^xsd:string;
+  knora-base:isDeleted false;
+  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
+  knora-base:valueHasOrder 0;
+  knora-base:valueHasString "Testbrief2";
+  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
+  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
+
 <http://rdfh.ch/0801/letter_resource> a beol:letter;
   rdfs:label "Test letter";
   knora-base:isDeleted false;

--- a/test_data/all_data/beol-data.ttl
+++ b/test_data/all_data/beol-data.ttl
@@ -204,7 +204,6 @@
   knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
   knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF>;
   beol:title <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/jGtT_87FS2qTkUEigdXMPg>;
-  beol:hasSubject <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/YdnovfaXRnW4c5qO7h02Ag>;
   beol:creationDate <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/5_JuhLykRBmhJs_b9X0qhg>;
   beol:hasAuthor <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>;
   beol:hasAuthorValue <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/b5JkQWJEQz6V-Spue9TqGA>;
@@ -261,16 +260,6 @@
   knora-base:valueHasString "2018-06-04 CE";
   knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
   knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF> .
-
-<http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/YdnovfaXRnW4c5qO7h02Ag> a knora-base:ListValue;
-  knora-base:valueHasUUID "YdnovfaXRnW4c5qO7h02Ag"^^xsd:string;
-  knora-base:attachedToUser <http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF>;
-  knora-base:hasPermissions "CR knora-admin:Creator|V knora-admin:UnknownUser";
-  knora-base:isDeleted false;
-  knora-base:valueCreationDate "2020-09-18T10:46:06.442289Z"^^xsd:dateTime;
-  knora-base:valueHasListNode <http://rdfh.ch/lists/0801/dragging_motion_pursuit_curves_tractrix_construction>;
-  knora-base:valueHasOrder 0;
-  knora-base:valueHasString "http://rdfh.ch/lists/0801/logarithmic_curves" .
 
 <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g/values/jGtT_87FS2qTkUEigdXMPg> a knora-base:TextValue;
   knora-base:valueHasUUID "jGtT_87FS2qTkUEigdXMPg"^^xsd:string;

--- a/test_data/searchR2RV2/LetterNotToSelf.jsonld
+++ b/test_data/searchR2RV2/LetterNotToSelf.jsonld
@@ -1,0 +1,126 @@
+{
+  "@id" : "http://rdfh.ch/0801/_B3lQa6tSymIq7_7SowBsA",
+  "@type" : "beol:letter",
+  "beol:hasAuthorValue" : {
+    "@id" : "http://rdfh.ch/0801/_B3lQa6tSymIq7_7SowBsA/values/Cvp07eTqQQSnYdcvqlWW_g",
+    "@type" : "knora-api:LinkValue",
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD/Cvp07eTqQQSnYdcvqlWW_gI"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:linkValueHasTarget" : {
+      "@id" : "http://rdfh.ch/0801/VvYVIy-FSbOJBsh2d9ZFJw",
+      "@type" : "beol:person",
+      "knora-api:arkUrl" : {
+        "@type" : "xsd:anyURI",
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi"
+      },
+      "knora-api:attachedToProject" : {
+        "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
+      },
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF"
+      },
+      "knora-api:creationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-06-04T08:56:22.513Z"
+      },
+      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+      "knora-api:userHasPermission" : "RV",
+      "knora-api:versionArkUrl" : {
+        "@type" : "xsd:anyURI",
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/VvYVIy=FSbOJBsh2d9ZFJwi.20180604T085622513Z"
+      },
+      "rdfs:label" : "Testperson2"
+    },
+    "knora-api:userHasPermission" : "RV",
+    "knora-api:valueCreationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-06-04T08:56:33.879Z"
+    },
+    "knora-api:valueHasUUID" : "Cvp07eTqQQSnYdcvqlWW_g",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD/Cvp07eTqQQSnYdcvqlWW_gI.20180604T085633879Z"
+    }
+  },
+  "beol:hasRecipientValue" : {
+    "@id" : "http://rdfh.ch/0801/_B3lQa6tSymIq7_7SowBsA/values/DVqPKuBBSIauVqjUC7bNvA",
+    "@type" : "knora-api:LinkValue",
+    "knora-api:arkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD/DVqPKuBBSIauVqjUC7bNvAe"
+    },
+    "knora-api:attachedToUser" : {
+      "@id" : "http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF"
+    },
+    "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+    "knora-api:linkValueHasTarget" : {
+      "@id" : "http://rdfh.ch/0801/H7s3FmuWTkaCXa54eFANOA",
+      "@type" : "beol:person",
+      "knora-api:arkUrl" : {
+        "@type" : "xsd:anyURI",
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd"
+      },
+      "knora-api:attachedToProject" : {
+        "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
+      },
+      "knora-api:attachedToUser" : {
+        "@id" : "http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF"
+      },
+      "knora-api:creationDate" : {
+        "@type" : "xsd:dateTimeStamp",
+        "@value" : "2018-06-04T08:55:34.086Z"
+      },
+      "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+      "knora-api:userHasPermission" : "RV",
+      "knora-api:versionArkUrl" : {
+        "@type" : "xsd:anyURI",
+        "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/H7s3FmuWTkaCXa54eFANOAd.20180604T085534086Z"
+      },
+      "rdfs:label" : "Testperson1"
+    },
+    "knora-api:userHasPermission" : "RV",
+    "knora-api:valueCreationDate" : {
+      "@type" : "xsd:dateTimeStamp",
+      "@value" : "2018-06-04T08:56:33.879Z"
+    },
+    "knora-api:valueHasUUID" : "DVqPKuBBSIauVqjUC7bNvA",
+    "knora-api:versionArkUrl" : {
+      "@type" : "xsd:anyURI",
+      "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD/DVqPKuBBSIauVqjUC7bNvAe.20180604T085633879Z"
+    }
+  },
+  "knora-api:arkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD"
+  },
+  "knora-api:attachedToProject" : {
+    "@id" : "http://rdfh.ch/projects/yTerZGyxjZVqFMNNKXCDPF"
+  },
+  "knora-api:attachedToUser" : {
+    "@id" : "http://rdfh.ch/users/PSGbemdjZi4kQ6GHJVkLGF"
+  },
+  "knora-api:creationDate" : {
+    "@type" : "xsd:dateTimeStamp",
+    "@value" : "2018-06-04T08:56:33.879Z"
+  },
+  "knora-api:hasPermissions" : "CR knora-admin:Creator|M knora-admin:ProjectMember|V knora-admin:KnownUser|RV knora-admin:UnknownUser",
+  "knora-api:userHasPermission" : "RV",
+  "knora-api:versionArkUrl" : {
+    "@type" : "xsd:anyURI",
+    "@value" : "http://0.0.0.0:3336/ark:/72163/1/0801/_B3lQa6tSymIq7_7SowBsAD.20180604T085633879Z"
+  },
+  "rdfs:label" : "Testbrief1",
+  "@context" : {
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "knora-api" : "http://api.knora.org/ontology/knora-api/v2#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "beol" : "http://0.0.0.0:3333/ontology/0801/beol/v2#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#"
+  }
+}

--- a/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/util/search/gravsearch/types/InferringGravsearchTypeInspector.scala
@@ -107,7 +107,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
     /**
      * Infers the type of an entity if there is an `rdf:type` statement about it.
      */
-    private class RdfTypeRule(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+    private class InferTypeOfSubjectOfRdfTypePredicate(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
         override def infer(entityToType: TypeableEntity,
                            intermediateResult: IntermediateTypeInspectionResult,
                            entityInfo: EntityInfoGetResponseV2,
@@ -132,12 +132,12 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                         if (classDef.isResourceClass) {
                                             // Yes. Infer rdf:type knora-api:Resource.
                                             val inferredType = NonPropertyTypeInfo(classDef.entityInfoContent.classIri, isResourceType = classDef.isResourceClass, isValueType = classDef.isValueClass)
-                                            log.debug("RdfTypeRule: {} {} .", entityToType, inferredType)
+                                            log.debug("InferTypeOfSubjectOfRdfTypePredicate: {} {} .", entityToType, inferredType)
                                             Some(inferredType)
                                         } else if (classDef.isStandoffClass) {
                                             // It's not a resource class, it's a standoff class. Infer rdf:type knora-api:StandoffTag.
                                             val inferredType = NonPropertyTypeInfo(OntologyConstants.KnoraApiV2Complex.StandoffTag.toSmartIri)
-                                            log.debug("RdfTypeRule: {} {} .", entityToType, inferredType)
+                                            log.debug("InferTypeOfSubjectOfRdfTypePredicate: {} {} .", entityToType, inferredType)
                                             Some(inferredType)
                                         } else {
 
@@ -145,7 +145,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                             if (GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(rdfType.toString)) {
                                                 // Yes. Return it.
                                                 val inferredType = NonPropertyTypeInfo(rdfType, isValueType = true)
-                                                log.debug("RdfTypeRule: {} {} .", entityToType, inferredType)
+                                                log.debug("InferTypeOfSubjectOfRdfTypePredicate: {} {} .", entityToType, inferredType)
                                                 Some(inferredType)
                                             } else {
                                                 // No. This must mean it's not allowed in Gravsearch queries.
@@ -162,7 +162,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                 // This isn't a Knora entity. If it's valid in a type inspection result, return it.
 
                                 val inferredType = NonPropertyTypeInfo(rdfType, isValueType = true)
-                                log.debug("RdfTypeRule: {} {} .", entityToType, inferredType)
+                                log.debug("InferTypeOfSubjectOfRdfTypePredicate: {} {} .", entityToType, inferredType)
                                 Some(inferredType)
                             } else {
                                 None
@@ -186,7 +186,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
     /**
      * Infers the `knora-api:objectType` of a property if the property's IRI is used as a predicate.
      */
-    private class KnoraObjectTypeFromPropertyIriRule(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+    private class InferTypeOfPropertyFromItsIri(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
         override def infer(entityToType: TypeableEntity,
                            intermediateResult: IntermediateTypeInspectionResult,
                            entityInfo: EntityInfoGetResponseV2,
@@ -205,7 +205,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                     case Some(objectTypeIri: SmartIri) =>
                                         val isValue = GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(objectTypeIri.toString)
                                         val inferredType = PropertyTypeInfo(objectTypeIri = objectTypeIri, objectIsResourceType = readPropertyInfo.isLinkProp, objectIsValueType = isValue)
-                                        log.debug("KnoraObjectTypeFromPropertyIriRule: {} {} .", entityToType, inferredType)
+                                        log.debug("InferTypeOfPropertyFromItsIri: {} {} .", entityToType, inferredType)
                                         Set(inferredType)
 
                                     case None =>
@@ -241,12 +241,12 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
      * Infers an entity's type if the entity is used as the object of a statement and the predicate's
      * `knora-api:objectType` is known.
      */
-    private class TypeOfObjectFromPropertyRule(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+    private class InferTypeOfObjectFromPredicate(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
         override def infer(entityToType: TypeableEntity,
                            intermediateResult: IntermediateTypeInspectionResult,
                            entityInfo: EntityInfoGetResponseV2,
                            usageIndex: UsageIndex): IntermediateTypeInspectionResult = {
-            // for standoff links it is necessary to refine the determined types first.
+            // for standoff links it is necessary to refine the determined types first. TODO: why in this rule and not in all rules?
             val updatedIntermediateResult: IntermediateTypeInspectionResult = refineDeterminedTypes(
                 intermediateResult = intermediateResult,
                 entityInfo = entityInfo
@@ -269,7 +269,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                             entityTypes.flatMap {
                                                 case propertyTypeInfo: PropertyTypeInfo =>
                                                     val inferredType: GravsearchEntityTypeInfo = NonPropertyTypeInfo(propertyTypeInfo.objectTypeIri, isResourceType = propertyTypeInfo.objectIsResourceType, isValueType = propertyTypeInfo.objectIsValueType)
-                                                    log.debug("TypeOfObjectFromPropertyRule: {} {} .", entityToType, inferredType)
+                                                    log.debug("InferTypeOfObjectFromPredicate: {} {} .", entityToType, inferredType)
                                                     Some(inferredType)
                                                 case _ =>
                                                     None
@@ -301,10 +301,10 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
 
 
     /**
-     * Infers an entity's type if the entity is used as the subject of a statement and
-     * the predicate's `knora-api:subjectType` is known.
+     * Infers an entity's type if the entity is used as the subject of a statement in which the predicate is a
+     * property IRI whose `knora-api:subjectType` is known.
      */
-    private class TypeOfSubjectFromPropertyRule(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+    private class InferTypeOfSubjectFromPredicateIri(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
         override def infer(entityToType: TypeableEntity,
                            intermediateResult: IntermediateTypeInspectionResult,
                            entityInfo: EntityInfoGetResponseV2,
@@ -328,7 +328,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                                     // Yes. Use that type.
                                                     val isValue = GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(subjectTypeIri.toString)
                                                     val inferredType = NonPropertyTypeInfo(subjectTypeIri, isResourceType = readPropertyInfo.isResourceProp, isValueType = isValue)
-                                                    log.debug("TypeOfSubjectFromPropertyRule: {} {} .", entityToType, inferredType)
+                                                    log.debug("InferTypeOfSubjectFromPredicateIri: {} {} .", entityToType, inferredType)
                                                     Some(inferredType)
 
                                                 case None =>
@@ -365,12 +365,12 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
     /**
      * Infers the `knora-api:objectType` of a property variable or IRI if it's used with an object whose type is known.
      */
-    private class KnoraObjectTypeFromObjectRule(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+    private class InferTypeOfPredicateFromObject(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
         override def infer(entityToType: TypeableEntity,
                            intermediateResult: IntermediateTypeInspectionResult,
                            entityInfo: EntityInfoGetResponseV2,
                            usageIndex: UsageIndex): IntermediateTypeInspectionResult = {
-            // for standoff links it is necessary to refine the types first.
+            // for standoff links it is necessary to refine the types first. TODO: why in this rule and not in all rules?
             val updatedIntermediateResult: IntermediateTypeInspectionResult = refineDeterminedTypes(
                 intermediateResult = intermediateResult,
                 entityInfo = entityInfo
@@ -392,7 +392,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                             entityTypes.flatMap {
                                                 case nonPropertyTypeInfo: NonPropertyTypeInfo =>
                                                     val inferredType: GravsearchEntityTypeInfo = PropertyTypeInfo(objectTypeIri = nonPropertyTypeInfo.typeIri, objectIsResourceType = nonPropertyTypeInfo.isResourceType, nonPropertyTypeInfo.isValueType)
-                                                    log.debug("KnoraObjectTypeFromObjectRule: {} {} .", entityToType, inferredType)
+                                                    log.debug("InferTypeOfPredicateFromObject: {} {} .", entityToType, inferredType)
                                                     Some(inferredType)
 
                                                 case _ =>
@@ -424,14 +424,14 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
     }
 
     /**
-     * Infers the types of entities from their use in FILTER expressions.
+     * Infers the types of entities if their type was already determined by examining a FILTER expression when
+     * constructing the usage index.
      */
-    private class EntityTypeFromFilterRule(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+    private class InferTypeOfEntityFromKnownTypeInFilter(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
         override def infer(entityToType: TypeableEntity,
                            intermediateResult: IntermediateTypeInspectionResult,
                            entityInfo: EntityInfoGetResponseV2,
                            usageIndex: UsageIndex): IntermediateTypeInspectionResult = {
-
             // Do we have one or more types for this entity from a FILTER?
             val typesFromFilters: Set[GravsearchEntityTypeInfo] = usageIndex.typedEntitiesInFilters.get(entityToType) match {
                 case Some(typesFromFilters: Set[SmartIri]) =>
@@ -440,7 +440,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         typeFromFilter =>
                             val isValue = GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(typeFromFilter.toString)
                             val inferredType = NonPropertyTypeInfo(typeFromFilter, isResourceType = !isValue, isValueType = isValue)
-                            log.debug("EntityTypeFromFilterRule: {} {} .", entityToType, inferredType)
+                            log.debug("InferTypeOfEntityFromKnownTypeInFilter: {} {} .", entityToType, inferredType)
                             inferredType
                     }
 
@@ -449,8 +449,25 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                     Set.empty[GravsearchEntityTypeInfo]
             }
 
-            // Is this entity a variable?
-            val typesFromPropertyIriComparisons: Set[GravsearchEntityTypeInfo] = entityToType match {
+            runNextRule(
+                entityToType = entityToType,
+                intermediateResult = intermediateResult.addTypes(entityToType, typesFromFilters),
+                entityInfo = entityInfo,
+                usageIndex = usageIndex
+            )
+        }
+    }
+
+    /**
+     * Infers a variable's type if it has been compared with a property IRI in a FILTER expression.
+     */
+    private class InferTypeOfVariableFromComparisonWithPropertyIriInFilter(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+        override def infer(entityToType: TypeableEntity,
+                           intermediateResult: IntermediateTypeInspectionResult,
+                           entityInfo: EntityInfoGetResponseV2, usageIndex: UsageIndex): IntermediateTypeInspectionResult = {
+
+            val typesFromComparisons: Set[GravsearchEntityTypeInfo] = entityToType match {
+                // Is this entity a variable?
                 case variableToType: TypeableVariable =>
                     // Yes. Has it been used as a predicate?
                     usageIndex.predicateIndex.get(entityToType) match {
@@ -470,7 +487,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                                             // Yes. Use that type.
                                                             val isValue = GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(objectTypeIri.toString)
                                                             val inferredType = PropertyTypeInfo(objectTypeIri = objectTypeIri, objectIsResourceType = readPropertyInfo.isLinkProp, objectIsValueType = isValue)
-                                                            log.debug("EntityTypeFromFilterRule: {} {} .", variableToType, inferredType)
+                                                            log.debug("InferTypeOfEntityFromKnownTypeInFilter: {} {} .", variableToType, inferredType)
                                                             Some(inferredType)
 
                                                         case None =>
@@ -500,11 +517,45 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                     Set.empty[GravsearchEntityTypeInfo]
             }
 
-            val inferredTypes: Set[GravsearchEntityTypeInfo] = typesFromFilters ++ typesFromPropertyIriComparisons
+            runNextRule(
+                entityToType = entityToType,
+                intermediateResult = intermediateResult.addTypes(entityToType, typesFromComparisons),
+                entityInfo = entityInfo,
+                usageIndex = usageIndex
+            )
+        }
+    }
+
+    /**
+     * Infers the type of a variable that has been compared with another variable in a FILTER expression.
+     */
+    private class InferTypeOfVariableFromComparisonWithOtherVariableInFilter(nextRule: Option[InferenceRule]) extends InferenceRule(nextRule = nextRule) {
+        override def infer(entityToType: TypeableEntity,
+                           intermediateResult: IntermediateTypeInspectionResult,
+                           entityInfo: EntityInfoGetResponseV2,
+                           usageIndex: UsageIndex): IntermediateTypeInspectionResult = {
+            val typesFromComparisons: Set[GravsearchEntityTypeInfo] = entityToType match {
+                // Is this entity a variable?
+                case variableToType: TypeableVariable =>
+                    // Yes. Has it been compared with one or more other variables in a FILTER?
+                    usageIndex.variablesComparedInFilters.get(variableToType) match {
+                        case Some(comparedVariables: Set[TypeableVariable]) =>
+                            // Yes. Get the types that have been inferred for those variables, if any.
+                            comparedVariables.flatMap(comparedVariable => intermediateResult.entities(comparedVariable))
+
+                        case None =>
+                            // This variable hasn't been compared with other variables in a FILTER.
+                            Set.empty[GravsearchEntityTypeInfo]
+                    }
+
+                case _ =>
+                    // The entity isn't a variable.
+                    Set.empty[GravsearchEntityTypeInfo]
+            }
 
             runNextRule(
                 entityToType = entityToType,
-                intermediateResult = intermediateResult.addTypes(entityToType, inferredTypes),
+                intermediateResult = intermediateResult.addTypes(entityToType, typesFromComparisons),
                 entityInfo = entityInfo,
                 usageIndex = usageIndex
             )
@@ -547,24 +598,24 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
          * @return the IRI of the inferred `knora-api:subjectType` of the property, or `None` if it could not inferred.
          */
         def readPropertyInfoToSubjectType(readPropertyInfo: ReadPropertyInfoV2, entityInfo: EntityInfoGetResponseV2, querySchema: ApiV2Schema): Option[SmartIri] = {
-
-            // It's not a resource property. Get the knora-api:subjectType that the ontology responder provided.
+            // Get the knora-api:subjectType that the ontology responder provided.
             readPropertyInfo.entityInfoContent.getPredicateIriObject(OntologyConstants.KnoraApiV2Simple.SubjectType.toSmartIri).
                 orElse(readPropertyInfo.entityInfoContent.getPredicateIriObject(OntologyConstants.KnoraApiV2Complex.SubjectType.toSmartIri)) match {
                 case Some(subjectType: SmartIri) =>
                     val subjectTypeStr = subjectType.toString
 
-                    // Is it knora-api:Value or one of the knora-api:ValueBase classes?
-                    if (subjectTypeStr == OntologyConstants.KnoraApiV2Complex.Value || OntologyConstants.KnoraApiV2Complex.ValueBaseClasses.contains(subjectTypeStr)) {
-                        // Yes. Don't use it.
-                        None
-                    } else if (readPropertyInfo.isResourceProp) {
+                    // Is it a resource class?
+                    if (readPropertyInfo.isResourceProp) {
+                        // Yes. Use it.
                         Some(subjectType)
+                    } else if (subjectTypeStr == OntologyConstants.KnoraApiV2Complex.Value || OntologyConstants.KnoraApiV2Complex.ValueBaseClasses.contains(subjectTypeStr)) {
+                        // If it's knora-api:Value or one of the knora-api:ValueBase classes, don't use it.
+                        None
                     } else if (OntologyConstants.KnoraApiV2Complex.FileValueClasses.contains(subjectTypeStr)) {
-                        // No. If it's a file value class, return the representation of file values in the specified schema.
+                        // If it's a file value class, return the representation of file values in the specified schema.
                         Some(getFileTypeForSchema(querySchema))
                     } else {
-                        // It's not a file value class, either. Is it a standoff class?
+                        // It's not any of those types. Is it a standoff class?
                         val isStandoffClass: Boolean = entityInfo.classInfoMap.get(subjectType) match {
                             case Some(classDef) => classDef.isStandoffClass
                             case None => false
@@ -574,7 +625,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                             // Yes. Infer knora-api:subjectType knora-api:StandoffTag.
                             Some(OntologyConstants.KnoraApiV2Complex.StandoffTag.toSmartIri)
                         } else if (GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(subjectTypeStr)) {
-                            // It's not any of those. If it's valid in a type inspection result, return it.
+                            // It's not any of those. If it's a value type, return it.
                             Some(subjectType)
                         } else {
                             // It's not valid in a type inspection result. This must mean it's not allowed in Gravsearch queries.
@@ -628,7 +679,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                 // Yes. return the object type resource class.
                                 Some(objectType)
                             } else if (GravsearchTypeInspectionUtil.GravsearchValueTypeIris.contains(objectTypeStr)) {
-                                // It's not any of those. If it's valid in a type inspection result, return it.
+                                // It's not any of those. If it's a value type, return it.
                                 Some(objectType)
                             } else {
                                 // No. This must mean it's not allowed in Gravsearch queries.
@@ -644,17 +695,19 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
 
     // The inference rule pipeline for the first iteration. Includes rules that cannot return additional
     // information if they are run more than once.
-    private val firstIterationRulePipeline = new RdfTypeRule(
-        Some(new KnoraObjectTypeFromPropertyIriRule(
-            Some(new TypeOfSubjectFromPropertyRule(
-                Some(new EntityTypeFromFilterRule(
-                    Some(new TypeOfObjectFromPropertyRule(
-                        Some(new KnoraObjectTypeFromObjectRule(None)))))))))))
+    private val firstIterationRulePipeline = new InferTypeOfSubjectOfRdfTypePredicate(
+        Some(new InferTypeOfPropertyFromItsIri(
+            Some(new InferTypeOfSubjectFromPredicateIri(
+                Some(new InferTypeOfEntityFromKnownTypeInFilter(
+                    Some(new InferTypeOfVariableFromComparisonWithPropertyIriInFilter(
+                        Some(new InferTypeOfObjectFromPredicate(
+                            Some(new InferTypeOfPredicateFromObject(None)))))))))))))
 
     // The inference rule pipeline for subsequent iterations. Excludes rules that cannot return additional
     // information if they are run more than once.
-    private val subsequentIterationRulePipeline = new TypeOfObjectFromPropertyRule(
-        Some(new KnoraObjectTypeFromObjectRule(None)))
+    private val subsequentIterationRulePipeline = new InferTypeOfObjectFromPredicate(
+        Some(new InferTypeOfPredicateFromObject(
+            Some(new InferTypeOfVariableFromComparisonWithOtherVariableInFilter(None)))))
 
     /**
      * An index of entity usage in a Gravsearch query.
@@ -667,14 +720,16 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
      * @param knoraPropertyVariablesInFilters a map of query variables to Knora property IRIs that they are compared to in
      *                                        FILTER expressions.
      * @param typedEntitiesInFilters          a map of entities to types found for them in FILTER expressions.
+     * @param variablesComparedInFilters      variables that are compared to other variables in FILTER expressions.
      */
-    case class UsageIndex(knoraClassIris: Set[SmartIri] = Set.empty[SmartIri],
-                          knoraPropertyIris: Set[SmartIri] = Set.empty[SmartIri],
-                          subjectIndex: Map[TypeableEntity, Set[StatementPattern]] = Map.empty[TypeableEntity, Set[StatementPattern]],
-                          predicateIndex: Map[TypeableEntity, Set[StatementPattern]] = Map.empty[TypeableEntity, Set[StatementPattern]],
-                          objectIndex: Map[TypeableEntity, Set[StatementPattern]] = Map.empty[TypeableEntity, Set[StatementPattern]],
-                          knoraPropertyVariablesInFilters: Map[TypeableVariable, Set[SmartIri]] = Map.empty[TypeableVariable, Set[SmartIri]],
-                          typedEntitiesInFilters: Map[TypeableEntity, Set[SmartIri]] = Map.empty[TypeableEntity, Set[SmartIri]],
+    case class UsageIndex(knoraClassIris: Set[SmartIri] = Set.empty,
+                          knoraPropertyIris: Set[SmartIri] = Set.empty,
+                          subjectIndex: Map[TypeableEntity, Set[StatementPattern]] = Map.empty,
+                          predicateIndex: Map[TypeableEntity, Set[StatementPattern]] = Map.empty,
+                          objectIndex: Map[TypeableEntity, Set[StatementPattern]] = Map.empty,
+                          knoraPropertyVariablesInFilters: Map[TypeableVariable, Set[SmartIri]] = Map.empty,
+                          typedEntitiesInFilters: Map[TypeableEntity, Set[SmartIri]] = Map.empty,
+                          variablesComparedInFilters: Map[TypeableVariable, Set[TypeableVariable]] = Map.empty,
                           querySchema: ApiV2Schema)
 
     override def inspectTypes(previousResult: IntermediateTypeInspectionResult,
@@ -880,8 +935,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
          */
         def findCommonBaseResourceClass(typesToBeChecked: Set[GravsearchEntityTypeInfo]): SmartIri = {
             val baseClassesOfFirstType: Seq[SmartIri] = entityInfo.classInfoMap.get(iriOfGravsearchTypeInfo(typesToBeChecked.head)) match {
-                case Some(classDef: ReadClassInfoV2) =>
-                    classDef.allBaseClasses
+                case Some(classDef: ReadClassInfoV2) => classDef.allBaseClasses
                 case _ => Seq.empty[SmartIri]
             }
 
@@ -890,8 +944,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                     (acc, aType) =>
                         // get class info of the type Iri
                         val baseClassesOfType: Seq[SmartIri] = entityInfo.classInfoMap.get(iriOfGravsearchTypeInfo(aType)) match {
-                            case Some(classDef: ReadClassInfoV2) =>
-                                classDef.allBaseClasses
+                            case Some(classDef: ReadClassInfoV2) => classDef.allBaseClasses
                             case _ => Seq.empty[SmartIri]
                         }
 
@@ -928,7 +981,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
         inconsistentEntities.keySet.foldLeft(lastResults) {
             (acc, typedEntity) =>
                 // all inconsistent types
-                val typesToBeChecked: Set[GravsearchEntityTypeInfo] = inconsistentEntities.getOrElse(typedEntity, Set.empty[GravsearchEntityTypeInfo])
+                val typesToBeChecked: Set[GravsearchEntityTypeInfo] = inconsistentEntities.getOrElse(typedEntity, Set.empty)
                 val commonBaseClassIri: SmartIri = findCommonBaseResourceClass(typesToBeChecked)
 
                 // Are all inconsistent types NonPropertyTypeInfo and resourceType?
@@ -982,7 +1035,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
         // iterate over all typeable entities, refine determined types for it by keeping only the specific types.
         intermediateResult.entities.keySet.foldLeft(intermediateResult) {
             (acc: IntermediateTypeInspectionResult, typedEntity: TypeableEntity) =>
-                val types: Set[GravsearchEntityTypeInfo] = intermediateResult.entities.getOrElse(typedEntity, Set.empty[GravsearchEntityTypeInfo])
+                val types: Set[GravsearchEntityTypeInfo] = intermediateResult.entities.getOrElse(typedEntity, Set.empty)
 
                 types.foldLeft(acc) {
                     (refinedResults: IntermediateTypeInspectionResult, currType: GravsearchEntityTypeInfo) =>
@@ -1128,7 +1181,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                   statementIndex: Map[TypeableEntity, Set[StatementPattern]]): Map[TypeableEntity, Set[StatementPattern]] = {
             GravsearchTypeInspectionUtil.maybeTypeableEntity(statementEntity) match {
                 case Some(typeableEntity) =>
-                    val currentPatterns = statementIndex.getOrElse(typeableEntity, Set.empty[StatementPattern])
+                    val currentPatterns: Set[StatementPattern] = statementIndex.getOrElse(typeableEntity, Set.empty)
                     statementIndex + (typeableEntity -> (currentPatterns + statementPattern))
 
                 case None => statementIndex
@@ -1163,7 +1216,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                             // Index the property IRI.
 
                             val typeableVariable = TypeableVariable(queryVariable.variableName)
-                            val currentIris: Set[SmartIri] = acc.knoraPropertyVariablesInFilters.getOrElse(typeableVariable, Set.empty[SmartIri])
+                            val currentIris: Set[SmartIri] = acc.knoraPropertyVariablesInFilters.getOrElse(typeableVariable, Set.empty)
 
                             acc.copy(
                                 knoraPropertyIris = acc.knoraPropertyIris + iriRef.iri,
@@ -1173,10 +1226,25 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         case CompareExpression(queryVariable: QueryVariable, _, xsdLiteral: XsdLiteral) =>
                             // A variable is compared to an XSD literal. Index the variable and the literal's type.
                             val typeableVariable = TypeableVariable(queryVariable.variableName)
-                            val currentVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(typeableVariable, Set.empty[SmartIri])
+                            val currentVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(typeableVariable, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters + (typeableVariable -> (currentVarTypesFromFilters + xsdLiteral.datatype))
+                            )
+
+                        case CompareExpression(leftQueryVariable: QueryVariable, _, rightQueryVariable: QueryVariable) =>
+                            // Two variables are compared. Index them both.
+
+                            val leftTypeableVariable = TypeableVariable(leftQueryVariable.variableName)
+                            val rightTypeableVariable = TypeableVariable(rightQueryVariable.variableName)
+
+                            val currentComparisonsForLeftVariable: Set[TypeableVariable] = acc.variablesComparedInFilters.getOrElse(leftTypeableVariable, Set.empty)
+                            val currentCompareisonsForRightVariable: Set[TypeableVariable] = acc.variablesComparedInFilters.getOrElse(rightTypeableVariable, Set.empty)
+
+                            acc.copy(
+                                variablesComparedInFilters = acc.variablesComparedInFilters +
+                                    (leftTypeableVariable -> (currentComparisonsForLeftVariable + rightTypeableVariable)) +
+                                    (rightTypeableVariable -> (currentCompareisonsForRightVariable + leftTypeableVariable))
                             )
 
                         case _ =>
@@ -1192,7 +1260,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         case OntologyConstants.KnoraApiV2Simple.MatchTextFunction =>
                             // The first argument is a variable representing a string.
                             val textVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
-                            val currentTextVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(textVar, Set.empty[SmartIri])
+                            val currentTextVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(textVar, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters +
@@ -1202,7 +1270,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         case OntologyConstants.KnoraApiV2Complex.MatchTextFunction =>
                             // The first argument is a variable representing a text value.
                             val textVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
-                            val currentTextVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(textVar, Set.empty[SmartIri])
+                            val currentTextVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(textVar, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters +
@@ -1212,7 +1280,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         case OntologyConstants.KnoraApiV2Simple.MatchLabelFunction =>
                             // The first argument is a variable representing a resource.
                             val resourceVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
-                            val currentResourceVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty[SmartIri])
+                            val currentResourceVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters +
@@ -1222,7 +1290,7 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         case OntologyConstants.KnoraApiV2Complex.MatchLabelFunction =>
                             // The first argument is a variable representing a resource.
                             val resourceVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
-                            val currentResourceVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty[SmartIri])
+                            val currentResourceVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(resourceVar, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters +
@@ -1232,11 +1300,11 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                         case OntologyConstants.KnoraApiV2Complex.MatchTextInStandoffFunction =>
                             // The first argument is a variable representing a text value.
                             val textVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(0).variableName)
-                            val currentTextVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(textVar, Set.empty[SmartIri])
+                            val currentTextVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(textVar, Set.empty)
 
                             // The second argument is a variable representing a standoff tag.
                             val standoffTagVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(1).variableName)
-                            val currentStandoffVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(standoffTagVar, Set.empty[SmartIri])
+                            val currentStandoffVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(standoffTagVar, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters +
@@ -1252,13 +1320,13 @@ class InferringGravsearchTypeInspector(nextInspector: Option[GravsearchTypeInspe
                                 entity => GravsearchTypeInspectionUtil.maybeTypeableEntity(entity)
                             }.map {
                                 typeableEntity =>
-                                    val currentVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(typeableEntity, Set.empty[SmartIri])
+                                    val currentVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(typeableEntity, Set.empty)
                                     typeableEntity -> (currentVarTypesFromFilters + OntologyConstants.KnoraApiV2Complex.Resource.toSmartIri)
                             }
 
                             // The second argument is a variable representing a standoff tag.
                             val standoffTagVar = TypeableVariable(functionCallExpression.getArgAsQueryVar(1).variableName)
-                            val currentStandoffVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(standoffTagVar, Set.empty[SmartIri])
+                            val currentStandoffVarTypesFromFilters: Set[SmartIri] = acc.typedEntitiesInFilters.getOrElse(standoffTagVar, Set.empty)
 
                             acc.copy(
                                 typedEntitiesInFilters = acc.typedEntitiesInFilters ++ resourceEntitiesAndTypes +

--- a/webapi/src/test/resources/logback-test.xml
+++ b/webapi/src/test/resources/logback-test.xml
@@ -88,7 +88,8 @@
     <logger name="org.knora.webapi.viewhandlers.ResourceHtmlView" level="INFO"/>
 
     <!-- V2 -->
-    <logger name="org.knora.webapi.responders.v2.search.gravsearch" level="INFO"/>
+    <logger name="org.knora.webapi.responders.v2.SearchResponderV2" level="INFO"/>
+    <logger name="org.knora.webapi.messages.util.search.gravsearch.types.InferringGravsearchTypeInspector" level="INFO"/>
 
     <!-- Admin -->
     <logger name="org.knora.webapi.responders.admin.GroupsResponderADM" level="INFO"/>

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -8374,5 +8374,61 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }
+
+        /*
+        "perform a search that compares two variables representing resources (in the simple schema)" in {
+            val gravsearchQuery: String =
+                """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?letter knora-api:isMainResource true .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |} WHERE {
+                  |    ?letter a beol:letter .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |    FILTER(?person1 != ?person2) .
+                  |}
+                  |OFFSET 0""".stripMargin
+
+            // We should get one result, not including <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g> ("letter to self").
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("test_data/searchR2RV2/LetterNotToSelf.jsonld"), writeTestDataFiles)
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "perform a search that compares two variables representing resources (in the complex schema)" in {
+            val gravsearchQuery: String =
+                """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?letter knora-api:isMainResource true .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |} WHERE {
+                  |    ?letter a beol:letter .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |    FILTER(?person1 != ?person2) .
+                  |}
+                  |OFFSET 0""".stripMargin
+
+            // We should get one result, not including <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g> ("letter to self").
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("test_data/searchR2RV2/LetterNotToSelf.jsonld"))
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+        */
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/e2e/v2/SearchRouteV2R2RSpec.scala
@@ -2499,68 +2499,6 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
-        "do a Gravsearch query for a letter that links to a person with a specified name (optional)" in {
-
-            val gravsearchQuery =
-                """
-                  |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
-                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
-                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                  |
-                  |    CONSTRUCT {
-                  |        ?letter knora-api:isMainResource true .
-                  |
-                  |        ?letter beol:creationDate ?date .
-                  |
-                  |        ?letter ?linkingProp1  ?person1 .
-                  |
-                  |        ?person1 beol:hasFamilyName ?name .
-                  |
-                  |    } WHERE {
-                  |        ?letter a knora-api:Resource .
-                  |        ?letter a beol:letter .
-                  |
-                  |        ?letter beol:creationDate ?date .
-                  |
-                  |        beol:creationDate knora-api:objectType knora-api:Date .
-                  |        ?date a knora-api:Date .
-                  |
-                  |        ?letter ?linkingProp1 ?person1 .
-                  |
-                  |        ?person1 a knora-api:Resource .
-                  |
-                  |        ?linkingProp1 knora-api:objectType knora-api:Resource .
-                  |        FILTER(?linkingProp1 = beol:hasAuthor || ?linkingProp1 = beol:hasRecipient)
-                  |
-                  |        beol:hasAuthor knora-api:objectType knora-api:Resource .
-                  |        beol:hasRecipient knora-api:objectType knora-api:Resource .
-                  |
-                  |        OPTIONAL {
-                  |             ?person1 beol:hasFamilyName ?name .
-                  |
-                  |             beol:hasFamilyName knora-api:objectType xsd:string .
-                  |             ?name a xsd:string .
-                  |
-                  |             FILTER(?name = "Meier")
-                  |        }
-                  |
-                  |    } ORDER BY ?date
-                """.stripMargin
-
-
-            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
-
-                assert(status == StatusCodes.OK, response.toString)
-
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("test_data/searchR2RV2/letterWithPersonWithNameOptional.jsonld"), writeTestDataFiles)
-
-                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
-
-                checkSearchResponseNumberOfResults(responseAs[String], 1)
-
-            }
-        }
-
         "do a Gravsearch query for a letter that links to another person with a specified name" in {
 
             val gravsearchQuery =
@@ -4889,55 +4827,6 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
-        "do a Gravsearch query for a letter that links to a person with a specified name (optional) (with type inference)" in {
-
-            val gravsearchQuery =
-                """
-                  |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
-                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
-                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                  |
-                  |    CONSTRUCT {
-                  |        ?letter knora-api:isMainResource true .
-                  |
-                  |        ?letter beol:creationDate ?date .
-                  |
-                  |        ?letter ?linkingProp1  ?person1 .
-                  |
-                  |        ?person1 beol:hasFamilyName ?name .
-                  |
-                  |    } WHERE {
-                  |        ?letter a beol:letter .
-                  |
-                  |        ?letter beol:creationDate ?date .
-                  |
-                  |        ?letter ?linkingProp1 ?person1 .
-                  |
-                  |        FILTER(?linkingProp1 = beol:hasAuthor || ?linkingProp1 = beol:hasRecipient)
-                  |
-                  |        OPTIONAL {
-                  |             ?person1 beol:hasFamilyName ?name .
-                  |
-                  |             FILTER(?name = "Meier")
-                  |        }
-                  |
-                  |    } ORDER BY ?date
-                """.stripMargin
-
-
-            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
-
-                assert(status == StatusCodes.OK, response.toString)
-
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("test_data/searchR2RV2/letterWithPersonWithNameOptional.jsonld"), writeTestDataFiles)
-
-                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
-
-                checkSearchResponseNumberOfResults(responseAs[String], 1)
-
-            }
-        }
-
         "do a Gravsearch query for a letter that links to another person with a specified name (with type inference)" in {
 
             val gravsearchQuery =
@@ -6945,55 +6834,6 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
-        "do a Gravsearch query for a letter that links to a person with a specified name (optional) (submitting the complex schema)" in {
-
-            val gravsearchQuery =
-                """
-                  |PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
-                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
-                  |PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-                  |
-                  |    CONSTRUCT {
-                  |        ?letter knora-api:isMainResource true .
-                  |
-                  |        ?letter beol:creationDate ?date .
-                  |
-                  |        ?letter ?linkingProp1  ?person1 .
-                  |
-                  |        ?person1 beol:hasFamilyName ?name .
-                  |
-                  |    } WHERE {
-                  |        ?letter a beol:letter .
-                  |
-                  |        ?letter beol:creationDate ?date .
-                  |
-                  |        ?letter ?linkingProp1 ?person1 .
-                  |
-                  |        FILTER(?linkingProp1 = beol:hasAuthor || ?linkingProp1 = beol:hasRecipient)
-                  |
-                  |        OPTIONAL {
-                  |             ?person1 beol:hasFamilyName ?name .
-                  |
-                  |             ?name knora-api:valueAsString "Meier" .
-                  |        }
-                  |
-                  |    } ORDER BY ?date
-                """.stripMargin
-
-
-            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> addCredentials(BasicHttpCredentials(anythingUserEmail, password)) ~> searchPath ~> check {
-
-                assert(status == StatusCodes.OK, response.toString)
-
-                val expectedAnswerJSONLD = readOrWriteTextFile(responseAs[String], new File("test_data/searchR2RV2/letterWithPersonWithNameOptional.jsonld"), writeTestDataFiles)
-
-                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = responseAs[String])
-
-                checkSearchResponseNumberOfResults(responseAs[String], 1)
-
-            }
-        }
-
         "do a Gravsearch query for a letter that links to another person with a specified name (submitting the complex schema)" in {
 
             val gravsearchQuery =
@@ -8375,7 +8215,6 @@ class SearchRouteV2R2RSpec extends R2RSpec {
             }
         }
 
-        /*
         "perform a search that compares two variables representing resources (in the simple schema)" in {
             val gravsearchQuery: String =
                 """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
@@ -8429,6 +8268,59 @@ class SearchRouteV2R2RSpec extends R2RSpec {
                 compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
             }
         }
-        */
+
+        "perform a search that compares a variable with a resource IRI (in the simple schema)" in {
+            val gravsearchQuery: String =
+                """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?letter knora-api:isMainResource true .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |} WHERE {
+                  |    ?letter a beol:letter .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |    FILTER(?person1 != <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>) .
+                  |}
+                  |OFFSET 0""".stripMargin
+
+            // We should get one result, not including <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g> ("letter to self").
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("test_data/searchR2RV2/LetterNotToSelf.jsonld"))
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
+
+        "perform a search that compares a variable with a resource IRI (in the complex schema)" in {
+            val gravsearchQuery: String =
+                """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
+                  |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+                  |
+                  |CONSTRUCT {
+                  |    ?letter knora-api:isMainResource true .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |} WHERE {
+                  |    ?letter a beol:letter .
+                  |    ?letter beol:hasAuthor ?person1 .
+                  |    ?letter beol:hasRecipient ?person2 .
+                  |    FILTER(?person1 != <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>) .
+                  |}
+                  |OFFSET 0""".stripMargin
+
+            // We should get one result, not including <http://rdfh.ch/0801/XNn6wanrTHWShGTjoULm5g> ("letter to self").
+
+            Post("/v2/searchextended", HttpEntity(SparqlQueryConstants.`application/sparql-query`, gravsearchQuery)) ~> searchPath ~> check {
+                val searchResponseStr = responseAs[String]
+                assert(status == StatusCodes.OK, searchResponseStr)
+                val expectedAnswerJSONLD = readOrWriteTextFile(searchResponseStr, new File("test_data/searchR2RV2/LetterNotToSelf.jsonld"))
+                compareJSONLDForResourcesResponse(expectedJSONLD = expectedAnswerJSONLD, receivedJSONLD = searchResponseStr)
+            }
+        }
     }
 }

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
@@ -496,6 +496,134 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
         )))
     )
 
+    val QueryComparingResourceIriInSimpleSchema: String =
+        """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?letter knora-api:isMainResource true .
+          |    ?letter beol:hasAuthor ?person1 .
+          |    ?letter beol:hasRecipient ?person2 .
+          |} WHERE {
+          |    ?letter a beol:letter .
+          |    ?letter beol:hasAuthor ?person1 .
+          |    ?letter beol:hasRecipient ?person2 .
+          |    FILTER(?person1 != <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>) .
+          |}
+          |OFFSET 0""".stripMargin
+
+    val QueryComparingResourceIriInSimpleSchemaResult: GravsearchTypeInspectionResult =
+        GravsearchTypeInspectionResult(
+            entities = Map(
+                TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasRecipient".toSmartIri) -> PropertyTypeInfo(
+                    objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    objectIsResourceType = true,
+                    objectIsValueType = false
+                ),
+                TypeableVariable(variableName = "person2") -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableVariable(variableName = "person1") -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableIri(iri = "http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA".toSmartIri) -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableVariable(variableName = "letter") -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasAuthor".toSmartIri) -> PropertyTypeInfo(
+                    objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    objectIsResourceType = true,
+                    objectIsValueType = false
+                )
+            ),
+            entitiesInferredFromProperties = Map(
+                TypeableVariable(variableName = "person2") -> Set(NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                )),
+                TypeableVariable(variableName = "person1") -> Set(NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ))
+            )
+        )
+
+    val QueryComparingResourceIriInComplexSchema: String =
+        """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+          |
+          |CONSTRUCT {
+          |    ?letter knora-api:isMainResource true .
+          |    ?letter beol:hasAuthor ?person1 .
+          |    ?letter beol:hasRecipient ?person2 .
+          |} WHERE {
+          |    ?letter a beol:letter .
+          |    ?letter beol:hasAuthor ?person1 .
+          |    ?letter beol:hasRecipient ?person2 .
+          |    FILTER(?person1 != <http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA>) .
+          |}
+          |OFFSET 0""".stripMargin
+
+    val QueryComparingResourceIriInComplexSchemaResult: GravsearchTypeInspectionResult =
+        GravsearchTypeInspectionResult(
+            entities = Map(
+                TypeableVariable(variableName = "person2") -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/v2#hasAuthor".toSmartIri) -> PropertyTypeInfo(
+                    objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    objectIsResourceType = true,
+                    objectIsValueType = false
+                ),
+                TypeableVariable(variableName = "person1") -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/v2#hasRecipient".toSmartIri) -> PropertyTypeInfo(
+                    objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    objectIsResourceType = true,
+                    objectIsValueType = false
+                ),
+                TypeableIri(iri = "http://rdfh.ch/0801/F4n1xKa3TCiR4llJeElAGA".toSmartIri) -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ),
+                TypeableVariable(variableName = "letter") -> NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#letter".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                )
+            ),
+            entitiesInferredFromProperties = Map(
+                TypeableVariable(variableName = "person1") -> Set(NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                )),
+                TypeableVariable(variableName = "person2") -> Set(NonPropertyTypeInfo(
+                    typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                    isResourceType = true,
+                    isValueType = false
+                ))
+            )
+        )
+
     val PathologicalQuery: String =
         """
           |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
@@ -1106,6 +1234,22 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
             val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
             val result = Await.result(resultFuture, timeout)
             assert(result.entities == QueryComparingResourcesInComplexSchemaResult.entities)
+        }
+
+        "infer the type of a resource IRI when it is compared with a variable in a FILTER (in the simple schema)" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryComparingResourceIriInSimpleSchema)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result.entities == QueryComparingResourceIriInSimpleSchemaResult.entities)
+        }
+
+        "infer the type of a resource IRI when it is compared with a variable in a FILTER (in the complex schema)" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryComparingResourceIriInComplexSchema)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result.entities == QueryComparingResourceIriInComplexSchemaResult.entities)
         }
 
         "reject a query with a non-Knora property whose type cannot be inferred" in {

--- a/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
+++ b/webapi/src/test/scala/org/knora/webapi/messages/util/search/gravsearch/types/GravsearchTypeInspectorSpec.scala
@@ -396,6 +396,106 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
           |}
         """.stripMargin
 
+    val QueryComparingResourcesInSimpleSchema: String =
+        """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/simple/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/simple/v2#>
+          |
+          |CONSTRUCT {
+          |    ?letter knora-api:isMainResource true .
+          |    ?letter beol:hasAuthor ?person1 .
+          |} WHERE {
+          |    ?letter a beol:letter .
+          |    ?letter beol:hasAuthor ?person1 .
+          |    ?letter ?prop ?person2 .
+          |    FILTER(?person1 != ?person2) .
+          |}
+          |OFFSET 0""".stripMargin
+
+    val QueryComparingResourcesInSimpleSchemaResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(
+        entities = Map(
+            TypeableVariable(variableName = "person2") -> NonPropertyTypeInfo(
+                typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                isResourceType = true,
+                isValueType = false
+            ),
+            TypeableVariable(variableName = "person1") -> NonPropertyTypeInfo(
+                typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                isResourceType = true,
+                isValueType = false
+            ),
+            TypeableVariable(variableName = "letter") -> NonPropertyTypeInfo(
+                typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri,
+                isResourceType = true,
+                isValueType = false
+            ),
+            TypeableVariable(variableName = "prop") -> PropertyTypeInfo(
+                objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                objectIsResourceType = true,
+                objectIsValueType = false
+            ),
+            TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#hasAuthor".toSmartIri) -> PropertyTypeInfo(
+                objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+                objectIsResourceType = true,
+                objectIsValueType = false
+            )
+        ),
+        entitiesInferredFromProperties = Map(TypeableVariable(variableName = "person1") -> Set(NonPropertyTypeInfo(
+            typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri,
+            isResourceType = true,
+            isValueType = false
+        )))
+    )
+
+    val QueryComparingResourcesInComplexSchema: String =
+        """PREFIX beol: <http://0.0.0.0:3333/ontology/0801/beol/v2#>
+          |PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+          |
+          |CONSTRUCT {
+          |    ?letter knora-api:isMainResource true .
+          |    ?letter beol:hasAuthor ?person1 .
+          |} WHERE {
+          |    ?letter a beol:letter .
+          |    ?letter ?prop ?person1 .
+          |    ?letter beol:hasRecipient ?person2 .
+          |    FILTER(?person2 != ?person1) .
+          |}
+          |OFFSET 0""".stripMargin
+
+    val QueryComparingResourcesInComplexSchemaResult: GravsearchTypeInspectionResult = GravsearchTypeInspectionResult(
+        entities = Map(
+            TypeableVariable(variableName = "person2") -> NonPropertyTypeInfo(
+                typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                isResourceType = true,
+                isValueType = false
+            ),
+            TypeableVariable(variableName = "person1") -> NonPropertyTypeInfo(
+                typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                isResourceType = true,
+                isValueType = false
+            ),
+            TypeableIri(iri = "http://0.0.0.0:3333/ontology/0801/beol/v2#hasRecipient".toSmartIri) -> PropertyTypeInfo(
+                objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                objectIsResourceType = true,
+                objectIsValueType = false
+            ),
+            TypeableVariable(variableName = "letter") -> NonPropertyTypeInfo(
+                typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#letter".toSmartIri,
+                isResourceType = true,
+                isValueType = false
+            ),
+            TypeableVariable(variableName = "prop") -> PropertyTypeInfo(
+                objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+                objectIsResourceType = true,
+                objectIsValueType = false
+            )
+        ),
+        entitiesInferredFromProperties = Map(TypeableVariable(variableName = "person2") -> Set(NonPropertyTypeInfo(
+            typeIri = "http://0.0.0.0:3333/ontology/0801/beol/v2#person".toSmartIri,
+            isResourceType = true,
+            isValueType = false
+        )))
+    )
+
     val PathologicalQuery: String =
         """
           |PREFIX incunabula: <http://0.0.0.0:3333/ontology/0803/incunabula/simple/v2#>
@@ -680,7 +780,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
                 ),
-                entitiesInferredFromProperties = Map(TypeableVariable(variableName = "mainRes") -> Set(
+                entitiesInferredFromPropertyIris = Map(TypeableVariable(variableName = "mainRes") -> Set(
                     NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true),
                     NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
                 )
@@ -697,7 +797,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
             ))
 
             // Is it removed from entitiesInferredFromProperties?
-            intermediateTypesWithoutResource.entitiesInferredFromProperties should contain(TypeableVariable(variableName = "mainRes") -> Set(
+            intermediateTypesWithoutResource.entitiesInferredFromPropertyIris should contain(TypeableVariable(variableName = "mainRes") -> Set(
                 NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
         }
 
@@ -713,7 +813,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true)
                     )
                 ),
-                entitiesInferredFromProperties = Map(
+                entitiesInferredFromPropertyIris = Map(
                     TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#basicLetter".toSmartIri, isResourceType = true))
                 )
             )
@@ -726,7 +826,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
             assert(refinedIntermediateResults.entities.size == 1)
             refinedIntermediateResults.entities should contain(TypeableVariable(variableName = "letter") -> Set(
                 NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
-            assert(refinedIntermediateResults.entitiesInferredFromProperties.isEmpty)
+            assert(refinedIntermediateResults.entitiesInferredFromPropertyIris.isEmpty)
         }
 
         "sanitize inconsistent resource types that only have knora-base:Resource as base class in common" in {
@@ -744,7 +844,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                         PropertyTypeInfo(objectTypeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#person".toSmartIri, objectIsResourceType = true)
                     )
                 ),
-                entitiesInferredFromProperties = Map(TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
+                entitiesInferredFromPropertyIris = Map(TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
             )
 
             val refinedIntermediateResults = typeInspectionRunner.refineDeterminedTypes(
@@ -761,7 +861,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                     TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, isResourceType = true)),
                     TypeableVariable(variableName = "linkingProp1") -> Set(PropertyTypeInfo(objectTypeIri = "http://api.knora.org/ontology/knora-api/simple/v2#Resource".toSmartIri, objectIsResourceType = true))
                 ),
-                entitiesInferredFromProperties = Map(
+                entitiesInferredFromPropertyIris = Map(
                     TypeableVariable(variableName = "letter") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true))
                 )
             )
@@ -780,7 +880,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                         NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#manuscript".toSmartIri, isResourceType = true)
                     )
                 ),
-                entitiesInferredFromProperties = Map(TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
+                entitiesInferredFromPropertyIris = Map(TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true)))
             )
 
             val refinedIntermediateResults = typeInspectionRunner.refineDeterminedTypes(
@@ -796,7 +896,7 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
                 entities = Map(
                     TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#writtenSource".toSmartIri, isResourceType = true))
                 ),
-                entitiesInferredFromProperties = Map(
+                entitiesInferredFromPropertyIris = Map(
                     TypeableVariable(variableName = "document") -> Set(NonPropertyTypeInfo(typeIri = "http://0.0.0.0:3333/ontology/0801/beol/simple/v2#letter".toSmartIri, isResourceType = true))
                 )
             )
@@ -990,6 +1090,22 @@ class GravsearchTypeInspectorSpec extends CoreSpec() with ImplicitSender {
             val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
             val result = Await.result(resultFuture, timeout)
             assert(result.entities == RdfsLabelWithVariableResult.entities)
+        }
+
+        "infer the type of a variable when it is compared with another variable in a FILTER (in the simple schema)" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryComparingResourcesInSimpleSchema)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result.entities == QueryComparingResourcesInSimpleSchemaResult.entities)
+        }
+
+        "infer the type of a variable when it is compared with another variable in a FILTER (in the complex schema)" in {
+            val typeInspectionRunner = new GravsearchTypeInspectionRunner(responderData = responderData, inferTypes = true)
+            val parsedQuery = GravsearchParser.parseQuery(QueryComparingResourcesInComplexSchema)
+            val resultFuture: Future[GravsearchTypeInspectionResult] = typeInspectionRunner.inspectTypes(parsedQuery.whereClause, requestingUser = anythingAdminUser)
+            val result = Await.result(resultFuture, timeout)
+            assert(result.entities == QueryComparingResourcesInComplexSchemaResult.entities)
         }
 
         "reject a query with a non-Knora property whose type cannot be inferred" in {


### PR DESCRIPTION
https://dasch.myjetbrains.com/youtrack/issue/DSP-656

- [x] In `InferringGravsearchTypeInspector`:
    - [x] Index variables that are compared with other variables or IRIs in `FILTER` expressions, and add a rule (`InferTypeOfEntityFromComparisonWithOtherEntityInFilter`) that infers the types of those entities from those comparisons.
      - [x] Refactor `visitFilterExpression` because it was getting too long and hard to read.
      - [x] Rename all the inference rules and refactor them a bit for clarity.
    - [x] In the rule `InferTypeOfObjectFromPredicate`: If we have a statement like `?letter ?prop ?person1`, where the property is a variable, and we have already inferred its type, and then we use that to infer the type of `?person1`, don't use that as a reason to optimise away `?person1 rdf:type ...` later, because in the triplestore, a pattern like `?letter ?prop ?person1` could match any statement.
- [x] In `AbstractPrequeryGenerator.handleQueryVar()`, allow a `FILTER` expression comparing two entities representing resources.
- [x] Add tests.
  - [x] Remove some tests from `SearchRouteV2R2RSpec` using `OPTIONAL`, because they make it difficult to add new test data, and seem redundant anyway (the `OPTIONAL` doesn't affect the results).
- [x] Add docs.

Closes #1441.