### PR TITLE
fix(api-v2): Fix post-update check for resource with standoff link (DSP-841)

### DIFF
--- a/docs/05-internals/development/generating-client-test-data.md
+++ b/docs/05-internals/development/generating-client-test-data.md
@@ -36,6 +36,12 @@ with the list in `webapi/scripts/expected-client-test-data.txt`.
 
 ## Usage
 
+On macOS, you will need to install Redis in order to have the `redis-cli` command-line tool:
+
+```
+brew install redis
+```
+
 To generate client test data, type:
 
 ```

--- a/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/messages/v2/responder/valuemessages/ValueMessagesV2.scala
@@ -528,9 +528,11 @@ case class GenerateSparqlForValueInNewResourceV2(valueContent: ValueContentV2,
  *                         update that will create the values.
  * @param unverifiedValues a map of property IRIs to [[UnverifiedValueV2]] objects describing
  *                         the values that should have been created.
+ * @param hasStandoffLink  `true` if the property `knora-base:hasStandoffLinkToValue` was automatically added.
  */
 case class GenerateSparqlToCreateMultipleValuesResponseV2(insertSparql: String,
-                                                          unverifiedValues: Map[SmartIri, Seq[UnverifiedValueV2]])
+                                                          unverifiedValues: Map[SmartIri, Seq[UnverifiedValueV2]],
+                                                          hasStandoffLink: Boolean)
 
 /**
  * The value of a Knora property in the context of some particular input or output operation.

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -65,9 +65,11 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
      * @param sparqlTemplateResourceToCreate a [[SparqlTemplateResourceToCreate]] describing SPARQL for creating
      *                                       the resource.
      * @param values                         the resource's values for verification.
+     * @param hasStandoffLink                `true` if the property `knora-base:hasStandoffLinkToValue` was automatically added.
      */
     private case class ResourceReadyToCreate(sparqlTemplateResourceToCreate: SparqlTemplateResourceToCreate,
-                                             values: Map[SmartIri, Seq[UnverifiedValueV2]])
+                                             values: Map[SmartIri, Seq[UnverifiedValueV2]],
+                                             hasStandoffLink: Boolean)
 
     /**
      * Receives a message of type [[ResourcesResponderRequestV2]], and returns an appropriate response message.
@@ -701,7 +703,8 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 resourceLabel = internalCreateResource.label,
                 resourceCreationDate = creationDate
             ),
-            values = sparqlForValuesResponse.unverifiedValues
+            values = sparqlForValuesResponse.unverifiedValues,
+            hasStandoffLink = sparqlForValuesResponse.hasStandoffLink
         )
     }
 
@@ -1066,11 +1069,25 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
                 throw AssertionException(s"Resource <$resourceIri> was saved, but it has the wrong label")
             }
 
-            _ = if (resource.values.keySet != resourceReadyToCreate.values.keySet) {
-                throw AssertionException(s"Resource <$resourceIri> was saved, but it has the wrong properties")
+            savedPropertyIris: Set[SmartIri] = resource.values.keySet
+
+            // Check that the property knora-base:hasStandoffLinkToValue was automatically added if necessary.
+            expectedPropertyIris: Set[SmartIri] = resourceReadyToCreate.values.keySet ++ (if (resourceReadyToCreate.hasStandoffLink) {
+                Some(OntologyConstants.KnoraBase.HasStandoffLinkToValue.toSmartIri)
+            } else {
+                None
+            })
+
+            _ = if (savedPropertyIris != expectedPropertyIris) {
+                throw AssertionException(s"Resource <$resourceIri> was saved, but it has the wrong properties: expected (${expectedPropertyIris.map(_.toSparql).mkString(", ")}), but saved (${savedPropertyIris.map(_.toSparql).mkString(", ")})")
             }
 
-            _ = resource.values.foreach {
+            // Ignore knora-base:hasStandoffLinkToValue when checking the expected values.
+            resourceWithoutStandoffLinkProp = resource.copy(
+                values = resource.values - OntologyConstants.KnoraBase.HasStandoffLinkToValue.toSmartIri
+            )
+
+            _ = resourceWithoutStandoffLinkProp.values.foreach {
                 case (propertyIri: SmartIri, savedValues: Seq[ReadValueV2]) =>
                     val expectedValues: Seq[UnverifiedValueV2] = resourceReadyToCreate.values(propertyIri)
 

--- a/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
+++ b/webapi/src/main/scala/org/knora/webapi/responders/v2/ResourcesResponderV2.scala
@@ -1083,11 +1083,7 @@ class ResourcesResponderV2(responderData: ResponderData) extends ResponderWithSt
             }
 
             // Ignore knora-base:hasStandoffLinkToValue when checking the expected values.
-            resourceWithoutStandoffLinkProp = resource.copy(
-                values = resource.values - OntologyConstants.KnoraBase.HasStandoffLinkToValue.toSmartIri
-            )
-
-            _ = resourceWithoutStandoffLinkProp.values.foreach {
+            _ = (resource.values - OntologyConstants.KnoraBase.HasStandoffLinkToValue.toSmartIri).foreach {
                 case (propertyIri: SmartIri, savedValues: Seq[ReadValueV2]) =>
                     val expectedValues: Seq[UnverifiedValueV2] = resourceReadyToCreate.values(propertyIri)
 


### PR DESCRIPTION
resolves [DSP-841](https://dasch.myjetbrains.com/youtrack/issue/DSP-841)

- [x] FIx post-update check for resource created with standoff link.
- [x] Add test.
- [x] Fix docs to mention that you have to install `redis-cli` to get client test data.