### PR TITLE
DSP-877 Upload api-client-test-data to GitHub release

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,1 @@
-resolves [DSP-xy](https://dasch.myjetbrains.com/youtrack/issue/DSP-xy)
+resolves DSP-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,14 @@ jobs:
           df -h
       - name: run API E2E tests
         run: make test-e2e
+      - name: Add api-client-test-data to release assets (on release only)
+        if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GH_TOKEN }}
+          file: client-test-data.zip
+          tag: ${{ github.ref }}
+          overwrite: true
       - name: Disk Free After
         run: |
           df -h


### PR DESCRIPTION
resolves DSP-877

In this PR:

- Add [Upload files to a GitHub release](https://github.com/marketplace/actions/upload-files-to-a-github-release) action
- Result should look like <https://github.com/dasch-swiss/knora-api/releases> --> s. assets
- Runs only on release
![Screenshot 2020-10-19 at 11 13 57](https://user-images.githubusercontent.com/4253580/96425638-8a05d180-11fc-11eb-8a3c-5709caf388a0.png)

- Additional: Update Github PR template
