### PR TITLE
docs: Update required mkdocs package

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.1.2
-mkdocs-material
+mkdocs-material==6.0.1

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,6 +144,6 @@ theme:
     primary: 'deep purple'
     accent: 'deep purple'
   features:
-    - tabs
+    - navigation.tabs
 extra_css:
   - 'assets/style/theme.css'


### PR DESCRIPTION
I figured out that the Github actions script for deploying the docs uses the latest version of mkdocs-material that contains a breaking change. So I had to update the configuration in documentation.