### PR TITLE
DSP-1022 SIPI_EXTERNAL_HOSTNAME doesn't contain the external hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     restart: unless-stopped
     environment:
       - SIPI_EXTERNAL_PROTOCOL=http
-      - SIPI_EXTERNAL_HOSTNAME=sipi
+      - SIPI_EXTERNAL_HOSTNAME=localhost
       - SIPI_EXTERNAL_PORT=1024
       - SIPI_WEBAPI_HOSTNAME=api
       - SIPI_WEBAPI_PORT=3333


### PR DESCRIPTION
resolves DSP-1022
